### PR TITLE
feat(halo): map tenants to Halo clients using Halo's Azure tenant IDs

### DIFF
--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
@@ -104,7 +104,9 @@ Function Invoke-ExecExtensionMapping {
           Write-Host "Started permissions orchestration with ID = '$InstanceId'"
           $Result = 'AutoMapping Request has been queued. Exact name matches will appear first and matches on device names and serials will take longer. Please check the CIPP Logbook and refresh the page once complete.'
         }
-
+        'HaloPSA' {
+          $Result = Invoke-HaloAutoMap -CIPPMapping $Table
+        }
       }
     }
     $StatusCode = [HttpStatusCode]::OK

--- a/backend/Modules/CippExtensions/Public/Halo/Invoke-HaloAutoMap.ps1
+++ b/backend/Modules/CippExtensions/Public/Halo/Invoke-HaloAutoMap.ps1
@@ -1,0 +1,99 @@
+function Invoke-HaloAutoMap {
+    <#
+    .SYNOPSIS
+        Auto-maps CIPP tenants to HaloPSA clients using Halo's own Azure tenant IDs
+    .DESCRIPTION
+        HaloPSA's Microsoft 365 integration stores the Azure tenant ID on each client it is
+        connected to. Those IDs are exact matches for CIPP's tenant customerId, so mappings
+        can be created without any name guessing. Existing mappings are never overwritten.
+    .PARAMETER CIPPMapping
+        The CippMapping table context from Get-CIPPTable
+    #>
+    [CmdletBinding()]
+    param (
+        $CIPPMapping
+    )
+
+    $Table = Get-CIPPTable -TableName Extensionsconfig
+    $Configuration = ((Get-CIPPAzDataTableEntity @Table).config | ConvertFrom-Json -ErrorAction Stop).HaloPSA
+    if (!$Configuration.ResourceURL) {
+        return 'HaloPSA is not configured. Configure the extension before running AutoMap.'
+    }
+
+    try {
+        $Token = Get-HaloToken -configuration $Configuration
+    } catch {
+        $Message = if ($_.ErrorDetails.Message) { Get-NormalizedError -Message $_.ErrorDetails.Message } else { $_.Exception.Message }
+        return "Could not authenticate to HaloPSA: $Message"
+    }
+
+    $GuidRegex = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    $Headers = @{Authorization = "Bearer $($Token.access_token)" }
+
+    # type=2 connections are Halo's customer-tenant (Microsoft 365) integrations; the
+    # connection detail carries the client <-> Azure tenant ID mapping table.
+    try {
+        $ConnectionsResponse = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/AzureADConnection?type=2" -Method GET -ContentType 'application/json' -Headers $Headers
+        $Connections = if ($ConnectionsResponse -is [array]) {
+            $ConnectionsResponse
+        } elseif ($ConnectionsResponse.id) {
+            @($ConnectionsResponse)
+        } else {
+            @($ConnectionsResponse.PSObject.Properties | Where-Object { $_.Value -is [array] } | Select-Object -First 1).Value
+        }
+
+        $HaloTenantMappings = foreach ($Connection in $Connections) {
+            $Detail = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/AzureADConnection/$($Connection.id)?type=2&includedetails=true&includetenants=true" -Method GET -ContentType 'application/json' -Headers $Headers
+            $Detail.mappings_client | Where-Object { $_.azure_tenant_id -match $GuidRegex -and $_.client_id }
+        }
+    } catch {
+        $Message = if ($_.ErrorDetails.Message) { Get-NormalizedError -Message $_.ErrorDetails.Message } else { $_.Exception.Message }
+        Write-LogMessage -API 'HaloAutoMap' -message "Could not get Azure tenant mappings from HaloPSA: $Message" -Sev 'Error'
+        return "Could not get Azure tenant mappings from HaloPSA: $Message. Check that Halo's Azure AD/Microsoft 365 integration is configured and the API agent may read integration settings."
+    }
+
+    if (($HaloTenantMappings | Measure-Object).Count -eq 0) {
+        return "No Azure tenant IDs were found on any HaloPSA client. Map tenants to clients in Halo's Azure AD/Microsoft 365 integration first, or map them manually here."
+    }
+
+    $MappingsByTenantId = $HaloTenantMappings | Group-Object -Property azure_tenant_id
+    $Tenants = Get-Tenants -IncludeErrors
+    $ExistingMappings = Get-ExtensionMapping -Extension 'Halo'
+
+    $Matched = 0
+    $AlreadyMapped = 0
+    $Ambiguous = 0
+    $Unmatched = 0
+
+    foreach ($Tenant in $Tenants) {
+        if ($Tenant.customerId -in $ExistingMappings.RowKey) {
+            $AlreadyMapped++
+            continue
+        }
+        $Group = $MappingsByTenantId | Where-Object { $_.Name -eq $Tenant.customerId }
+        if (!$Group) {
+            $Unmatched++
+            continue
+        }
+        $ClientIds = @($Group.Group.client_id | Sort-Object -Unique)
+        if ($ClientIds.Count -gt 1) {
+            $Ambiguous++
+            $ClientNames = ($Group.Group | Sort-Object -Property client_id -Unique | ForEach-Object { "$($_.client_name) ($($_.client_id))" }) -join ', '
+            Write-LogMessage -API 'HaloAutoMap' -message "Skipped tenant $($Tenant.displayName): its Azure tenant ID is present on multiple HaloPSA clients: $ClientNames" -Sev 'Warning'
+            continue
+        }
+        $Entry = $Group.Group | Select-Object -First 1
+        $AddObject = @{
+            PartitionKey    = 'HaloMapping'
+            RowKey          = "$($Tenant.customerId)"
+            IntegrationId   = "$($Entry.client_id)"
+            IntegrationName = "$($Entry.client_name)"
+        }
+        Add-CIPPAzDataTableEntity @CIPPMapping -Entity $AddObject -Force
+        Write-LogMessage -API 'HaloAutoMap' -message "Added mapping from Azure tenant ID match for $($Tenant.displayName) to $($Entry.client_name)" -Sev 'Info'
+        $Matched++
+    }
+
+    Write-LogMessage -API 'HaloAutoMap' -message "AutoMap complete: $Matched tenant(s) mapped from HaloPSA Azure tenant IDs, $AlreadyMapped already mapped, $Ambiguous skipped as ambiguous, $Unmatched with no matching Halo client" -Sev 'Info'
+    return "AutoMap complete: $Matched new tenant mapping(s) added, $($Matched + $AlreadyMapped) tenant(s) mapped in total."
+}

