### PR TITLE
Fix: Move queryKey placement in SignInLogsDialog component

### DIFF
--- a/frontend/src/pages/identity/administration/users/user/index.jsx
+++ b/frontend/src/pages/identity/administration/users/user/index.jsx
@@ -56,6 +56,7 @@ const SignInLogsDialog = ({ open, onClose, userId, tenantFilter }) => {
         <CippDataTable
           noCard={true}
           title="Sign-In Logs"
+          queryKey={`ListSignIns-${userId}`}
           simpleColumns={[
             'createdDateTime',
             'status',
@@ -72,7 +73,6 @@ const SignInLogsDialog = ({ open, onClose, userId, tenantFilter }) => {
               tenantFilter: tenantFilter,
               top: 50,
             },
-            queryKey: `ListSignIns-${userId}`,
           }}
         />
       </DialogContent>


### PR DESCRIPTION
Move queryKey outside the api prop to ensure it functions as intended in the SignInLogsDialog component.

Fixes User 1's sign-in logs being loaded on User 2 if the button is pressed inside the cache window.