### PR TITLE
fix(alerts): send PSA-safe HTML fragments and resolve subject variables

### DIFF
--- a/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-SchedulerCIPPNotifications.ps1
+++ b/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-SchedulerCIPPNotifications.ps1
@@ -143,7 +143,7 @@ function Push-SchedulerCIPPNotifications {
             foreach ($g in $LogsByTenant) {
                 $tenant = $g.Name
                 $Data = $g.Group | Select-Object Message, API, Tenant, Username, Severity
-                $HTMLContent = New-CIPPAlertTemplate -Data $Data -Format 'html' -InputObject 'table' -CIPPURL $CIPPURL
+                $HTMLContent = New-CIPPAlertTemplate -Data $Data -Format 'psa' -InputObject 'table' -CIPPURL $CIPPURL
                 $Title = "$tenant CIPP Alert: Alerts found starting at $((Get-Date).AddMinutes(-15))"
                 Send-CIPPAlert -Type 'psa' -Title $Title -HTMLContent $HTMLContent.htmlcontent -TenantFilter $tenant -APIName 'Alerts'
                 & $MarkSent $g.Group $LogTable
@@ -153,7 +153,7 @@ function Push-SchedulerCIPPNotifications {
                 $tenant = $g.Name
                 $Data = $g.Group
                 $Subject = "$($tenant): Standards are out of sync for $tenant"
-                $HTMLContent = New-CIPPAlertTemplate -Data $Data -Format 'html' -InputObject 'standards' -CIPPURL $CIPPURL
+                $HTMLContent = New-CIPPAlertTemplate -Data $Data -Format 'psa' -InputObject 'standards' -CIPPURL $CIPPURL
                 Send-CIPPAlert -Type 'psa' -Title $Subject -HTMLContent $HTMLContent.htmlcontent -TenantFilter $tenant -APIName 'Alerts'
                 & $MarkSent $g.Group $StandardsTable
                 $Data = $null; $HTMLContent = $null

--- a/backend/Modules/CIPPCore/Public/ConvertTo-PSAHtml.ps1
+++ b/backend/Modules/CIPPCore/Public/ConvertTo-PSAHtml.ps1
@@ -1,0 +1,25 @@
+function ConvertTo-PSAHtml {
+    <#
+    .SYNOPSIS
+        Converts alert HTML into a fragment that renders correctly in PSA ticket bodies
+    .DESCRIPTION
+        Halo stores details_html as-is, but doesn't apply the <style> block when it renders
+        the ticket, so class-styled tables come out with no borders or cell padding. Drops
+        the style block and moves the styling inline, along with the old border/cellpadding
+        attributes, so the markup doesn't depend on a stylesheet being picked up.
+    .PARAMETER Html
+        The HTML content to convert
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Html
+    )
+
+    $TableTag = '<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse;">'
+    $Html = $Html -replace '(?s)<style\b[^>]*>.*?</style>', ''
+    $Html = $Html -replace '<table\s+class\s*=\s*"?[\w-]+"?\s*>', $TableTag -replace '<table>', $TableTag
+    $Html = $Html -replace '<th>', '<th style="text-align:left;background-color:#f0f0f0;padding:6px 8px;border:1px solid #d0d0d0;">'
+    $Html = $Html -replace '<td>', '<td style="padding:6px 8px;border:1px solid #d0d0d0;vertical-align:top;">'
+    return $Html
+}

--- a/backend/Modules/CIPPCore/Public/New-CIPPAlertTemplate.ps1
+++ b/backend/Modules/CIPPCore/Public/New-CIPPAlertTemplate.ps1
@@ -313,7 +313,29 @@ function New-CIPPAlertTemplate {
     }
 
     if (![string]::IsNullOrWhiteSpace($CustomSubject)) {
-        $Title = '{0} - {1}' -f $Tenant, $CustomSubject
+        # Resolve %property% tokens against the alert data so subjects like
+        # '%username% - suspicious login' carry the actual value. Unknown tokens stay as-is.
+        # $Data is a single object for audit logs but an array of rows for logbook alerts,
+        # so only resolve when every row agrees - a multi-user alert has no one username.
+        $ResolvedSubject = [regex]::Replace($CustomSubject, '%(\w+)%', {
+            param($Match)
+            $PropertyName = switch ($Match.Groups[1].Value) {
+                'username' { 'UserId' }
+                'tenant' { return $Tenant }
+                default { $Match.Groups[1].Value }
+            }
+            $Values = foreach ($Row in @($Data)) {
+                if ($null -eq $Row) { continue }
+                if ($Row -is [System.Collections.IDictionary]) {
+                    $Row[$PropertyName]
+                } else {
+                    ($Row.PSObject.Properties | Where-Object { $_.Name -ieq $PropertyName } | Select-Object -First 1).Value
+                }
+            }
+            $Distinct = @($Values | Where-Object { ![string]::IsNullOrWhiteSpace("$_") } | ForEach-Object { "$_" } | Select-Object -Unique)
+            if ($Distinct.Count -eq 1) { $Distinct[0] } else { $Match.Value }
+        })
+        $Title = '{0} - {1}' -f $Tenant, $ResolvedSubject
     }
 
     if ($Format -eq 'html') {
@@ -322,6 +344,24 @@ function New-CIPPAlertTemplate {
         return [pscustomobject]@{
             title       = $Title
             htmlcontent = $AssembledHtml
+        }
+    } elseif ($Format -eq 'psa') {
+        # PSA ticket bodies get a bare fragment instead of the full email template: the
+        # template styles its tables with a <style> block and classes, which Halo stores
+        # but never applies, so the tables lose their borders and padding (#4243).
+        $PsaContent = $IntroText
+        if ($ButtonUrl -and $ButtonText) {
+            $PsaContent = "$PsaContent<p><a href=`"$ButtonUrl`">$ButtonText</a></p>"
+        }
+        if ($AfterButtonText) {
+            $PsaContent = "$PsaContent$AfterButtonText"
+        }
+        if ($AuditLogLink) {
+            $PsaContent = "$PsaContent<p><a href=`"$AuditLogLink`">View the audit log entry in CIPP</a></p>"
+        }
+        return [pscustomobject]@{
+            title       = $Title
+            htmlcontent = (ConvertTo-PSAHtml -Html $PsaContent)
         }
     } elseif ($Format -eq 'json') {
         if ($InputObject -eq 'auditlog') {

--- a/backend/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
+++ b/backend/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
@@ -268,7 +268,7 @@ function Send-CIPPScheduledTaskAlert {
                                 foreach ($Group in $Groups) {
                                     $GroupKey = $Group.Name
                                     $GroupHTMLFragment = $Group.Group | ForEach-Object { ConvertTo-AlertDisplayRow -Row $_ } | ConvertTo-Html -Fragment
-                                    $GroupHTML = $GroupHTMLFragment -replace '\[\[BR\]\]', '<br />' -replace '<table>', "$AlertHeader $TableDesign<table class=adaptiveTable>" | Out-String
+                                    $GroupHTML = ConvertTo-PSAHtml -Html ($GroupHTMLFragment -replace '\[\[BR\]\]', '<br />' -replace '<table>', "$AlertHeader $TableDesign<table class=adaptiveTable>" | Out-String)
 
                                     if ([string]::IsNullOrWhiteSpace($GroupKey)) {
                                         # Rows without a usable user identifier - fall back to the
@@ -296,7 +296,7 @@ function Send-CIPPScheduledTaskAlert {
                 }
 
                 if (-not $PsaSplitSent) {
-                    $PsaParams = @{ Type = 'psa'; Title = $title; HTMLContent = $HTML; TenantFilter = $TenantFilter }
+                    $PsaParams = @{ Type = 'psa'; Title = $title; HTMLContent = (ConvertTo-PSAHtml -Html $HTML); TenantFilter = $TenantFilter }
                     if ($TaskAffectedUser) { $PsaParams.AffectedUser = $TaskAffectedUser }
                     Send-CIPPAlert @PsaParams
                 }

--- a/backend/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPWebhookProcessing.ps1
+++ b/backend/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPWebhookProcessing.ps1
@@ -171,10 +171,11 @@ function Invoke-CippWebhookProcessing {
                 Write-Host 'email should be sent'
             }
             'generatePSA' {
+                $GeneratePSA = New-CIPPAlertTemplate -format 'psa' -data $Data -ActionResults $ActionResults -CIPPURL $CIPPURL -Tenant $Tenant.defaultDomainName -AuditLogLink $AuditLogLink -AlertComment $AlertComment -CustomSubject $Data.CIPPCustomSubject
                 $CIPPAlert = @{
                     Type         = 'psa'
-                    Title        = $GenerateEmail.title
-                    HTMLContent  = $GenerateEmail.htmlcontent
+                    Title        = $GeneratePSA.title
+                    HTMLContent  = $GeneratePSA.htmlcontent
                     TenantFilter = $TenantFilter
                 }
                 if ($AffectedUser) {


### PR DESCRIPTION
PSA ticket bodies are built from the same email template as the email alerts. Halo stores the HTML as-is but never applies the `<style>` block, so the tables end up with no borders or cell padding (#4243).

Adds a `psa` format to `New-CIPPAlertTemplate` that returns a bare fragment with the styling inline, plus a `ConvertTo-PSAHtml` helper for the scheduled task and notification paths that assemble their own HTML.

The webhook path was also reading `$GenerateEmail` in its PSA branch, so the title and body came off the email render rather than the PSA one.

Custom subjects with `%property%` tokens were never resolved and went out literally (#6024). They resolve against the alert data now. `$Data` is a single object for audit logs but an array of rows for logbook alerts, so a token only resolves when every row agrees — a multi-user alert has no one username, so it's left alone.

Tested against a Halo instance by reading the ticket back through the API:

- before: `<table class=adaptiveTable>` with bare `<td>`
- after: `<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse;">` with inline `<td style=...>`

Also checked in the Halo UI that the tables come out with borders and padding now.
