### PR TITLE
chore: secure pipeline config

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -72,7 +72,7 @@ RUN dotnet build CIPPSharp.csproj -c Release --no-restore -o /out && \
 # ── Frontend build ──
 FROM node:22-slim AS frontend-deps
 WORKDIR /build
-COPY frontend/package.json frontend/yarn.lock ./
+COPY frontend/package.json frontend/yarn.lock frontend/.npmrc frontend/.yarnrc ./
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
     yarn install --frozen-lockfile --network-timeout 100000
 

--- a/build/Dockerfile.release
+++ b/build/Dockerfile.release
@@ -72,7 +72,7 @@ RUN dotnet build CIPPSharp.csproj -c Release --no-restore -o /out && \
 # ── Frontend build ──
 FROM node:22-slim AS frontend-deps
 WORKDIR /build
-COPY frontend/package.json frontend/yarn.lock ./
+COPY frontend/package.json frontend/yarn.lock frontend/.npmrc frontend/.yarnrc ./
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
     yarn install --frozen-lockfile --network-timeout 100000
 

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,5 +1,6 @@
 # Supply-chain hardening for CIPP
-# This file is honored by BOTH npm and yarn (yarn classic reads .npmrc).
+# npm honors this file. yarn classic does NOT read `ignore-scripts` from
+# .npmrc (only registry/auth keys); the yarn equivalents live in .yarnrc.
 # Any change here should be reviewed for CI/CD impact.
 
 # Refuse to execute package lifecycle scripts (pre/postinstall, prepare, etc.)
@@ -12,13 +13,13 @@ ignore-scripts=true
 # CI / contributor installs to a malicious mirror.
 registry=https://registry.npmjs.org/
 
-# Require integrity hashes (sha512) to match the lockfile on install.
-# npm honors this directly; yarn classic always verifies lockfile integrity
-# but this makes the intent explicit.
+# Severity threshold at which `npm audit` exits non-zero. (Integrity hashes
+# are always verified against the lockfile on install; that needs no flag.)
 audit-level=high
 
-# Don't auto-save changes to the lockfile from arbitrary install commands.
-# Lockfile edits should only happen via Dependabot PRs or explicit upgrades.
+# Write exact versions to package.json when adding deps via `npm install <pkg>`,
+# so a future lockfile regeneration cannot drift to a newer release.
+# npm-only; the yarn equivalent is `yarn add --exact`.
 save-exact=true
 
 # Disable funding/notifier noise so CI logs only show real signal.

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,26 @@
+# Supply-chain hardening for CIPP
+# This file is honored by BOTH npm and yarn (yarn classic reads .npmrc).
+# Any change here should be reviewed for CI/CD impact.
+
+# Refuse to execute package lifecycle scripts (pre/postinstall, prepare, etc.)
+# on dependency install. CIPP has zero of its own lifecycle scripts in
+# package.json, so the only scripts this would block are from third-party
+# packages — exactly the attack surface we want to close.
+ignore-scripts=true
+
+# Pin the registry explicitly so an inherited per-user .npmrc cannot redirect
+# CI / contributor installs to a malicious mirror.
+registry=https://registry.npmjs.org/
+
+# Require integrity hashes (sha512) to match the lockfile on install.
+# npm honors this directly; yarn classic always verifies lockfile integrity
+# but this makes the intent explicit.
+audit-level=high
+
+# Don't auto-save changes to the lockfile from arbitrary install commands.
+# Lockfile edits should only happen via Dependabot PRs or explicit upgrades.
+save-exact=true
+
+# Disable funding/notifier noise so CI logs only show real signal.
+fund=false
+update-notifier=false

--- a/frontend/.yarnrc
+++ b/frontend/.yarnrc
@@ -1,8 +1,8 @@
 # Supply-chain hardening for CIPP (yarn 1 / classic)
 #
-# This complements .npmrc — yarn 1 honors `ignore-scripts` from .npmrc, but
-# we set the per-command equivalents here as defense in depth so the
-# protection survives even if .npmrc is missing or ignored.
+# This complements .npmrc but is not redundant with it: yarn 1 does NOT
+# honor `ignore-scripts` from .npmrc, so for yarn installs these per-command
+# flags are the protection, not defense in depth.
 
 # Refuse to execute lifecycle scripts on `yarn install` / `yarn add` /
 # `yarn upgrade`. Mirrors `ignore-scripts=true` in .npmrc.

--- a/frontend/.yarnrc
+++ b/frontend/.yarnrc
@@ -1,0 +1,18 @@
+# Supply-chain hardening for CIPP (yarn 1 / classic)
+#
+# This complements .npmrc — yarn 1 honors `ignore-scripts` from .npmrc, but
+# we set the per-command equivalents here as defense in depth so the
+# protection survives even if .npmrc is missing or ignored.
+
+# Refuse to execute lifecycle scripts on `yarn install` / `yarn add` /
+# `yarn upgrade`. Mirrors `ignore-scripts=true` in .npmrc.
+--install.ignore-scripts true
+--add.ignore-scripts true
+--upgrade.ignore-scripts true
+
+# Pin the registry so a poisoned per-user .yarnrc cannot redirect installs.
+registry "https://registry.npmjs.org/"
+
+# Disable yarn's self-update check — CI should never auto-update its own
+# yarn binary mid-build.
+disable-self-update-check true


### PR DESCRIPTION
pulled in KelvinTegelaar/CIPP@4c2843c74331a4af685b700ab82f20b4cdbe33b7 which wasn't copied over
tested yarn behavior, it doesn't follow npmrc `ignore-scripts`, updated the comments in these files
added both npmrc and yarnrc to both dockerfiles so that script execution policy is respected