### PR TITLE
chore: Update repository links to new owner

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Reports
-    url: https://github.com/KelvinTegelaar/CIPP/security/advisories
+    url: https://github.com/CyberDrain/CIPP/security/advisories
     about: Please report security vulnerabilities here.
   - name: Community Discord
     url: https://discord.gg/cyberdrain

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-The current [release](https://github.com/KelvinTegelaar/CIPP/releases) is the only "supported version" and should not have any security bugs. However if you find a security issue in an older release feel free to also report this in case of regression, We'd rather know we made a mistake at one point in time and avoid that in the future.
+The current [release](https://github.com/CyberDrain/CIPP/releases) is the only "supported version" and should not have any security bugs. However if you find a security issue in an older release feel free to also report this in case of regression, We'd rather know we made a mistake at one point in time and avoid that in the future.
 
 ## Reporting a Vulnerability
 

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tools/GitHub/Invoke-ListGitHubReleaseNotes.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tools/GitHub/Invoke-ListGitHubReleaseNotes.ps1
@@ -13,7 +13,7 @@
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
 
-    $Owner = 'KelvinTegelaar'
+    $Owner = 'CyberDrain'
     $Repository = 'CIPP'
 
     if (-not $Owner) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "author": "CIPP Contributors",
   "homepage": "https://cipp.app/",
   "bugs": {
-    "url": "https://github.com/KelvinTegelaar/CIPP/issues"
+    "url": "https://github.com/CyberDrain/CIPP/issues"
   },
   "license": "AGPL-3.0",
   "engines": {

--- a/frontend/src/components/ReleaseNotesDialog.js
+++ b/frontend/src/components/ReleaseNotesDialog.js
@@ -32,7 +32,7 @@ import { CippAutoComplete } from './CippComponents/CippAutocomplete'
 
 const RELEASE_COOKIE_KEY = 'cipp_release_notice'
 const RELEASE_PERMANENT_HIDE_KEY = 'cipp_release_notice_permanently_hidden'
-const RELEASE_OWNER = 'KelvinTegelaar'
+const RELEASE_OWNER = 'CyberDrain'
 const RELEASE_REPO = 'CIPP'
 
 const secureFlag = () => {

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -221,18 +221,18 @@ const App = (props) => {
       id: 'bug-report',
       icon: <BugReportIcon />,
       name: 'Report Bug',
-      href: 'https://github.com/KelvinTegelaar/CIPP/issues/new?template=bug.yml',
+      href: 'https://github.com/CyberDrain/CIPP/issues/new?template=bug.yml',
       onClick: () =>
-        window.open('https://github.com/KelvinTegelaar/CIPP/issues/new?template=bug.yml', '_blank'),
+        window.open('https://github.com/CyberDrain/CIPP/issues/new?template=bug.yml', '_blank'),
     },
     {
       id: 'feature-request',
       icon: <FeedbackIcon />,
       name: 'Request Feature',
-      href: 'https://github.com/KelvinTegelaar/CIPP/issues/new?template=feature.yml',
+      href: 'https://github.com/CyberDrain/CIPP/issues/new?template=feature.yml',
       onClick: () =>
         window.open(
-          'https://github.com/KelvinTegelaar/CIPP/issues/new?template=feature.yml',
+          'https://github.com/CyberDrain/CIPP/issues/new?template=feature.yml',
           '_blank'
         ),
     },

--- a/frontend/src/pages/tenant/administration/applications/app-registrations.js
+++ b/frontend/src/pages/tenant/administration/applications/app-registrations.js
@@ -1,4 +1,3 @@
-// this page is going to need some love for accounting for filters: https://github.com/KelvinTegelaar/CIPP/blob/main/src/views/tenant/administration/ListEnterpriseApps.jsx#L83
 import { Layout as DashboardLayout } from '../../../../layouts/index.js'
 import { TabbedLayout } from '../../../../layouts/TabbedLayout'
 import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'

--- a/frontend/src/pages/tenant/administration/applications/enterprise-apps.js
+++ b/frontend/src/pages/tenant/administration/applications/enterprise-apps.js
@@ -1,4 +1,3 @@
-// this page is going to need some love for accounting for filters: https://github.com/KelvinTegelaar/CIPP/blob/main/src/views/tenant/administration/ListEnterpriseApps.jsx#L83
 import { Layout as DashboardLayout } from '../../../../layouts/index.js'
 import { TabbedLayout } from '../../../../layouts/TabbedLayout'
 import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'

--- a/frontend/src/pages/tools/community-repos/index.js
+++ b/frontend/src/pages/tools/community-repos/index.js
@@ -304,7 +304,7 @@ const Page = () => {
               >
                 <TextField
                   fullWidth
-                  label="Repository in 'owner/repo' format (e.g. KelvinTegelaar/CIPP)"
+                  label="Repository in 'owner/repo' format (e.g. CyberDrain/CIPP)"
                   value={repo}
                   onChange={(e) => setRepo(e.target.value)}
                   required={true}


### PR DESCRIPTION
Change many of the references from the old repository owner to the new one, ensuring that links point to the updated repository.

The version checker in the Application settings I left alone on purpose, as idk how that works now