### PR TITLE
fix(tenant access check): add RoleManagement.Read.Exchange delegated permission

### DIFF
--- a/backend/Config/SAMManifest.json
+++ b/backend/Config/SAMManifest.json
@@ -626,6 +626,10 @@
         {
           "id": "e2edbde8-4448-4e49-8ebb-d53ba72df0f3",
           "type": "Scope"
+        },
+        {
+          "id": "3bc15058-7858-4141-b24f-ae43b4e80b52",
+          "type": "Scope"
         }
       ]
     },


### PR DESCRIPTION
## Problem

The tenant access check audits Organization Management roles via `GET /beta/roleManagement/exchange/roleDefinitions` (`Test-CIPPAccessTenant`), but the CIPP-SAM permission set (SAMManifest.json + AdditionalPermissions.json) contains no read scope for the Graph Exchange RBAC provider. That endpoint requires `RoleManagement.Read.Exchange` (or `RoleManagement.Read.All`), so the delegated `.default` token can never carry an accepted scope and the provider rejects the call with an opaque `UnknownError` (empty `error.message`).

Because the failure lands in the Exchange section's catch, the access check reports **"Failed to connect to Exchange: UnknownError"** even though the `New-ExoRequest` calls (`Get-OrganizationConfig`, `Get-ManagementRoleAssignment`) immediately before it succeeded.

Direct tenants hit this on every access check, since their token scopes come solely from the grants consented in the tenant itself.

## Fix

Add the delegated `RoleManagement.Read.Exchange` scope (`3bc15058-7858-4141-b24f-ae43b4e80b52`, least privilege for this read) to the Microsoft Graph resource block of SAMManifest.json. New consents get it automatically; existing tenants pick it up on their next permission refresh.

## Verification

- Reproduced the failure via Graph Explorer against a direct tenant: `roleManagement/exchange/roleDefinitions` returns `UnknownError`; Entra shows no `RoleManagement.*` consent on CIPP-SAM in that tenant.
- Confirmed the permission push resolves scope names from the live Graph service principal's `publishedPermissionScopes`, so no PermissionsTranslator.json change is needed.
- SAMManifest.json validates as JSON with the new scope present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)