### PR TITLE
fix: typo in manifest for pwa

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "CIPP",
-  "name": "CIPP - CyberDrian Improved Partner Portal",
+  "name": "CIPP - CyberDrain Improved Partner Portal",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
<img width="1638" height="172" alt="image" src="https://github.com/user-attachments/assets/5dd07b7e-6cd8-4326-848a-2800baa23dac" />

fixed typo