### PR TITLE
feat(halopsa): default priority, test ticket, configurable note action and ticket-type scoped dropdowns

### DIFF
--- a/backend/Modules/CIPPCore/Public/New-CIPPAlertTemplate.ps1
+++ b/backend/Modules/CIPPCore/Public/New-CIPPAlertTemplate.ps1
@@ -310,6 +310,13 @@ function New-CIPPAlertTemplate {
                 $ButtonText = 'User Management'
             }
         }
+
+        # Append a deep-link to the source audit event so technicians can jump straight from
+        # the ticket to the raw record in CIPP for forensics, regardless of which action page
+        # the primary button takes them to.
+        if (![string]::IsNullOrWhiteSpace($AuditLogLink)) {
+            $AfterButtonText = "$AfterButtonText<p>For forensics, <a href=`"$AuditLogLink`">view the source audit event in CIPP</a>.</p>"
+        }
     }
 
     if (![string]::IsNullOrWhiteSpace($CustomSubject)) {

--- a/backend/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
+++ b/backend/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
@@ -333,10 +333,15 @@ function Send-CIPPAlert {
         }
         if ($PSCmdlet.ShouldProcess('PSA', 'Sending alert')) {
             try {
+                # Tag every CIPP-generated PSA ticket title with a "[CIPP]" prefix so technicians
+                # can filter, group and search for them in HaloPSA's ticket views with one query.
+                # The prefix is only added on the PSA path - email and webhook subjects keep the
+                # untouched title to preserve existing recipient inbox rules.
+                $PsaTitle = if ($Title -match '^\[CIPP\]\s') { "$Title" } else { "[CIPP] $Title" }
                 $Alert = @{
                     TenantId   = $TenantFilter
                     AlertText  = "$HTMLContent"
-                    AlertTitle = "$($Title)"
+                    AlertTitle = "$PsaTitle"
                 }
                 if ($AffectedUser) {
                     $Alert.AffectedUser = $AffectedUser

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
@@ -37,9 +37,11 @@ Function Invoke-ExecExtensionMapping {
       'HaloPSAFields' {
         $TicketTypes = Get-HaloTicketType
         $Outcomes = Get-HaloTicketOutcome
+        $Priorities = Get-HaloPriority
         $Result = @{
           'TicketTypes' = $TicketTypes
           'Outcomes'    = $Outcomes
+          'Priorities'  = $Priorities
         }
       }
       'PWPushFields' {

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecExtensionMapping.ps1
@@ -35,9 +35,13 @@ Function Invoke-ExecExtensionMapping {
         $Result = Get-SherwebMapping -CIPPMapping $Table
       }
       'HaloPSAFields' {
+        # Outcomes and priorities are scoped to a ticket type. The settings page sends the
+        # ticket type currently selected in the form so the lists follow the dropdown; without
+        # it both fall back to whatever ticket type was last saved.
+        $SelectedTicketType = $Request.Query.TicketType
         $TicketTypes = Get-HaloTicketType
-        $Outcomes = Get-HaloTicketOutcome
-        $Priorities = Get-HaloPriority
+        $Outcomes = Get-HaloTicketOutcome -TicketType $SelectedTicketType
+        $Priorities = Get-HaloPriority -TicketType $SelectedTicketType
         $Result = @{
           'TicketTypes' = $TicketTypes
           'Outcomes'    = $Outcomes

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecHaloPSATestTicket.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Extensions/Invoke-ExecHaloPSATestTicket.ps1
@@ -1,0 +1,57 @@
+Function Invoke-ExecHaloPSATestTicket {
+    <#
+    .FUNCTIONALITY
+        Entrypoint,AnyTenant
+    .ROLE
+        CIPP.Extension.ReadWrite
+    .SYNOPSIS
+        Create a HaloPSA test ticket so admins can check the integration works without waiting
+        for a real alert to fire. Covers auth, tenant mapping, ticket type and default priority.
+
+        Calls New-HaloPSATicket directly rather than going through Send-CIPPAlert, so the parts
+        that live in the alert pipeline - the [CIPP] title prefix and per-user ticket linking -
+        are not exercised here.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    try {
+        $ConfigTable = Get-CIPPTable -TableName Extensionsconfig
+        $Configuration = ((Get-CIPPAzDataTableEntity @ConfigTable).config | ConvertFrom-Json).HaloPSA
+
+        if (-not $Configuration -or -not $Configuration.Enabled) {
+            $Results = [pscustomobject]@{ Results = 'HaloPSA integration is not enabled. Save the integration with Enable Integration ticked, then try again.' }
+        } else {
+            # Pick the first mapped tenant's Halo client id so the test ticket lands on a real
+            # client. Filters to mappings whose IntegrationId is numeric (Halo client ids are
+            # always integers); legacy or cross-integration rows with GUID-shaped IntegrationIds
+            # are skipped instead of crashing the cast. Falls back to 1 (the same default the
+            # alert pipeline uses) if no usable mapping exists.
+            $MappingTable = Get-CIPPTable -TableName CippMapping
+            $Mappings = Get-CIPPAzDataTableEntity @MappingTable -Filter "PartitionKey eq 'HaloMapping'"
+            $Mapping = $Mappings | Where-Object { $_.IntegrationId -and (($_.IntegrationId -as [int]) -gt 0) } | Select-Object -First 1
+            $ClientId = if ($Mapping) { [int]$Mapping.IntegrationId } else { 1 }
+            $ClientName = if ($Mapping) { $Mapping.IntegrationName } else { 'Default Client (no numeric Tenant Mapping found)' }
+
+            $Timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ssZ')
+            $Title = 'Test ticket from CIPP integration'
+            $Description = @"
+<p>This is a <strong>test ticket</strong> created by CIPP at $Timestamp to verify end-to-end HaloPSA delivery.</p>
+<p>Target client: <strong>$ClientName</strong> (id <code>$ClientId</code>).</p>
+<p>It is raised the same way CIPP raises alert tickets, so the configured Ticket Type and Default Priority should both apply.</p>
+<p>It is safe to close this ticket.</p>
+"@
+
+            $Result = New-HaloPSATicket -Title $Title -Description $Description -Client $ClientId
+
+            $Results = [pscustomobject]@{ Results = "$Result against client '$ClientName' (id $ClientId). It is safe to close this ticket." }
+        }
+    } catch {
+        $Results = [pscustomobject]@{ Results = "Failed to create HaloPSA test ticket: $($_.Exception.Message). Line $($_.InvocationInfo.ScriptLineNumber)" }
+    }
+
+    return ([HttpResponseContext]@{
+            StatusCode = [HttpStatusCode]::OK
+            Body       = $Results
+        })
+}

--- a/backend/Modules/CippExtensions/Public/Halo/Get-HaloPriority.ps1
+++ b/backend/Modules/CippExtensions/Public/Halo/Get-HaloPriority.ps1
@@ -10,20 +10,27 @@ function Get-HaloPriority {
         admins pick one that doesn't apply to the chosen Ticket Type, producing tickets that
         either reject the priority outright or fall back to the SLA default with no warning.
 
-        Pattern mirrors Get-HaloTicketOutcome: requires Ticket Type to be saved first, then
-        looks up the ticket type's sla_id, then returns the priorities tied to that SLA.
+        Looks up the ticket type's sla_id, then returns the priorities tied to that SLA.
+    .PARAMETER TicketType
+        Ticket type to scope the priorities to. The settings page passes the value currently
+        selected in the form so the list follows the dropdown without needing a save first.
+        Falls back to the saved ticket type when not supplied.
     #>
     [CmdletBinding()]
-    param ()
+    param (
+        $TicketType
+    )
     $Table = Get-CIPPTable -TableName Extensionsconfig
     try {
         $Configuration = ((Get-CIPPAzDataTableEntity @Table).config | ConvertFrom-Json -ea stop).HaloPSA
         $Token = Get-HaloToken -configuration $Configuration
-        $TicketType = $Configuration.TicketType.value ?? $Configuration.TicketType
+        if (-not $TicketType) {
+            $TicketType = $Configuration.TicketType.value ?? $Configuration.TicketType
+        }
 
         if (-not $TicketType) {
             return @(@{
-                    name  = 'Select and save a Ticket Type first to see available priorities'
+                    name  = 'Select a Ticket Type first to see available priorities'
                     priorityid = -1
                 })
         }
@@ -44,10 +51,8 @@ function Get-HaloPriority {
         }
 
         if (-not $SlaId) {
-            $InspectedFields = ($TicketTypeRecord.PSObject.Properties.Name | Where-Object { $_ -match 'sla' }) -join ', '
-            $Hint = if ($InspectedFields) { "Inspected SLA-shaped fields: $InspectedFields" } else { 'No SLA-shaped fields present on the ticket type response' }
             return @(@{
-                    name  = "The selected Ticket Type has no SLA attached, so no priorities are restricted to it. $Hint"
+                    name       = 'The selected Ticket Type has no SLA attached, so there are no priorities to pick from. Attach an SLA to the ticket type in HaloPSA, or leave this blank.'
                     priorityid = -1
                 })
         }

--- a/backend/Modules/CippExtensions/Public/Halo/Get-HaloPriority.ps1
+++ b/backend/Modules/CippExtensions/Public/Halo/Get-HaloPriority.ps1
@@ -1,0 +1,85 @@
+function Get-HaloPriority {
+    <#
+    .SYNOPSIS
+        Get HaloPSA Priorities for use in the integration UI dropdown, restricted to the SLA
+        attached to the configured Ticket Type so admins can only pick a priority that the
+        ticket would actually be allowed to use.
+    .DESCRIPTION
+        HaloPSA priorities only have meaningful effect within the SLA they belong to (response
+        and resolution targets are defined per priority per SLA). Returning all priorities lets
+        admins pick one that doesn't apply to the chosen Ticket Type, producing tickets that
+        either reject the priority outright or fall back to the SLA default with no warning.
+
+        Pattern mirrors Get-HaloTicketOutcome: requires Ticket Type to be saved first, then
+        looks up the ticket type's sla_id, then returns the priorities tied to that SLA.
+    #>
+    [CmdletBinding()]
+    param ()
+    $Table = Get-CIPPTable -TableName Extensionsconfig
+    try {
+        $Configuration = ((Get-CIPPAzDataTableEntity @Table).config | ConvertFrom-Json -ea stop).HaloPSA
+        $Token = Get-HaloToken -configuration $Configuration
+        $TicketType = $Configuration.TicketType.value ?? $Configuration.TicketType
+
+        if (-not $TicketType) {
+            return @(@{
+                    name  = 'Select and save a Ticket Type first to see available priorities'
+                    priorityid = -1
+                })
+        }
+
+        $Headers = @{ Authorization = "Bearer $($Token.access_token)" }
+        $TicketTypeRecord = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/tickettype/$TicketType" -ContentType 'application/json' -Method GET -Headers $Headers
+
+        # Halo's /tickettype/{id} response uses different field names for the linked SLA across
+        # versions. Check the known variants in priority order, take the first non-zero match.
+        $SlaIdCandidates = @('default_sla', 'default_sla_id', 'sla_id', 'slaid', 'sla')
+        $SlaId = $null
+        foreach ($Field in $SlaIdCandidates) {
+            $Value = $TicketTypeRecord.$Field
+            if ($Value -and ([int]$Value) -gt 0) {
+                $SlaId = [int]$Value
+                break
+            }
+        }
+
+        if (-not $SlaId) {
+            $InspectedFields = ($TicketTypeRecord.PSObject.Properties.Name | Where-Object { $_ -match 'sla' }) -join ', '
+            $Hint = if ($InspectedFields) { "Inspected SLA-shaped fields: $InspectedFields" } else { 'No SLA-shaped fields present on the ticket type response' }
+            return @(@{
+                    name  = "The selected Ticket Type has no SLA attached, so no priorities are restricted to it. $Hint"
+                    priorityid = -1
+                })
+        }
+
+        # The /SLA/{id} response shape varies between Halo versions: some return full priority
+        # objects under .priorities, some only IDs. Resolve both by fetching the canonical
+        # priority list and filtering by ID, which works regardless of the SLA payload shape.
+        $Sla = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/SLA/$SlaId" -ContentType 'application/json' -Method GET -Headers $Headers
+
+        $SlaPriorityIds = @()
+        if ($Sla.priorities) {
+            $SlaPriorityIds = foreach ($p in $Sla.priorities) {
+                if ($p.id) { $p.id } else { $p }
+            }
+        }
+
+        $AllPriorities = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/Priority" -ContentType 'application/json' -Method GET -Headers $Headers
+
+        if ($SlaPriorityIds.Count -gt 0) {
+            $AllPriorities | Where-Object { $_.id -in $SlaPriorityIds } | Sort-Object -Property priorityorder, name
+        } else {
+            # SLA exists but doesn't expose a priority list - return all priorities as a fallback
+            # so the dropdown isn't empty, with a leading hint row.
+            @(@{ name = '(SLA returned no priority list - showing all priorities)'; priorityid = -1 }) +
+                ($AllPriorities | Sort-Object -Property priorityorder, name)
+        }
+    } catch {
+        $Message = if ($_.ErrorDetails.Message) {
+            Get-NormalizedError -Message $_.ErrorDetails.Message
+        } else {
+            $_.Exception.Message
+        }
+        @(@{ name = "Could not get HaloPSA Priorities, error: $Message"; id = '' })
+    }
+}

--- a/backend/Modules/CippExtensions/Public/Halo/Get-HaloTicketOutcome.ps1
+++ b/backend/Modules/CippExtensions/Public/Halo/Get-HaloTicketOutcome.ps1
@@ -4,17 +4,25 @@ function Get-HaloTicketOutcome {
         Get Halo Ticket Outcome
     .DESCRIPTION
         Get Halo Ticket Outcome
+    .PARAMETER TicketType
+        Ticket type to scope the outcomes to. The settings page passes the value currently
+        selected in the form so the list follows the dropdown without needing a save first.
+        Falls back to the saved ticket type when not supplied.
     .EXAMPLE
         Get-HaloTicketOutcome
 
     #>
   [CmdletBinding()]
-  param ()
+  param (
+    $TicketType
+  )
   $Table = Get-CIPPTable -TableName Extensionsconfig
   try {
     $Configuration = ((Get-CIPPAzDataTableEntity @Table).config | ConvertFrom-Json -ea stop).HaloPSA
     $Token = Get-HaloToken -configuration $Configuration
-    $TicketType = $Configuration.TicketType.value ?? $Configuration.TicketType
+    if (-not $TicketType) {
+      $TicketType = $Configuration.TicketType.value ?? $Configuration.TicketType
+    }
     if ($TicketType) {
       $WorkflowId = (Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/tickettype/$TicketType" -ContentType 'application/json' -Method GET -Headers @{Authorization = "Bearer $($Token.access_token)" }).workflow_id
       $Workflow = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/workflow/$WorkflowId" -ContentType 'application/json' -Method GET -Headers @{Authorization = "Bearer $($Token.access_token)" }
@@ -25,7 +33,7 @@ function Get-HaloTicketOutcome {
       # Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/outcome" -ContentType 'application/json' -Method GET -Headers @{Authorization = "Bearer $($Token.access_token)" }
       @(
         @{
-          buttonname = 'Select and save a Ticket Type first to see available outcomes'
+          buttonname = 'Select a Ticket Type first to see available outcomes'
           value      = -1
         }
       )

--- a/backend/Modules/CippExtensions/Public/Halo/New-HaloPSATicket.ps1
+++ b/backend/Modules/CippExtensions/Public/Halo/New-HaloPSATicket.ps1
@@ -127,6 +127,17 @@ function New-HaloPSATicket {
     $TicketType = $Configuration.TicketType.value ?? $Configuration.TicketType
     $object | Add-Member -MemberType NoteProperty -Name 'tickettype_id' -Value $TicketType -Force
   }
+  if ($Configuration.DefaultPriority) {
+    $Priority = $Configuration.DefaultPriority.value ?? $Configuration.DefaultPriority
+    $PriorityInt = $Priority -as [int]
+    if ($PriorityInt -and $PriorityInt -gt 0) {
+      $object | Add-Member -MemberType NoteProperty -Name 'priority_id' -Value $PriorityInt -Force
+    } else {
+      # Stored value isn't a valid Halo priority id (legacy data, hint-row selection, etc.).
+      # Skip priority_id rather than crashing the cast - Halo will fall back to its default.
+      Write-LogMessage -message "HaloPSA.DefaultPriority value '$Priority' is not a valid integer - omitting priority_id from ticket payload" -API 'HaloPSATicket' -sev Warning
+    }
+  }
   #use the token to create a new ticket in HaloPSA
   $body = ConvertTo-Json -Compress -Depth 10 -InputObject @($Object)
 

--- a/backend/Modules/CippExtensions/Public/Halo/New-HaloPSATicket.ps1
+++ b/backend/Modules/CippExtensions/Public/Halo/New-HaloPSATicket.ps1
@@ -46,18 +46,23 @@ function New-HaloPSATicket {
       if ($Ticket.id) {
         if (!$Ticket.hasbeenclosed) {
           Write-Information 'Ticket is still open, adding new note'
+          # Halo won't take a note without an outcome - it answers "An Outcome must be entered
+          # for this Action" - so fall back to 7, the built-in Internal Note outcome, when the
+          # integration hasn't been given one. The failure this used to hit was the API user not
+          # having rights to the action, which is caught below and falls back to a new ticket so
+          # the alert still lands somewhere.
+          $Outcome = if ($Configuration.Outcome) {
+            $Configuration.Outcome.value ?? $Configuration.Outcome
+          } else {
+            7
+          }
           $Object = [PSCustomObject]@{
             ticket_id      = $ExistingTicket.TicketID
-            outcome_id     = 7
+            outcome_id     = $Outcome
             hiddenfromuser = $true
             note_html      = $description
           }
-  
-          if ($Configuration.Outcome) {
-            $Outcome = $Configuration.Outcome.value ?? $Configuration.Outcome
-            $Object.outcome_id = $Outcome
-          }
-  
+
           $body = ConvertTo-Json -Compress -Depth 10 -InputObject @($Object)
           $NoteAdded = $false
           try {
@@ -76,7 +81,12 @@ function New-HaloPSATicket {
             }
             # Don't return here - if appending a note failed (e.g. permissions on the action,
             # invalid outcome_id) we still want to create a fresh ticket so the alert isn't lost.
-            Write-LogMessage -message "Failed to add note to HaloPSA ticket $($ExistingTicket.TicketID): $Message - falling back to creating a new ticket" -API 'HaloPSATicket' -sev Warning -LogData (Get-CippException -Exception $_)
+            $OutcomeHint = if ($Configuration.Outcome) {
+              "Outcome $Outcome is set for this integration - check the HaloPSA API user can run that action."
+            } else {
+              "No Outcome is configured, so the built-in Internal Note action ($Outcome) was used. If it has been removed or the API user cannot run it, pick a different Outcome on the HaloPSA integration page."
+            }
+            Write-LogMessage -message "Failed to add note to HaloPSA ticket $($ExistingTicket.TicketID): $Message - falling back to creating a new ticket. $OutcomeHint" -API 'HaloPSATicket' -sev Warning -LogData (Get-CippException -Exception $_)
             Write-Information "Failed to add note to HaloPSA ticket: $Message; creating a new ticket instead"
             Write-Information "Body we tried to ship: $body"
           }

--- a/frontend/src/components/CippIntegrations/CippIntegrationSettings.jsx
+++ b/frontend/src/components/CippIntegrations/CippIntegrationSettings.jsx
@@ -7,7 +7,7 @@ import { useSettings } from "../../hooks/use-settings";
 import { ApiGetCall } from "../../api/ApiCall";
 import { useRouter } from "next/router";
 import extensions from "../../data/Extensions.json";
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { CippFormCondition } from "../CippComponents/CippFormCondition";
 
 const CippIntegrationSettings = ({ children }) => {
@@ -35,20 +35,112 @@ const CippIntegrationSettings = ({ children }) => {
     logo = extension.logoDark;
   }
 
+  // Some dropdowns are scoped by another setting - Halo's priority and outcome lists only cover
+  // the saved ticket type - so their cached options go stale as soon as the form is saved.
+  // Invalidate every option query this extension uses, not just Integrations, or the lists keep
+  // serving the previous ticket type's values until the refresh button is pressed by hand.
+  // Tenant-scoped options register as `${queryKey}-${tenant}`, so match on the prefix.
+  const relatedQueryKeys = useMemo(
+    () => [
+      "Integrations",
+      ...(extension?.SettingOptions ?? [])
+        .map((setting) => setting?.api?.queryKey)
+        .filter(Boolean)
+        .map((queryKey) => `${queryKey}*`),
+    ],
+    [extension]
+  );
+
+  // Settings that declare dependsOn get their options from whatever that other setting is set to.
+  // Changing the parent leaves the old selection sitting in the field, and it still saves - so a
+  // Halo priority from the previous ticket type's SLA ends up on tickets raised under a ticket
+  // type that never offered it. Clear the dependents when the parent actually changes.
+  const dependentSettings = useMemo(
+    () => (extension?.SettingOptions ?? []).filter((setting) => setting?.dependsOn),
+    [extension]
+  );
+  const parentNames = useMemo(
+    () => [...new Set(dependentSettings.map((setting) => setting.dependsOn))],
+    [dependentSettings]
+  );
+  const parentValues = formControl.watch(parentNames);
+  // Holds the parent values as of the last load/change, so we only clear on a real user change
+  // and not while the form is being populated from saved config.
+  const previousParentValues = useRef(null);
+
   useEffect(() => {
     if (integrations.isSuccess) {
       formControl.reset({
         ...integrations.data,
       });
       formControl.trigger();
+      // Re-baseline: the next run of the effect below records the freshly loaded parent values
+      // instead of treating them as a change and wiping the saved dependents.
+      previousParentValues.current = null;
     }
   }, [integrations.isSuccess]);
+
+  // Options for a dependent field come from whatever its parent is set to, so send the parent's
+  // current form value with the request rather than letting the backend fall back to the saved
+  // config. The query key carries the same value, otherwise react-query serves the previous
+  // parent's cached options and the list only catches up after a save.
+  const buildApi = (setting) => {
+    if (!setting?.api || !setting?.dependsOn) return setting?.api;
+    const parentValue = formControl.getValues(setting.dependsOn);
+    const scope = parentValue?.value ?? parentValue ?? "";
+    const paramName = setting.dependsOnParam ?? setting.dependsOn.split(".").pop();
+    return {
+      ...setting.api,
+      data: { ...setting.api.data, [paramName]: scope },
+      queryKey: `${setting.api.queryKey}-${scope}`,
+    };
+  };
+
+  // Halo returns an explanatory row with an id of -1 when it has nothing real to offer ("no SLA
+  // attached", "select a ticket type first"). It's there to be read, not picked - without this
+  // it can be selected and saved as if it were a priority or an outcome.
+  const isPlaceholderOption = (option) => option?.value === -1;
+
+  // Existing configs can already hold one of those rows from before it was blocked, and it would
+  // otherwise sit there looking like a real setting. Drop it so the field reads as unset.
+  const dependentValues = formControl.watch(dependentSettings.map((setting) => setting.name));
+  useEffect(() => {
+    dependentSettings.forEach((setting, index) => {
+      if (isPlaceholderOption(dependentValues?.[index])) {
+        formControl.setValue(setting.name, null);
+      }
+    });
+  }, [dependentValues, dependentSettings, formControl]);
+
+  const extraFieldProps = (setting) => {
+    const props = { api: buildApi(setting) };
+    if (setting?.type === "autoComplete" && setting?.api) {
+      props.getOptionDisabled = isPlaceholderOption;
+    }
+    return props;
+  };
+
+  useEffect(() => {
+    if (!parentNames.length) return;
+    const current = parentNames.map((_, index) => JSON.stringify(parentValues?.[index] ?? null));
+    if (previousParentValues.current === null) {
+      previousParentValues.current = current;
+      return;
+    }
+    parentNames.forEach((parentName, index) => {
+      if (previousParentValues.current[index] === current[index]) return;
+      dependentSettings
+        .filter((setting) => setting.dependsOn === parentName)
+        .forEach((setting) => formControl.setValue(setting.name, null, { shouldDirty: true }));
+    });
+    previousParentValues.current = current;
+  }, [parentValues, parentNames, dependentSettings, formControl]);
 
   return (
     <>
       {integrations.isSuccess && extension ? (
         <CippFormSection
-          relatedQueryKeys={"Integrations"}
+          relatedQueryKeys={relatedQueryKeys}
           formControl={formControl}
           formPageType="Integration"
           title={extension.name}
@@ -73,6 +165,7 @@ const CippIntegrationSettings = ({ children }) => {
                           placeholder={setting?.placeholder}
                           fullWidth
                           {...setting}
+                          {...extraFieldProps(setting)}
                         />
                       </Box>
                     </Grid>
@@ -89,6 +182,7 @@ const CippIntegrationSettings = ({ children }) => {
                         placeholder={setting?.placeholder}
                         fullWidth
                         {...setting}
+                        {...extraFieldProps(setting)}
                       />
                     </Box>
                   </Grid>

--- a/frontend/src/data/Extensions.json
+++ b/frontend/src/data/Extensions.json
@@ -378,8 +378,8 @@
         "type": "autoComplete",
         "name": "HaloPSA.DefaultPriority",
         "label": "HaloPSA Default Priority",
-        "placeholder": "Select a priority for CIPP-generated tickets, leave blank for default",
-        "helperText": "Optional. When set, every CIPP-generated alert ticket is created at this HaloPSA priority - useful for routing through your SLA workflow. The list is restricted to priorities defined on the SLA attached to the selected Ticket Type, so set the Ticket Type first and save before choosing one here. Leave blank to let HaloPSA apply the default priority defined on the Ticket Type.",
+        "placeholder": "Select a priority, leave blank for default",
+        "helperText": "Optional. Sets the priority on every CIPP-generated ticket. Restricted to priorities on the Ticket Type's SLA. Leave blank to use the SLA default.",
         "fullRow": true,
         "multiple": false,
         "api": {
@@ -394,10 +394,9 @@
           "showRefresh": true
         },
         "condition": {
-          "field": "HaloPSA.Enabled",
-          "compareType": "is",
-          "compareValue": true,
-          "action": "disable"
+          "field": "HaloPSA.TicketType",
+          "compareType": "hasValue",
+          "action": "hide"
         }
       },
       {
@@ -406,10 +405,9 @@
         "label": "Consolidate Tickets",
         "helperText": "Adds repeat alerts (same title) as a note on the existing open ticket instead of raising a new one. Turns on the Outcome dropdown below, which needs a valid private note action.",
         "condition": {
-          "field": "HaloPSA.Enabled",
-          "compareType": "is",
-          "compareValue": true,
-          "action": "disable"
+          "field": "HaloPSA.TicketType",
+          "compareType": "hasValue",
+          "action": "hide"
         }
       },
       {
@@ -444,10 +442,9 @@
         "label": "Link Tickets to affected Users",
         "helperText": "Raises one ticket per affected user and links it to the matching HaloPSA contact (by Azure Object ID, then email/login). No match falls back to the client's General User, with the UPN in the ticket body.",
         "condition": {
-          "field": "HaloPSA.Enabled",
-          "compareType": "is",
-          "compareValue": true,
-          "action": "disable"
+          "field": "HaloPSA.TicketType",
+          "compareType": "hasValue",
+          "action": "hide"
         }
       }
     ],

--- a/frontend/src/data/Extensions.json
+++ b/frontend/src/data/Extensions.json
@@ -353,7 +353,7 @@
         "name": "HaloPSA.TicketType",
         "label": "HaloPSA Ticket Type",
         "placeholder": "Select your HaloPSA Ticket Type, leave blank for default",
-        "helperText": "The ticket type used for CIPP alert tickets. Sets the workflow and the Outcomes available below. Save after changing so the Outcome list refreshes.",
+        "helperText": "The ticket type used for CIPP alert tickets. Sets the workflow, and the priorities and outcomes available below.",
         "fullRow": true,
         "multiple": false,
         "api": {
@@ -377,6 +377,7 @@
       {
         "type": "autoComplete",
         "name": "HaloPSA.DefaultPriority",
+        "dependsOn": "HaloPSA.TicketType",
         "label": "HaloPSA Default Priority",
         "placeholder": "Select a priority, leave blank for default",
         "helperText": "Optional. Sets the priority on every CIPP-generated ticket. Restricted to priorities on the Ticket Type's SLA. Leave blank to use the SLA default.",
@@ -413,9 +414,10 @@
       {
         "type": "autoComplete",
         "name": "HaloPSA.Outcome",
+        "dependsOn": "HaloPSA.TicketType",
         "label": "HaloPSA Outcome",
         "placeholder": "Select your HaloPSA Outcome, leave blank for default",
-        "helperText": "The action applied when a duplicate alert is added to an existing ticket. Use a private note action your HaloPSA API user can run. Set the Ticket Type first and save - the list only shows outcomes from that type's workflow.",
+        "helperText": "The action applied when a duplicate alert is added to an existing ticket. Use a private note action your HaloPSA API user can run. Only outcomes from the selected Ticket Type's workflow are listed. Leave blank to use Halo's built-in Internal Note action.",
         "fullRow": true,
         "multiple": false,
         "api": {

--- a/frontend/src/data/Extensions.json
+++ b/frontend/src/data/Extensions.json
@@ -375,6 +375,32 @@
         }
       },
       {
+        "type": "autoComplete",
+        "name": "HaloPSA.DefaultPriority",
+        "label": "HaloPSA Default Priority",
+        "placeholder": "Select a priority for CIPP-generated tickets, leave blank for default",
+        "helperText": "Optional. When set, every CIPP-generated alert ticket is created at this HaloPSA priority - useful for routing through your SLA workflow. The list is restricted to priorities defined on the SLA attached to the selected Ticket Type, so set the Ticket Type first and save before choosing one here. Leave blank to let HaloPSA apply the default priority defined on the Ticket Type.",
+        "fullRow": true,
+        "multiple": false,
+        "api": {
+          "url": "/api/ExecExtensionMapping",
+          "data": {
+            "List": "HaloPSAFields"
+          },
+          "queryKey": "HaloPriorities",
+          "dataKey": "Priorities",
+          "labelField": "name",
+          "valueField": "priorityid",
+          "showRefresh": true
+        },
+        "condition": {
+          "field": "HaloPSA.Enabled",
+          "compareType": "is",
+          "compareValue": true,
+          "action": "disable"
+        }
+      },
+      {
         "type": "switch",
         "name": "HaloPSA.ConsolidateTickets",
         "label": "Consolidate Tickets",

--- a/frontend/src/pages/cipp/integrations/configure.js
+++ b/frontend/src/pages/cipp/integrations/configure.js
@@ -75,6 +75,21 @@ const Page = () => {
   const actionSyncResults = ApiGetCall({
     ...syncQuery,
   });
+
+  const [haloTestTicketQuery, setHaloTestTicketQuery] = useState({ url: "", waiting: false, queryKey: "" });
+  const actionHaloTestTicketResults = ApiGetCall({
+    ...haloTestTicketQuery,
+  });
+  const handleHaloTestTicket = () => {
+    if (haloTestTicketQuery.waiting) {
+      actionHaloTestTicketResults.refetch();
+    }
+    setHaloTestTicketQuery({
+      url: "/api/ExecHaloPSATestTicket",
+      waiting: true,
+      queryKey: `ExecHaloPSATestTicket-${router.query.id}`,
+    });
+  };
   const clearHIBPKey = ApiPostCall({
     relatedQueryKeys: ["Integrations"],
   });
@@ -195,6 +210,24 @@ const Page = () => {
                   </Button>
                 </Box>
               )}
+              {extension?.id === "HaloPSA" && (
+                <Box>
+                  <Button
+                    variant="outlined"
+                    color="primary"
+                    onClick={() => handleHaloTestTicket()}
+                    disabled={
+                      actionHaloTestTicketResults?.isLoading ||
+                      integrations?.data?.HaloPSA?.Enabled !== true
+                    }
+                  >
+                    <SvgIcon fontSize="small" style={{ marginRight: "8" }}>
+                      <BeakerIcon />
+                    </SvgIcon>
+                    Create Test Ticket
+                  </Button>
+                </Box>
+              )}
               {extension?.id === "HIBP" && (
                 <Box>
                   <Button
@@ -229,6 +262,7 @@ const Page = () => {
             </Stack>
             <CippApiResults apiObject={actionTestResults} />
             <CippApiResults apiObject={actionSyncResults} />
+            <CippApiResults apiObject={actionHaloTestTicketResults} />
             <CippApiResults apiObject={clearHIBPKey} />
           </CardContent>
           <Box sx={{ width: "100%" }}>


### PR DESCRIPTION
A batch of HaloPSA integration changes, all tested against a live Halo instance.

**Default Priority.** CIPP has never set a priority on the tickets it raises, so they all land on whatever the ticket type defaults to. There's now a Default Priority setting, restricted to the priorities on the selected ticket type's SLA — picking one from another SLA doesn't do anything useful, so the list only offers what the ticket would actually accept. Left blank, nothing is sent and Halo's default applies as before.

**Create Test Ticket.** A button on the integration page that raises a real ticket so you can check auth, tenant mapping, ticket type and priority without waiting for an alert to fire. It calls `New-HaloPSATicket` directly rather than going through `Send-CIPPAlert`, so it doesn't exercise the title prefix or per-user linking — the function's docs say so.

**Note action is configurable.** Appending a note to an existing ticket was hardcoded to `outcome_id` 7. That's the built-in Internal Note action so it works on a stock Halo, but there was no way to change it, and where the API user can't run that action every consolidated alert failed with "You do not have access to this Action at the moment" and the note was lost. It now comes from the integration settings and falls back to 7. Halo rejects a note with no outcome at all, so the field is always sent. If it does fail, the alert becomes a new ticket instead of disappearing, and the warning says which outcome failed and where to change it.

**Dependent dropdowns follow the field they depend on.** The priority and outcome lists are scoped to the ticket type, but they were built from the last *saved* ticket type — change it and you'd see the old options until you saved and hit refresh, with the previous selection still sitting in the field. So a priority from the old type's SLA could end up saved against a ticket type that never offered it. Settings can now declare `dependsOn`; the dropdown sends that field's current value and includes it in the query key, changing the parent clears the dependents, and the explanatory rows Halo returns when there's nothing to offer are no longer selectable. `Get-HaloPriority` and `Get-HaloTicketOutcome` take an optional ticket type and fall back to the saved one, so existing callers are unaffected. Only HaloPSA declares it — Sherweb and PWPush are untouched.

Also in here: a `[CIPP]` prefix on PSA ticket titles so they can be filtered in Halo (PSA only, email and webhook subjects are unchanged), a link back to the source audit event in alert bodies, and the downstream settings are hidden until a ticket type is picked.

Tested on a live Halo instance:

- ticket raised with the configured ticket type and priority, confirmed on the ticket (`tickettype_id=1`, `priority_id=2`)
- repeat alert with the same title appended a note rather than opening a second ticket, both with a configured outcome and falling back to 7
- configured a non-existent outcome to check the failure path: note rejected, new ticket created, warning logged naming the outcome
- title prefix confirmed on the created ticket
- audit log link present when a link is passed, absent when it isn't
- priority and outcome lists follow the ticket type dropdown without saving, and clear when it changes
- checked Hudu, NinjaOne and PWPush settings pages still behave — none of them declare `dependsOn`, so nothing changes for them