--- a/frontend/src/components/CippIntegrations/CippIntegrationTenantMapping.jsx
+++ b/frontend/src/components/CippIntegrations/CippIntegrationTenantMapping.jsx
@@ -47,8 +47,11 @@ const CippIntegrationSettings = ({ children }) => {
     defaultValues: mappings?.data,
   });
 
+  // Server-side automap writes the mappings itself, so the list has to be refetched or the
+  // table keeps showing the pre-automap rows and the new mappings look like they failed.
   const automapPostCall = ApiPostCall({
     datafromUrl: true,
+    relatedQueryKeys: [`IntegrationTenantMapping-${router.query.id}`],
   });
 
   const postCall = ApiPostCall({
@@ -169,11 +172,13 @@ const CippIntegrationSettings = ({ children }) => {
     return Array.isArray(tableData) ? tableData.map((item) => item.TenantId) : [];
   }, [tableData]);
 
+  // isSuccess only goes false -> true once, so depending on it alone meant a refetch never
+  // reached the table and server-side automap results stayed hidden until a page reload.
   useEffect(() => {
     if (mappings.isSuccess) {
       setTableData(mappings.data.Mappings ?? []);
     }
-  }, [mappings.isSuccess]);
+  }, [mappings.isSuccess, mappings.data]);
 
   return (
     <>

--- a/frontend/src/components/CippIntegrations/CippIntegrationTenantMapping.jsx
+++ b/frontend/src/components/CippIntegrations/CippIntegrationTenantMapping.jsx
@@ -269,7 +269,7 @@ const CippIntegrationSettings = ({ children }) => {
                 reportTitle={`${extension.id}-tenant-map`}
                 data={tableData}
                 simple={false}
-                simpleColumns={["IntegrationName", "Tenant", "TenantDomain"]}
+                simpleColumns={["IntegrationName", "Tenant", "TenantDomain", "TenantId"]}
                 isFetching={mappings.isFetching}
                 refreshFunction={() => mappings.refetch()}
               />

--- a/frontend/src/components/CippIntegrations/CippIntegrationTenantMapping.jsx
+++ b/frontend/src/components/CippIntegrations/CippIntegrationTenantMapping.jsx
@@ -99,12 +99,32 @@ const CippIntegrationSettings = ({ children }) => {
     formControl.setValue("integrationCompany", null);
   };
 
+  // Companies often differ from the GDAP tenant name only by case or legal suffix
+  // ("Company A LTD" vs "Company a Ltd" vs "Company A Limited"), so compare on a
+  // normalized form: lowercased, punctuation stripped, trailing legal suffixes removed.
+  const normalizeCompanyName = (name) => {
+    if (!name) return "";
+    let normalized = name
+      .toLowerCase()
+      .replace(/[.,'()&]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    const legalSuffixes = /\s(ltd|limited|llc|llp|inc|incorporated|plc|pty|corp|corporation|gmbh|bv|co)$/;
+    while (legalSuffixes.test(normalized)) {
+      normalized = normalized.replace(legalSuffixes, "").trim();
+    }
+    return normalized;
+  };
+
   const handleAutoMap = () => {
     const newTableData = [];
     tenantList.data?.pages[0]?.forEach((tenant) => {
-      const matchingCompany = mappings.data.Companies.find(
-        (company) => company.name === tenant.displayName
+      const normalizedTenant = normalizeCompanyName(tenant.displayName);
+      const matchingCompanies = mappings.data.Companies.filter(
+        (company) => normalizeCompanyName(company.name) === normalizedTenant
       );
+      // More than one company collapsing to the same name is ambiguous - leave it manual.
+      const matchingCompany = matchingCompanies.length === 1 ? matchingCompanies[0] : null;
       if (
         Array.isArray(tableData) &&
         tableData?.find((item) => item.TenantId === tenant.customerId)

--- a/frontend/src/data/Extensions.json
+++ b/frontend/src/data/Extensions.json
@@ -425,7 +425,8 @@
         }
       }
     ],
-    "mappingRequired": true
+    "mappingRequired": true,
+    "autoMapSyncApi": true
   },
   {
     "name": "NinjaOne",


### PR DESCRIPTION
Halo's Microsoft 365 integration already stores the Azure tenant ID against each client it's connected to, and those are exact matches for CIPP's `customerId`. Mapping off those instead of guessing at company names means the mapping is right even when the names have nothing in common — in my sandbox a tenant called `Contoso` maps to a Halo client called `Acorn Construction`, which no name matcher is ever going to get.

`Invoke-HaloAutoMap` reads the client/tenant table off Halo's `AzureADConnection?type=2` connection detail and matches on `azure_tenant_id`. It never overwrites an existing mapping, and it skips anything where the same tenant ID is on more than one Halo client rather than picking one. Halo is flagged `autoMapSyncApi` so the existing server-side automap path picks it up.

Also in here:

- Company name matching in the shared mapping component is now case-insensitive and ignores legal suffixes, so "Company A LTD" and "Company a Limited" match (#4070, #2547). If more than one company normalises to the same name it's left manual. This changes automap for Sherweb and Hudu too, since they use the client-side matcher.
- Tenant Id added to the mapping table columns, so you can actually see what a row is matched on.
- Fixes #97 — integrations with `autoMapSyncApi` wrote their mappings server-side but the table never refreshed, so nothing appeared until a page reload. `automapPostCall` wasn't invalidating the mapping query, and the effect that fills the table depended on `mappings.isSuccess`, which only flips once. NinjaOne is affected by this on current dev, not just Halo.

Tested against a Halo instance with two tenants that have Azure tenant IDs in Halo and one that doesn't: both mapped, existing mappings left alone, and the unmatched one skipped. Checked the mappings landed in the table and survived a reload.

Two things worth knowing before merging:

The `mappings.data` dependency relies on react-query handing back the same reference when the data hasn't changed, which it does, so this doesn't loop.

With the refetch working, unsaved rows the name matcher suggested get replaced when the table reloads. The underlying reason is that `tableData` is a `useState` copy of the query result that also holds pending edits, so there's no separation between saved and unsaved rows. I've left that alone — it's a bigger change to a component shared by four integrations and I can only test Halo. There's more detail at the bottom of #97 if you want it dealt with properly.
