### PR TITLE
fix: side-nav scroll desync

### DIFF
--- a/frontend/src/layouts/side-nav.js
+++ b/frontend/src/layouts/side-nav.js
@@ -135,15 +135,28 @@ export const SideNav = (props) => {
 
     let targetScrollTop = el.scrollTop
     let animating = false
+    let lastWrite = null
 
     const animate = () => {
+      if (!animating) {
+        return
+      }
       const diff = targetScrollTop - el.scrollTop
-      if (Math.abs(diff) < 0.5) {
-        el.scrollTop = targetScrollTop
+
+      // browsers can round to device pixels
+      if (Math.abs(diff) < 1) {
         animating = false
         return
       }
-      el.scrollTop += diff * 0.25
+      const before = el.scrollTop
+      lastWrite = before + diff * 0.25
+      el.scrollTop = lastWrite
+      if (el.scrollTop === before) {
+        // write clamped or rounded to a no-op, stop instead of spinning the raf loop
+        targetScrollTop = before
+        animating = false
+        return
+      }
       requestAnimationFrame(animate)
     }
 
@@ -157,8 +170,25 @@ export const SideNav = (props) => {
       }
     }
 
+    // scrollbar drags, keyboard and touch move scrollTop outside the wheel path,
+    // resync the target so the easing loop doesn't fight them for the thumb.
+    // mid-animation, events matching our own write are the loop's echo, skip those
+    const handleScroll = () => {
+      if (animating && lastWrite !== null && Math.abs(el.scrollTop - lastWrite) < 1) {
+        return
+      }
+      targetScrollTop = el.scrollTop
+      animating = false
+    }
+
     el.addEventListener('wheel', handleWheel, { passive: false })
-    return () => el.removeEventListener('wheel', handleWheel)
+    el.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      // queued animate() exits on guard, stopping RAF chain
+      animating = false
+      el.removeEventListener('wheel', handleWheel)
+      el.removeEventListener('scroll', handleScroll)
+    }
   }, [])
 
   // Preprocess items to mark which should be open


### PR DESCRIPTION
Clicking on the side-nav scroll bar after a scroll causes the scrollbar to jitter, click to play:
<img width="770" height="1028" alt="sidebar-scroll-jitter" src="https://github.com/user-attachments/assets/b1a5bcc6-9440-4c60-b029-f68c30e41940" />

this is caused by `targetScrollTop` only being writing from `wheel` events, not from keyboard moves, touch or dragging the scroll bar.   moving the scroll bar after using the scroll wheel causes requestAnimationFrame to continuously move the scollbar back to the stale position set by the `wheel` event.

fixed by adding a new scroll listener that sync `targetScrollTop` from `scroll` events and cancels any in-progress animation.  scroll events from the easing loop itself are skipped. the loop also stops when a write is clamped or rounds to a no-op. 
