### PR TITLE
fix(webhooks): harden audit log v2 processing

### DIFF
--- a/backend/Modules/CIPPCore/Public/AuditLogs/Get-CippAuditLogSearchResults.ps1
+++ b/backend/Modules/CIPPCore/Public/AuditLogs/Get-CippAuditLogSearchResults.ps1
@@ -28,6 +28,8 @@ function Get-CippAuditLogSearchResults {
             $GraphRequest.CountOnly = $true
         }
 
-        New-GraphGetRequest @GraphRequest -ErrorAction Stop | Sort-Object -Property createdDateTime -Descending
+        # Deliberately unsorted: Sort-Object blocks until the entire window is in memory, and
+        # no caller depends on the order.
+        New-GraphGetRequest @GraphRequest -Stream -ErrorAction Stop
     }
 }

--- a/backend/Modules/CIPPCore/Public/Webhooks/Push-AuditLogDownloadV2.ps1
+++ b/backend/Modules/CIPPCore/Public/Webhooks/Push-AuditLogDownloadV2.ps1
@@ -54,25 +54,28 @@ function Push-AuditLogDownloadV2 {
 
             if ($Status -eq 'succeeded') {
                 try {
-                    $Results = @(Get-CippAuditLogSearchResults -TenantFilter $TenantFilter -QueryId $SearchId)
-                    foreach ($SearchResult in $Results) {
+                    # Streamed, not collected: each record is written to CacheWebhooks and
+                    # dropped, so the window never needs to be resident.
+                    $WindowCount = 0
+                    Get-CippAuditLogSearchResults -TenantFilter $TenantFilter -QueryId $SearchId | ForEach-Object {
                         Add-CIPPAzDataTableEntity @CacheTable -Entity @{
-                            RowKey                = [string]$SearchResult.id
+                            RowKey                = [string]$_.id
                             PartitionKey          = [string]$TenantFilter
                             SearchId              = $SearchId
-                            JSON                  = [string]($SearchResult | ConvertTo-Json -Depth 10 -Compress)
+                            JSON                  = [string]($_ | ConvertTo-Json -Depth 10 -Compress)
                             CippProcessing        = $false
                             CippProcessingStarted = ''
                         } -Force
+                        $WindowCount++
                     }
-                    $Downloaded += $Results.Count
+                    $Downloaded += $WindowCount
                     # Empty windows have nothing to process - mark them Processed directly so they
                     # don't sit at Downloaded forever. Windows with records go to Downloaded and are
                     # advanced to Processed by Push-AuditLogTenantProcessV2 once their rows are drained.
-                    $DownloadState = if ($Results.Count -eq 0) { 'Processed' } else { 'Downloaded' }
+                    $DownloadState = if ($WindowCount -eq 0) { 'Processed' } else { 'Downloaded' }
                     $LedgerUpdate = @{
                         PartitionKey = $TenantFilter; RowKey = $Row.RowKey; State = $DownloadState
-                        RecordCount  = [int]$Results.Count; DownloadedUtc = $Now; Attempts = 0
+                        RecordCount  = [int]$WindowCount; DownloadedUtc = $Now; Attempts = 0
                         SearchStatus = 'succeeded'; LastPolledUtc = $Now
                     }
                     if ($DownloadState -eq 'Processed') {
@@ -80,7 +83,7 @@ function Push-AuditLogDownloadV2 {
                         $LedgerUpdate.MatchedCount = 0
                     }
                     Add-CIPPAzDataTableEntity @Ledger -Entity $LedgerUpdate -OperationType UpsertMerge
-                    Write-Information "AuditLogV2: downloaded $($Results.Count) record(s) for $TenantFilter window $($Row.RowKey)"
+                    Write-Information "AuditLogV2: downloaded $WindowCount record(s) for $TenantFilter window $($Row.RowKey)"
                 } catch {
                     $Attempts = [int]$Row.Attempts + 1
                     $RetryTotal = [int]$Row.RetryCount + 1

--- a/backend/Modules/CIPPCore/Public/Webhooks/Push-AuditLogTenantProcessV2.ps1
+++ b/backend/Modules/CIPPCore/Public/Webhooks/Push-AuditLogTenantProcessV2.ps1
@@ -25,22 +25,69 @@ function Push-AuditLogTenantProcessV2 {
         $CacheWebhooksTable = Get-CippTable -TableName 'CacheWebhooks'
         $SearchIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 
-        $Rows = foreach ($RowId in $RowIds) {
-            $CacheEntity = Get-CIPPAzDataTableEntity @CacheWebhooksTable -Filter "PartitionKey eq '$TenantFilter' and RowKey eq '$RowId'"
-            if ($CacheEntity) {
-                if ($CacheEntity.SearchId) { [void]$SearchIds.Add([string]$CacheEntity.SearchId) }
-                $CacheEntity.JSON | ConvertFrom-Json -ErrorAction SilentlyContinue
+        # Chunked so peak memory tracks $ChunkSize, not batch size. Don't raise much above
+        # 100: each chunk builds one `RowKey eq '<guid>'` predicate per row, and an over-long
+        # filter is rejected (Azure ~520 predicates, Azurite ~250) and swallowed by the catch.
+        $ChunkSize = 100
+        $ProcessedCount = 0
+        $MatchedLogs = 0
+
+        for ($Offset = 0; $Offset -lt $RowIds.Count; $Offset += $ChunkSize) {
+            $Slice = @($RowIds[$Offset..([Math]::Min($Offset + $ChunkSize - 1, $RowIds.Count - 1))])
+
+            # Raw cmdlet: the wrapper merges split parts and reports the logical RowKey.
+            $KeyFilter = "PartitionKey eq '$TenantFilter' and (" +
+                         (($Slice | ForEach-Object { "RowKey eq '$_'" }) -join ' or ') + ')'
+            $Keys = @(Get-AzDataTableEntity @CacheWebhooksTable -Filter $KeyFilter `
+                    -Property 'PartitionKey', 'RowKey', 'OriginalEntityId')
+            if ($Keys.Count -eq 0) { continue }
+
+            # Split records span X / X-part1 / X-part2 and only reassemble when every part
+            # arrives in one call, so select on OriginalEntityId rather than RowKey.
+            $Predicates = [System.Collections.Generic.List[string]]::new()
+            $SeenLogical = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($Key in $Keys) {
+                if ($Key.PSObject.Properties.Name -contains 'OriginalEntityId' -and $Key.OriginalEntityId) {
+                    if ($SeenLogical.Add([string]$Key.OriginalEntityId)) {
+                        $Predicates.Add("OriginalEntityId eq '$($Key.OriginalEntityId)'")
+                    }
+                } else {
+                    $Predicates.Add("RowKey eq '$($Key.RowKey)'")
+                }
             }
+            if ($Predicates.Count -eq 0) { continue }
+
+            # No -Property: a projection must list every JSON_Part* column or split rows
+            # come back empty.
+            $RowFilter = "PartitionKey eq '$TenantFilter' and (" + ($Predicates -join ' or ') + ')'
+            $Entities = @(Get-CIPPAzDataTableEntity @CacheWebhooksTable -Filter $RowFilter)
+
+            $Chunk = [System.Collections.Generic.List[object]]::new()
+            foreach ($Entity in $Entities) {
+                if ($Entity.SearchId) { [void]$SearchIds.Add([string]$Entity.SearchId) }
+                $Parsed = $Entity.JSON | ConvertFrom-Json -ErrorAction SilentlyContinue
+                if ($null -eq $Parsed) {
+                    Write-Information "AuditLogV2: unparseable cached JSON for RowKey $($Entity.RowKey) ($TenantFilter)"
+                    continue
+                }
+                $Chunk.Add($Parsed)
+            }
+
+            if ($Chunk.Count -gt 0) {
+                $Result = Test-CIPPAuditLogRules -TenantFilter $TenantFilter -Rows $Chunk
+                $MatchedLogs += [int]($Result.MatchedLogs ?? 0)
+                $ProcessedCount += $Chunk.Count
+            }
+            $Chunk.Clear()
+            $Entities = $null
         }
 
-        if ($Rows.Count -eq 0) {
+        if ($ProcessedCount -eq 0) {
             Write-Information "AuditLogV2: no rows found in cache for the provided row IDs ($TenantFilter)"
             return $false
         }
 
-        Write-Information "AuditLogV2: processing $($Rows.Count) row(s) for $TenantFilter"
-        $Result = Test-CIPPAuditLogRules -TenantFilter $TenantFilter -Rows $Rows
-        $MatchedLogs = [int]($Result.MatchedLogs ?? 0)
+        Write-Information "AuditLogV2: processed $ProcessedCount row(s) for $TenantFilter"
 
         # Advance the ledger to Processed for any SearchId now fully drained from the cache.
         if ($SearchIds.Count -gt 0) {

--- a/backend/Modules/CIPPCore/Public/Webhooks/Test-CIPPAuditLogRules.ps1
+++ b/backend/Modules/CIPPCore/Public/Webhooks/Test-CIPPAuditLogRules.ps1
@@ -455,6 +455,14 @@ function Test-CIPPAuditLogRules {
                 }
             }
 
+            # Deletes are flushed in small batches, not per record. The point is forward
+            # progress on a poison batch - a crash re-runs at most $DeleteFlushSize records,
+            # so the run always converges instead of looping on the same rows - and a batch
+            # takes minutes, so that window is real. Per-record calls cost ~13x more, since
+            # AzBobbyTables wraps each one in its own $batch transaction.
+            $DeleteFlushSize = 25
+            $PendingDeletes = [System.Collections.Generic.List[object]]::new()
+
             $ProcessedData = foreach ($AuditRecord in $SearchResults) {
                 $RecordStartTime = Get-Date
                 Write-Information "Processing RowKey $($AuditRecord.id) - $($TenantFilter)."
@@ -560,17 +568,30 @@ function Test-CIPPAuditLogRules {
                     Write-LogMessage -API 'Webhooks' -message 'Error Processing Audit Log Data' -LogData (Get-CippException -Exception $_) -sev Error -tenant $TenantFilter
                 }
 
-                try {
-                    $null = Remove-AzDataTableEntity -Force @CacheWebhooksTable -Entity ([pscustomobject]@{
-                            PartitionKey = $TenantFilter
-                            RowKey       = [string]$AuditRecord.id
-                        })
-                } catch {
-                    Write-Information "Error removing row $($AuditRecord.id) from cache: $($_.Exception.Message)"
+                $PendingDeletes.Add([PSCustomObject]@{
+                        PartitionKey = $TenantFilter
+                        RowKey       = [string]$AuditRecord.id
+                    })
+                if ($PendingDeletes.Count -ge $DeleteFlushSize) {
+                    try {
+                        $null = Remove-AzDataTableEntity -Force @CacheWebhooksTable -Entity $PendingDeletes.ToArray()
+                    } catch {
+                        Write-Information "Error removing $($PendingDeletes.Count) processed row(s) from cache: $($_.Exception.Message)"
+                    }
+                    $PendingDeletes.Clear()
                 }
                 $RecordEndTime = Get-Date
                 $RecordSeconds = ($RecordEndTime - $RecordStartTime).TotalSeconds
                 Write-Warning "Task took $RecordSeconds seconds for RowKey $($AuditRecord.id)"
+            }
+
+            if ($PendingDeletes.Count -gt 0) {
+                try {
+                    $null = Remove-AzDataTableEntity -Force @CacheWebhooksTable -Entity $PendingDeletes.ToArray()
+                } catch {
+                    Write-Information "Error removing $($PendingDeletes.Count) processed row(s) from cache: $($_.Exception.Message)"
+                }
+                $PendingDeletes.Clear()
             }
             #write-warning "Processed Data: $(($ProcessedData | Measure-Object).Count) - This should be higher than 0 in many cases, because the where object has not run yet."
             #write-warning "Creating filters - $(($ProcessedData.operation | Sort-Object -Unique) -join ',') - $($TenantFilter)"

--- a/backend/Modules/CIPPCore/Public/Webhooks/Test-CIPPAuditLogRules.ps1
+++ b/backend/Modules/CIPPCore/Public/Webhooks/Test-CIPPAuditLogRules.ps1
@@ -469,35 +469,50 @@ function Test-CIPPAuditLogRules {
                     # Write-Information 'Checking RootProperties for GUIDs to map to users, groups, devices, or service principals'
                     Add-CIPPGuidMappings -DataObject $RootProperties -UserLookup $UserLookup -GroupLookup $GroupLookup -DeviceLookup $DeviceLookup -ServicePrincipalLookup $ServicePrincipalLookup -PartnerUserLookup $PartnerUserLookup
 
+                    # Flattened onto $Data so rules can match the property names directly. One
+                    # Add-Member per sub-object: per-property calls rebuild the property bag each time.
                     if ($Data.ExtendedProperties) {
                         $Data.CIPPExtendedProperties = ($Data.ExtendedProperties | ConvertTo-Json -Compress -Depth 10)
-                        $Data.ExtendedProperties | ForEach-Object {
-                            if ($_.Value -in $ExtendedPropertiesIgnoreList) {
-                                #write-warning "No need to process this operation as its in our ignore list. Some extended information: $($data.operation):$($_.Value) - $($TenantFilter)"
-                                continue
-                            }
-                            $Data | Add-Member -NotePropertyName $_.Name -NotePropertyValue $_.Value -Force -ErrorAction SilentlyContinue
+                        $Flattened = @{}
+                        foreach ($Prop in $Data.ExtendedProperties) {
+                            # Must be a real loop: `continue` inside ForEach-Object unwinds to the
+                            # enclosing foreach and drops the whole record.
+                            if ($Prop.Value -in $ExtendedPropertiesIgnoreList) { continue }
+                            if ([string]::IsNullOrEmpty($Prop.Name)) { continue }
+                            $Flattened[$Prop.Name] = $Prop.Value
                         }
+                        if ($Flattened.Count -gt 0) { $Data | Add-Member -NotePropertyMembers $Flattened -Force -ErrorAction SilentlyContinue }
                     }
                     if ($Data.DeviceProperties) {
                         $Data.CIPPDeviceProperties = ($Data.DeviceProperties | ConvertTo-Json -Compress -Depth 10)
-                        $Data.DeviceProperties | ForEach-Object { $Data | Add-Member -NotePropertyName $_.Name -NotePropertyValue $_.Value -Force -ErrorAction SilentlyContinue }
+                        $Flattened = @{}
+                        foreach ($Prop in $Data.DeviceProperties) {
+                            if ([string]::IsNullOrEmpty($Prop.Name)) { continue }
+                            $Flattened[$Prop.Name] = $Prop.Value
+                        }
+                        if ($Flattened.Count -gt 0) { $Data | Add-Member -NotePropertyMembers $Flattened -Force -ErrorAction SilentlyContinue }
                     }
                     if ($Data.parameters) {
                         $Data.CIPPParameters = ($Data.parameters | ConvertTo-Json -Compress -Depth 10)
-                        $Data.parameters | ForEach-Object { $Data | Add-Member -NotePropertyName $_.Name -NotePropertyValue $_.Value -Force -ErrorAction SilentlyContinue }
+                        $Flattened = @{}
+                        foreach ($Prop in $Data.parameters) {
+                            if ([string]::IsNullOrEmpty($Prop.Name)) { continue }
+                            $Flattened[$Prop.Name] = $Prop.Value
+                        }
+                        if ($Flattened.Count -gt 0) { $Data | Add-Member -NotePropertyMembers $Flattened -Force -ErrorAction SilentlyContinue }
                     }
                     if ($Data.ModifiedProperties) {
                         $Data.CIPPModifiedProperties = ($Data.ModifiedProperties | ConvertTo-Json -Compress -Depth 10)
                         try {
-                            $Data.ModifiedProperties | ForEach-Object { $Data | Add-Member -NotePropertyName "$($_.Name)" -NotePropertyValue "$($_.NewValue)" -Force -ErrorAction SilentlyContinue }
+                            $Flattened = @{}
+                            foreach ($Prop in $Data.ModifiedProperties) {
+                                if ([string]::IsNullOrEmpty($Prop.Name)) { continue }
+                                $Flattened["$($Prop.Name)"] = "$($Prop.NewValue)"
+                                $Flattened["Previous_Value_$($Prop.Name)"] = "$($Prop.OldValue)"
+                            }
+                            if ($Flattened.Count -gt 0) { $Data | Add-Member -NotePropertyMembers $Flattened -Force -ErrorAction SilentlyContinue }
                         } catch {
-                            ##write-warning ($Data.ModifiedProperties | ConvertTo-Json -Depth 10)
-                        }
-                        try {
-                            $Data.ModifiedProperties | ForEach-Object { $Data | Add-Member -NotePropertyName $("Previous_Value_$($_.Name)") -NotePropertyValue "$($_.OldValue)" -Force -ErrorAction SilentlyContinue }
-                        } catch {
-                            ##write-warning ($Data.ModifiedProperties | ConvertTo-Json -Depth 10)
+                            Write-Information "Error flattening ModifiedProperties for $($AuditRecord.id): $($_.Exception.Message)"
                         }
                     }
 
@@ -690,8 +705,24 @@ function Test-CIPPAuditLogRules {
         try {
             $RowIds = [System.Collections.Generic.HashSet[string]]::new([string[]]@($Rows.id | Where-Object { $_ }))
             if ($RowIds.Count -gt 0) {
-                $CachedRows = Get-CIPPAzDataTableEntity @CacheWebhooksTable -Filter "PartitionKey eq '$TenantFilter'"
-                $RowsToRemove = @($CachedRows | Where-Object { $RowIds.Contains([string]$_.RowKey) })
+                # Only the rows being deleted, not a partition scan - this runs once per chunk.
+                # Raw cmdlet and OriginalEntityId: the wrapper reports a split record's logical
+                # RowKey, so deleting that left X-part1 / X-part2 orphaned.
+                $IdList = @($RowIds)
+                $FilterBatch = 50
+                $RowsToRemove = [System.Collections.Generic.List[object]]::new()
+
+                for ($Start = 0; $Start -lt $IdList.Count; $Start += $FilterBatch) {
+                    $Slice = @($IdList[$Start..([Math]::Min($Start + $FilterBatch - 1, $IdList.Count - 1))])
+                    $Predicate = ($Slice | ForEach-Object { "RowKey eq '$_' or OriginalEntityId eq '$_'" }) -join ' or '
+                    $Found = @(Get-AzDataTableEntity @CacheWebhooksTable `
+                            -Filter "PartitionKey eq '$TenantFilter' and ($Predicate)" `
+                            -Property 'PartitionKey', 'RowKey')
+                    foreach ($Row in $Found) {
+                        $RowsToRemove.Add([PSCustomObject]@{ PartitionKey = $Row.PartitionKey; RowKey = $Row.RowKey })
+                    }
+                }
+
                 if ($RowsToRemove.Count -gt 0) {
                     Remove-AzDataTableEntity @CacheWebhooksTable -Entity $RowsToRemove -Force
                     Write-Information "Removed $($RowsToRemove.Count) processed rows from cache"

--- a/backend/Tests/Webhooks/Get-CippAuditLogSearchResults.Tests.ps1
+++ b/backend/Tests/Webhooks/Get-CippAuditLogSearchResults.Tests.ps1
@@ -1,0 +1,81 @@
+# Pester tests for Get-CippAuditLogSearchResults.
+#
+# Covers the request shape and that every record comes back. Order is explicitly not part
+# of the contract - see the last test.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/AuditLogs/Get-CippAuditLogSearchResults.ps1'
+
+    function New-GraphGetRequest {
+        param($Uri, $tenantid, $AsApp, $CountOnly, [switch]$Stream, $ComplexFilter, $NoPagination)
+    }
+
+    . $FunctionPath
+}
+
+Describe 'Get-CippAuditLogSearchResults' {
+
+    BeforeEach {
+        $script:CapturedUri = $null
+        $script:CapturedTenant = $null
+        $script:CapturedAsApp = $null
+        $script:CapturedCountOnly = $null
+
+        Mock -CommandName New-GraphGetRequest -MockWith {
+            param($Uri, $tenantid, $AsApp, $CountOnly, [switch]$Stream, $ComplexFilter, $NoPagination)
+            $script:CapturedUri = $Uri
+            $script:CapturedTenant = $tenantid
+            $script:CapturedAsApp = $AsApp
+            $script:CapturedCountOnly = $CountOnly
+
+            # deliberately unsorted so ordering assumptions surface
+            @(
+                [pscustomobject]@{ id = 'b'; createdDateTime = '2026-07-29T10:00:00Z' }
+                [pscustomobject]@{ id = 'a'; createdDateTime = '2026-07-29T12:00:00Z' }
+                [pscustomobject]@{ id = 'c'; createdDateTime = '2026-07-29T11:00:00Z' }
+            )
+        }
+    }
+
+    It 'targets the records endpoint for the given query id' {
+        $null = Get-CippAuditLogSearchResults -TenantFilter 'contoso.com' -QueryId 'query-123'
+        $script:CapturedUri | Should -Match 'security/auditLog/queries/query-123/records'
+    }
+
+    It 'requests the maximum page size and a count' {
+        $null = Get-CippAuditLogSearchResults -TenantFilter 'contoso.com' -QueryId 'query-123'
+        $script:CapturedUri | Should -Match '\$top=999'
+        $script:CapturedUri | Should -Match '\$count=true'
+    }
+
+    It 'runs as the application against the requested tenant' {
+        $null = Get-CippAuditLogSearchResults -TenantFilter 'contoso.com' -QueryId 'query-123'
+        $script:CapturedTenant | Should -Be 'contoso.com'
+        $script:CapturedAsApp | Should -BeTrue
+    }
+
+    It 'returns every record from graph' {
+        $result = @(Get-CippAuditLogSearchResults -TenantFilter 'contoso.com' -QueryId 'query-123')
+        $result.Count | Should -Be 3
+        ($result.id | Sort-Object) | Should -Be @('a', 'b', 'c')
+    }
+
+    It 'accepts the query id from the pipeline by property name' {
+        $result = @([pscustomobject]@{ id = 'query-123' } | Get-CippAuditLogSearchResults -TenantFilter 'contoso.com')
+        $result.Count | Should -Be 3
+        $script:CapturedUri | Should -Match 'query-123'
+    }
+
+    It 'passes CountOnly through when requested' {
+        $null = Get-CippAuditLogSearchResults -TenantFilter 'contoso.com' -QueryId 'query-123' -CountOnly
+        $script:CapturedCountOnly | Should -BeTrue
+    }
+
+    It 'does not promise any particular record order' {
+        # Documented deliberately: the caller keys each record by id, so sorting here would
+        # mean holding the whole result set in memory for no downstream benefit.
+        $result = @(Get-CippAuditLogSearchResults -TenantFilter 'contoso.com' -QueryId 'query-123')
+        ($result | Measure-Object).Count | Should -Be 3
+    }
+}

--- a/backend/Tests/Webhooks/Push-AuditLogDownloadV2.Tests.ps1
+++ b/backend/Tests/Webhooks/Push-AuditLogDownloadV2.Tests.ps1
@@ -1,0 +1,204 @@
+# Pester tests for Push-AuditLogDownloadV2 - the audit log V2 download stage.
+#
+# Pins the ledger state machine and the CacheWebhooks writes. Record order is deliberately
+# not asserted; nothing downstream depends on it.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Webhooks/Push-AuditLogDownloadV2.ps1'
+
+    function Get-CippTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Context, $Filter, $Property, $First, $Skip, $Sort, $Count) }
+    # -Force must be [switch]: as a plain parameter the caller's trailing -Force binds no
+    # argument, and the resulting error is swallowed by the function's own catch.
+    function Add-CIPPAzDataTableEntity { param($TableName, $Context, $Entity, [switch]$Force, $OperationType) }
+    function New-GraphBulkRequest { param($Requests, $AsApp, $TenantId) }
+    function Get-CippAuditLogSearchResults { param($TenantFilter, $QueryId, [switch]$CountOnly) }
+    function Get-CippAuditLogNextAttempt { param($Attempts) }
+
+    function New-AuditRecord {
+        param([string]$Id, [string]$Created = '2026-07-29T09:00:00Z')
+        [pscustomobject]@{
+            id              = $Id
+            createdDateTime = $Created
+            operation       = 'Set-Mailbox'
+            auditData       = [pscustomobject]@{ ResultStatus = 'Success' }
+        }
+    }
+
+    . $FunctionPath
+}
+
+Describe 'Push-AuditLogDownloadV2' {
+
+    BeforeEach {
+        $script:CacheWrites = [System.Collections.Generic.List[object]]::new()
+        $script:LedgerWrites = [System.Collections.Generic.List[object]]::new()
+        $script:SearchResults = @()
+        $script:SearchStatus = 'succeeded'
+        $script:ThrowOnDownload = $false
+
+        Mock -CommandName Get-CippTable -MockWith {
+            param($TableName)
+            @{ TableName = $TableName }
+        }
+
+        # one ledger row in state Created, due now
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @(
+                [pscustomobject]@{
+                    PartitionKey = 'contoso.com'
+                    RowKey       = 'window-1'
+                    State        = 'Created'
+                    SearchId     = 'search-1'
+                    CreatedUtc   = (Get-Date).ToUniversalTime().AddMinutes(-5).ToString('o')
+                    Attempts     = 0
+                    RetryCount   = 0
+                }
+            )
+        }
+
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith {
+            param($TableName, $Context, $Entity, $Force, $OperationType)
+            if ($TableName -eq 'CacheWebhooks') { $script:CacheWrites.Add($Entity) }
+            else { $script:LedgerWrites.Add($Entity) }
+        }
+
+        Mock -CommandName New-GraphBulkRequest -MockWith {
+            @([pscustomobject]@{ body = [pscustomobject]@{ id = 'search-1'; status = $script:SearchStatus } })
+        }
+
+        Mock -CommandName Get-CippAuditLogSearchResults -MockWith {
+            if ($script:ThrowOnDownload) { throw 'graph exploded' }
+            $script:SearchResults
+        }
+
+        Mock -CommandName Get-CippAuditLogNextAttempt -MockWith { (Get-Date).ToUniversalTime().AddMinutes(10).ToString('o') }
+    }
+
+    Context 'succeeded search with records' {
+        BeforeEach {
+            $script:SearchResults = @(New-AuditRecord 'rec-1'), (New-AuditRecord 'rec-2'), (New-AuditRecord 'rec-3')
+        }
+
+        It 'writes one CacheWebhooks row per record' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $script:CacheWrites.Count | Should -Be 3
+        }
+
+        It 'keys each cache row by the record id and stores the record as JSON' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            ($script:CacheWrites.RowKey | Sort-Object) | Should -Be @('rec-1', 'rec-2', 'rec-3')
+            $first = $script:CacheWrites | Where-Object { $_.RowKey -eq 'rec-1' }
+            $first.PartitionKey | Should -Be 'contoso.com'
+            $first.SearchId | Should -Be 'search-1'
+            ($first.JSON | ConvertFrom-Json).id | Should -Be 'rec-1'
+            $first.CippProcessing | Should -BeFalse
+        }
+
+        It 'advances the ledger to Downloaded with the record count' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $ledger = $script:LedgerWrites | Where-Object { $_.RowKey -eq 'window-1' } | Select-Object -Last 1
+            $ledger.State | Should -Be 'Downloaded'
+            $ledger.RecordCount | Should -Be 3
+            $ledger.Attempts | Should -Be 0
+        }
+
+        It 'reports the downloaded count in its result' {
+            $result = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $result.Success | Should -BeTrue
+            $result.Downloaded | Should -Be 3
+        }
+    }
+
+    Context 'succeeded search with no records' {
+        BeforeEach { $script:SearchResults = @() }
+
+        It 'marks an empty window Processed rather than leaving it Downloaded' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $ledger = $script:LedgerWrites | Where-Object { $_.RowKey -eq 'window-1' } | Select-Object -Last 1
+            $ledger.State | Should -Be 'Processed'
+            $ledger.RecordCount | Should -Be 0
+            $ledger.MatchedCount | Should -Be 0
+        }
+
+        It 'writes no cache rows' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $script:CacheWrites.Count | Should -Be 0
+        }
+    }
+
+    Context 'single record' {
+        # Guards the PowerShell unrolling trap: one item must still count as a collection.
+        BeforeEach { $script:SearchResults = @(New-AuditRecord 'only-1') }
+
+        It 'writes exactly one cache row and counts it as one' {
+            $result = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $script:CacheWrites.Count | Should -Be 1
+            $result.Downloaded | Should -Be 1
+            $ledger = $script:LedgerWrites | Where-Object { $_.RowKey -eq 'window-1' } | Select-Object -Last 1
+            $ledger.State | Should -Be 'Downloaded'
+            $ledger.RecordCount | Should -Be 1
+        }
+    }
+
+    Context 'download throws' {
+        BeforeEach { $script:ThrowOnDownload = $true }
+
+        It 'increments Attempts and schedules a retry without dead-lettering' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $ledger = $script:LedgerWrites | Where-Object { $_.RowKey -eq 'window-1' } | Select-Object -Last 1
+            $ledger.Attempts | Should -Be 1
+            $ledger.State | Should -BeNullOrEmpty
+            $ledger.NextAttemptUtc | Should -Not -BeNullOrEmpty
+            $ledger.LastError | Should -Match 'graph exploded'
+        }
+
+        It 'still reports success for the activity as a whole' {
+            $result = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $result.Success | Should -BeTrue
+            $result.Downloaded | Should -Be 0
+        }
+    }
+
+    Context 'graph reports the search failed' {
+        BeforeEach { $script:SearchStatus = 'failed' }
+
+        It 're-plans the window and clears the search id' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $ledger = $script:LedgerWrites | Where-Object { $_.RowKey -eq 'window-1' } | Select-Object -Last 1
+            $ledger.State | Should -Be 'Planned'
+            $ledger.SearchId | Should -Be ''
+            $ledger.Attempts | Should -Be 1
+        }
+    }
+
+    Context 'search still running' {
+        BeforeEach { $script:SearchStatus = 'running' }
+
+        It 'leaves the window Created and records the live status' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $ledger = $script:LedgerWrites | Where-Object { $_.RowKey -eq 'window-1' } | Select-Object -Last 1
+            $ledger.State | Should -BeNullOrEmpty
+            $ledger.SearchStatus | Should -Be 'running'
+        }
+
+        It 'writes no cache rows' {
+            $null = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $script:CacheWrites.Count | Should -Be 0
+        }
+    }
+
+    Context 'no due ledger rows' {
+        BeforeEach {
+            Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { @() }
+        }
+
+        It 'returns early without polling graph' {
+            $result = Push-AuditLogDownloadV2 -Item @{ TenantFilter = 'contoso.com' }
+            $result.Success | Should -BeTrue
+            $result.Downloaded | Should -Be 0
+            Should -Invoke New-GraphBulkRequest -Times 0
+        }
+    }
+}

--- a/backend/Tests/Webhooks/Push-AuditLogTenantProcessV2.Tests.ps1
+++ b/backend/Tests/Webhooks/Push-AuditLogTenantProcessV2.Tests.ps1
@@ -1,0 +1,233 @@
+# Pester tests for Push-AuditLogTenantProcessV2 - the audit log V2 processing stage.
+#
+# Pins the ledger transitions and the rows handed to the rules engine. The cases that
+# matter are split records, stored across rows X / X-part1 / X-part2 and only reassembled
+# when every part is fetched in one call.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Webhooks/Push-AuditLogTenantProcessV2.ps1'
+
+    function Get-CippTable { param($TableName) }
+    function Get-AzDataTableEntity { param($Context, $Filter, $Property, $First) }
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter, $Property, $First) }
+    function Add-CIPPAzDataTableEntity { param($Context, $Entity, [switch]$Force, $OperationType) }
+    function Test-CIPPAuditLogRules { param($TenantFilter, $Rows) }
+
+    function Get-WantedFromFilter {
+        param([string]$Filter)
+        $ids = [regex]::Matches($Filter, "RowKey eq '([^']*)'") | ForEach-Object { $_.Groups[1].Value }
+        if ($ids) { @($ids) } else { $null }
+    }
+
+    . $FunctionPath
+}
+
+Describe 'Push-AuditLogTenantProcessV2' {
+
+    BeforeEach {
+        $script:RulesRows = $null
+        # AllRulesRows accumulates across chunks; RulesRows holds only the last chunk.
+        $script:AllRulesRows = [System.Collections.Generic.List[object]]::new()
+        $script:SeenFilters = [System.Collections.Generic.List[string]]::new()
+        $script:LedgerWrites = [System.Collections.Generic.List[object]]::new()
+        $script:MatchedLogs = 2
+
+        # Physical rows; split records carry OriginalEntityId on every part.
+        $script:CacheRows = @(
+            [PSCustomObject]@{ RowKey = 'rec-1'; OriginalEntityId = $null; SearchId = 'search-1'; JSON = '{"id":"rec-1"}' }
+            [PSCustomObject]@{ RowKey = 'rec-2'; OriginalEntityId = $null; SearchId = 'search-1'; JSON = '{"id":"rec-2"}' }
+        )
+        $script:LedgerRows = @(
+            [PSCustomObject]@{ PartitionKey = 'contoso.com'; RowKey = 'window-1'; SearchId = 'search-1'; State = 'Downloaded' }
+        )
+        $script:RemainingAfterProcess = @()
+        $script:DownloadedSweepRows = @()
+
+        # Real Get-CippTable returns only @{ Context = ... }; mirror that so splatting @Table
+        # behaves as it does in production.
+        Mock -CommandName Get-CippTable -MockWith { param($TableName) @{ Context = "ctx:$TableName" } }
+
+        Mock -CommandName Get-AzDataTableEntity -MockWith {
+            param($Context, $Filter, $Property, $First)
+            $script:SeenFilters.Add([string]$Filter)
+            $rows = $script:CacheRows
+            if ($Filter -match "RowKey gt '([^']*)'") { $rows = @($rows | Where-Object { $_.RowKey -gt $Matches[1] }) }
+            $wanted = Get-WantedFromFilter -Filter $Filter
+            if ($wanted) { $rows = @($rows | Where-Object { $wanted -contains $_.RowKey }) }
+            $rows = @($rows | Sort-Object RowKey)
+            if ($First) { $rows = @($rows | Select-Object -First $First) }
+            $rows | ForEach-Object {
+                [PSCustomObject]@{ PartitionKey = 'contoso.com'; RowKey = $_.RowKey; OriginalEntityId = $_.OriginalEntityId }
+            }
+        }
+
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            param($Context, $Filter, $Property, $First)
+            if ($Context -like '*AuditLogCoverage*') {
+                if ($Filter -match "State eq 'Downloaded'") { return $script:DownloadedSweepRows }
+                return $script:LedgerRows
+            }
+            # CacheWebhooks. A SearchId query is the "is this search drained yet" probe.
+            if ($Filter -match "SearchId eq") { return $script:RemainingAfterProcess }
+
+            # Selected by RowKey (simple records) or OriginalEntityId (every part of a split
+            # record, regardless of which parts this batch claimed).
+            $wantedRow = Get-WantedFromFilter -Filter $Filter
+            $wantedOrig = @([regex]::Matches($Filter, "OriginalEntityId eq '([^']*)'") | ForEach-Object { $_.Groups[1].Value })
+            $rows = if ($wantedRow -or $wantedOrig) {
+                @($script:CacheRows | Where-Object {
+                        ($wantedRow -contains $_.RowKey) -or
+                        ($_.OriginalEntityId -and $wantedOrig -contains $_.OriginalEntityId)
+                    })
+            } else {
+                @($script:CacheRows)
+            }
+            # rejoin parts sharing a logical id, exactly like the real wrapper
+            $rows | Group-Object { if ($_.OriginalEntityId) { $_.OriginalEntityId } else { $_.RowKey } } | ForEach-Object {
+                $ordered = @($_.Group | Sort-Object RowKey)
+                [PSCustomObject]@{
+                    PartitionKey = 'contoso.com'
+                    RowKey       = $_.Name
+                    SearchId     = $ordered[0].SearchId
+                    JSON         = ($ordered.JSON -join '')
+                }
+            }
+        }
+
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith {
+            param($Context, $Entity, [switch]$Force, $OperationType)
+            $script:LedgerWrites.Add($Entity)
+        }
+
+        Mock -CommandName Test-CIPPAuditLogRules -MockWith {
+            param($TenantFilter, $Rows)
+            $script:RulesRows = @($Rows)
+            foreach ($r in @($Rows)) { $script:AllRulesRows.Add($r) }
+            [PSCustomObject]@{ MatchedLogs = $script:MatchedLogs }
+        }
+    }
+
+    Context 'simple single-row records' {
+
+        It 'passes every cached record to the rules engine' {
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1', 'rec-2') }
+            @($script:RulesRows).Count | Should -Be 2
+            ($script:RulesRows.id | Sort-Object) | Should -Be @('rec-1', 'rec-2')
+        }
+
+        It 'deserialises the cached JSON before handing it over' {
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1') }
+            @($script:RulesRows)[0].id | Should -Be 'rec-1'
+        }
+
+        It 'returns true on success' {
+            Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1', 'rec-2') } | Should -BeTrue
+        }
+
+        It 'marks the ledger window Processed once the search is drained' {
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1', 'rec-2') }
+            $processed = $script:LedgerWrites | Where-Object { $_.State -eq 'Processed' -and $_.RowKey -eq 'window-1' }
+            $processed | Should -Not -BeNullOrEmpty
+            $processed.MatchedCount | Should -Be 2
+        }
+
+        It 'leaves the window alone while cache rows for the search remain' {
+            $script:RemainingAfterProcess = @([PSCustomObject]@{ PartitionKey = 'contoso.com'; RowKey = 'rec-9' })
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1') }
+            ($script:LedgerWrites | Where-Object { $_.RowKey -eq 'window-1' }) | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'no rows found for the batch' {
+        BeforeEach { $script:CacheRows = @() }
+
+        It 'returns false without invoking the rules engine' {
+            Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('gone-1') } | Should -BeFalse
+            Should -Invoke Test-CIPPAuditLogRules -Times 0
+        }
+    }
+
+    Context 'a record split across multiple rows' {
+        BeforeEach {
+            # One logical record stored across three physical rows.
+            $script:CacheRows = @(
+                [PSCustomObject]@{ RowKey = 'rec-1'; OriginalEntityId = $null; SearchId = 'search-1'; JSON = '{"id":"rec-1"}' }
+                [PSCustomObject]@{ RowKey = 'big'; OriginalEntityId = 'big'; SearchId = 'search-1'; JSON = '{"id":"big","pad":"AAA' }
+                [PSCustomObject]@{ RowKey = 'big-part1'; OriginalEntityId = 'big'; SearchId = 'search-1'; JSON = 'BBB' }
+                [PSCustomObject]@{ RowKey = 'big-part2'; OriginalEntityId = 'big'; SearchId = 'search-1'; JSON = 'CCC"}' }
+            )
+        }
+
+        It 'reassembles the split record into valid JSON' {
+            # Fetching one RowKey at a time leaves the reassembler with a fragment.
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1', 'big', 'big-part1', 'big-part2') }
+            $big = @($script:RulesRows) | Where-Object { $_.id -eq 'big' }
+            $big | Should -Not -BeNullOrEmpty
+            $big.pad | Should -Be 'AAABBBCCC'
+        }
+
+        It 'yields the split record exactly once, not once per physical row' {
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1', 'big', 'big-part1', 'big-part2') }
+            @($script:RulesRows).Count | Should -Be 2
+            @($script:RulesRows | Where-Object { $_.id -eq 'big' }).Count | Should -Be 1
+        }
+    }
+
+    Context 'a batch larger than one chunk' {
+        BeforeEach {
+            # 250 rows against a chunk size of 100 forces three passes. Smaller fixtures only
+            # execute the loop body once, hiding any off-by-one in the slice arithmetic.
+            $script:CacheRows = @(
+                1..250 | ForEach-Object {
+                    [PSCustomObject]@{
+                        RowKey           = ('rec-{0:D3}' -f $_)
+                        OriginalEntityId = $null
+                        SearchId         = 'search-1'
+                        JSON             = ('{{"id":"rec-{0:D3}"}}' -f $_)
+                    }
+                }
+            )
+        }
+
+        It 'processes every row across all chunks exactly once' {
+            $ids = @(1..250 | ForEach-Object { 'rec-{0:D3}' -f $_ })
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = $ids }
+            @($script:AllRulesRows).Count | Should -Be 250
+            (@($script:AllRulesRows).id | Sort-Object -Unique).Count | Should -Be 250
+        }
+
+        It 'invokes the rules engine once per chunk, not once per batch' {
+            $ids = @(1..250 | ForEach-Object { 'rec-{0:D3}' -f $_ })
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = $ids }
+            # 250 / 100 = 3 calls. This is what bounds peak memory - the whole batch is
+            # never resident at once.
+            Should -Invoke Test-CIPPAuditLogRules -Times 3 -Exactly
+        }
+
+        It 'never builds a filter long enough to trip the request size limit' {
+            # Azure rejects ~27kb of filter with HTTP 414 and Azurite ~13kb with HTTP 431,
+            # and the outer catch swallows both. Stay well inside the stricter one.
+            $ids = @(1..250 | ForEach-Object { 'rec-{0:D3}' -f $_ })
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = $ids }
+            $worst = ($script:SeenFilters | Measure-Object -Property Length -Maximum).Maximum
+            $worst | Should -BeLessThan 11000
+        }
+    }
+
+    Context 'orphaned Downloaded windows' {
+        BeforeEach {
+            $script:DownloadedSweepRows = @(
+                [PSCustomObject]@{ PartitionKey = 'contoso.com'; RowKey = 'orphan-1'; SearchId = 'search-orphan'; State = 'Downloaded' }
+            )
+        }
+
+        It 'sweeps a Downloaded window whose search has no cache rows left' {
+            $null = Push-AuditLogTenantProcessV2 -Item @{ TenantFilter = 'contoso.com'; RowIds = @('rec-1') }
+            $swept = $script:LedgerWrites | Where-Object { $_.RowKey -eq 'orphan-1' }
+            $swept | Should -Not -BeNullOrEmpty
+            $swept.State | Should -Be 'Processed'
+            $swept.MatchedCount | Should -Be 0
+        }
+    }
+}

--- a/backend/Tests/Webhooks/Test-CIPPAuditLogRules.Tests.ps1
+++ b/backend/Tests/Webhooks/Test-CIPPAuditLogRules.Tests.ps1
@@ -1,0 +1,346 @@
+# Pester tests for Test-CIPPAuditLogRules - record shaping and cache cleanup only.
+#
+# This function is large; these cover two seams. First, how an audit record is reshaped
+# before rule matching: ExtendedProperties, DeviceProperties, parameters and
+# ModifiedProperties are flattened onto the record, and rules match on those flattened
+# names. Second, the post-processing cleanup that removes drained rows from CacheWebhooks.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Webhooks/Test-CIPPAuditLogRules.ps1'
+
+    # Called as both -TableName and -tablename; binding is case-insensitive so one covers both.
+    function Get-CIPPTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Context, $Filter, $Property, $First) }
+    function Get-AzDataTableEntity { param($TableName, $Context, $Filter, $Property, $First) }
+    function Add-CIPPAzDataTableEntity { param($TableName, $Context, $Entity, [switch]$Force, $OperationType) }
+    function Remove-AzDataTableEntity { param($TableName, $Context, $Entity, [switch]$Force) }
+    function Expand-CIPPTenantGroups { param($TenantFilter) }
+    function Test-CIPPConditionFilter { param($Condition) }
+    function Invoke-CippWebhookProcessing { param($Data, $CIPPURL, $TenantFilter, $AlertComment) }
+    function Get-CIPPGeoIPLocationBatch { param($IPs) }
+    function Write-LogMessage { param($API, $tenant, $message, $sev, $LogData) }
+    function Get-CippException { param($Exception) [pscustomobject]@{ NormalizedError = "$Exception" } }
+    function New-CIPPDbRequest { param($TenantFilter, $Type, $Endpoint) }
+    function New-GraphBulkRequest { param($Requests, $AsApp, $TenantId) }
+    function New-GraphGetRequest { param($uri, $tenantid, $AsApp, [switch]$Stream, $ComplexFilter, $NoPagination) }
+    function Add-CIPPApplicationPermission { param($RequiredResourceAccess, $ApplicationId, $TenantFilter) }
+
+    # Lookup blob in the 'hashtable' cache format, so no Graph refresh is attempted.
+    function New-LookupRow {
+        param([string]$RowKey)
+        [pscustomobject]@{
+            PartitionKey = 'contoso.com'
+            RowKey       = $RowKey
+            Format       = 'hashtable'
+            Data         = (@{} | ConvertTo-Json -Compress)
+        }
+    }
+
+    function New-AuditRow {
+        param([string]$Id = 'rec-1', [string]$Operation = 'Set-Mailbox')
+        [pscustomobject]@{
+            id              = $Id
+            createdDateTime = '2026-07-29T09:00:00Z'
+            operation       = $Operation
+            auditData       = [pscustomobject]@{
+                Operation          = $Operation
+                ResultStatus       = 'Success'
+                clientip           = '203.0.113.10'
+                ExtendedProperties = @(
+                    [pscustomobject]@{ Name = 'ExtProp'; Value = 'ExtValue' }
+                )
+                DeviceProperties   = @(
+                    [pscustomobject]@{ Name = 'DevProp'; Value = 'DevValue' }
+                )
+                parameters         = @(
+                    [pscustomobject]@{ Name = 'ParamProp'; Value = 'ParamValue' }
+                )
+                ModifiedProperties = @(
+                    [pscustomobject]@{ Name = 'ModProp'; NewValue = 'NewVal'; OldValue = 'OldVal' }
+                )
+            }
+        }
+    }
+
+    . $FunctionPath
+}
+
+Describe 'Test-CIPPAuditLogRules record shaping' {
+
+    BeforeEach {
+        Mock -CommandName Get-CIPPTable -MockWith {
+            param($TableName)
+            @{ TableName = $TableName }
+        }
+
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            param($TableName, $Context, $Filter, $Property, $First)
+            switch ($TableName) {
+                'WebhookRules' {
+                    [pscustomobject]@{
+                        PartitionKey    = 'WebhookRules'
+                        RowKey          = 'rule-1'
+                        Tenants         = (@('AllTenants') | ConvertTo-Json -Compress)
+                        excludedTenants = $null
+                        Conditions      = (@(
+                                @{
+                                    Property = @{ label = 'Operation' }
+                                    Operator = @{ label = 'eq' }
+                                    Input    = @{ value = 'Set-Mailbox' }
+                                }
+                            ) | ConvertTo-Json -Compress -Depth 5)
+                        Actions         = (@('generatemail') | ConvertTo-Json -Compress)
+                        Type            = 'Audit'
+                        AlertComment    = 'test comment'
+                        CustomSubject   = ''
+                    }
+                }
+                'cacheauditloglookups' {
+                    @(
+                        New-LookupRow 'users'
+                        New-LookupRow 'groups'
+                        New-LookupRow 'devices'
+                        New-LookupRow 'servicePrincipals'
+                    )
+                }
+                'Config' { [pscustomobject]@{ Value = 'cipp.contoso.com' } }
+                default { @() }
+            }
+        }
+
+        # Physical CacheWebhooks rows used by the post-processing cleanup.
+        $script:PhysicalCacheRows = @(
+            [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = 'rec-1'; OriginalEntityId = $null }
+            [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = 'other'; OriginalEntityId = $null }
+        )
+        $script:RemovedRows = [System.Collections.Generic.List[object]]::new()
+        $script:CleanupProperty = $null
+        $script:CleanupFilter = $null
+
+        # Applies the filter rather than returning everything: the cleanup relies on the
+        # service to select rows, so a mock that ignores the predicate would prove nothing.
+        Mock -CommandName Get-AzDataTableEntity -MockWith {
+            param($TableName, $Context, $Filter, $Property, $First)
+            $script:CleanupProperty = $Property
+            $script:CleanupFilter = $Filter
+
+            $wantRow = @([regex]::Matches($Filter, "RowKey eq '([^']*)'") | ForEach-Object { $_.Groups[1].Value })
+            $wantOrig = @([regex]::Matches($Filter, "OriginalEntityId eq '([^']*)'") | ForEach-Object { $_.Groups[1].Value })
+
+            @($script:PhysicalCacheRows | Where-Object {
+                    ($wantRow -contains $_.RowKey) -or
+                    ($_.OriginalEntityId -and $wantOrig -contains $_.OriginalEntityId)
+                })
+        }
+
+        Mock -CommandName Remove-AzDataTableEntity -MockWith {
+            param($TableName, $Context, $Entity, [switch]$Force)
+            foreach ($e in @($Entity)) { $script:RemovedRows.Add($e) }
+        }
+
+        Mock -CommandName Expand-CIPPTenantGroups -MockWith { [pscustomobject]@{ value = @('AllTenants') } }
+        # Always-true predicate; rule matching is not what these tests cover.
+        Mock -CommandName Test-CIPPConditionFilter -MockWith { '$_.Operation -eq ''Set-Mailbox''' }
+        Mock -CommandName Invoke-CippWebhookProcessing -MockWith { }
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith { }
+        # Remove-AzDataTableEntity is mocked above with a capturing body; a second mock here
+        # would win and silently capture nothing.
+        Mock -CommandName Get-CIPPGeoIPLocationBatch -MockWith { @{} }
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName New-CIPPDbRequest -MockWith { @() }
+        Mock -CommandName New-GraphBulkRequest -MockWith { @() }
+        Mock -CommandName New-GraphGetRequest -MockWith { @() }
+    }
+
+    Context 'a record that matches a rule' {
+
+        It 'returns the matched record' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $result.MatchedLogs | Should -Be 1
+            @($result.DataToProcess).Count | Should -Be 1
+        }
+
+        It 'flattens ExtendedProperties onto the record' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.ExtProp | Should -Be 'ExtValue'
+        }
+
+        It 'flattens DeviceProperties onto the record' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.DevProp | Should -Be 'DevValue'
+        }
+
+        It 'flattens parameters onto the record' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.ParamProp | Should -Be 'ParamValue'
+        }
+
+        It 'flattens ModifiedProperties new and old values onto the record' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.ModProp | Should -Be 'NewVal'
+            $data.Previous_Value_ModProp | Should -Be 'OldVal'
+        }
+
+        It 'keeps ModifiedProperties available for lazy rendering' {
+            # New-CIPPAlertTemplate serialises this at render time once the eager
+            # CIPPModifiedProperties copy is gone, so the raw collection must survive.
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.ModifiedProperties | Should -Not -BeNullOrEmpty
+            @($data.ModifiedProperties)[0].NewValue | Should -Be 'NewVal'
+        }
+
+        It 'drops the raw sub-objects that were flattened' {
+            # The output projection excludes these three once flattened, so the record does
+            # not carry both representations. ModifiedProperties is not excluded.
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.ExtendedProperties | Should -BeNullOrEmpty
+            $data.DeviceProperties | Should -BeNullOrEmpty
+            $data.parameters | Should -BeNullOrEmpty
+        }
+
+        It 'must keep CIPPParameters because its source is dropped' {
+            # New-CIPPAlertTemplate renders this. It cannot become lazy like
+            # CIPPModifiedProperties - `parameters` is excluded by the projection above, so
+            # removing the eager copy would silently blank the parameters table in alerts.
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.CIPPParameters | Should -Not -BeNullOrEmpty
+            (@($data.CIPPParameters | ConvertFrom-Json)[0]).Name | Should -Be 'ParamProp'
+        }
+
+        It 'sets the action and clause metadata used by alerting' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $data = @($result.DataToProcess)[0]
+            $data.CIPPAction | Should -Not -BeNullOrEmpty
+            $data.CIPPClause | Should -Not -BeNullOrEmpty
+            $data.CIPPAlertComment | Should -Be 'test comment'
+        }
+
+        It 'dispatches the matched record to webhook processing' {
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            Should -Invoke Invoke-CippWebhookProcessing -Times 1
+        }
+    }
+
+    Context 'a record carrying an ignore-listed extended property' {
+        BeforeEach {
+            # 'Consent:Set' is on $ExtendedPropertiesIgnoreList inside the function.
+            $script:IgnoreRow = New-AuditRow
+            $script:IgnoreRow.auditData.ExtendedProperties = @(
+                [pscustomobject]@{ Name = 'IgnoredProp'; Value = 'Consent:Set' }
+                [pscustomobject]@{ Name = 'KeptProp'; Value = 'KeptValue' }
+            )
+        }
+
+        It 'still processes the record instead of dropping it' {
+            # Previously the ignore-list `continue` sat inside a ForEach-Object, where it
+            # unwound to the enclosing foreach and abandoned the whole record - so a record
+            # with an ignored property never reached $ProcessedData at all.
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @($script:IgnoreRow)
+            $result.MatchedLogs | Should -Be 1
+        }
+
+        It 'skips only the ignored property and keeps the rest' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @($script:IgnoreRow)
+            $data = @($result.DataToProcess)[0]
+            $data.KeptProp | Should -Be 'KeptValue'
+            $data.IgnoredProp | Should -BeNullOrEmpty
+        }
+
+        It 'still flattens the later sub-objects that used to be skipped' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @($script:IgnoreRow)
+            $data = @($result.DataToProcess)[0]
+            $data.ModProp | Should -Be 'NewVal'
+            $data.ParamProp | Should -Be 'ParamValue'
+        }
+    }
+
+    Context 'cache cleanup after processing' {
+
+        It 'reads only key columns, not the JSON payloads' {
+            # This read exists solely to pick RowKeys to delete.
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $script:CleanupProperty | Should -Contain 'RowKey'
+            $script:CleanupProperty | Should -Not -Contain 'JSON'
+        }
+
+        It 'asks only for the rows being deleted, never the whole partition' {
+            # The caller processes in chunks, so this runs once per chunk. A bare
+            # "PartitionKey eq X" scan here would be repeated for every chunk of every batch.
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow -Id 'rec-1')
+            $script:CleanupFilter | Should -Match "PartitionKey eq 'contoso.com'"
+            $script:CleanupFilter | Should -Match "RowKey eq 'rec-1'"
+            $script:CleanupFilter | Should -Match "OriginalEntityId eq 'rec-1'"
+        }
+
+        It 'removes the processed record and leaves unrelated rows alone' {
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow -Id 'rec-1')
+            @($script:RemovedRows).RowKey | Should -Contain 'rec-1'
+            @($script:RemovedRows).RowKey | Should -Not -Contain 'other'
+        }
+
+        It 'removes every physical part of a split record, not just the first' {
+            # Matching on the logical id but deleting the physical rows is what stops a split
+            # record's tail parts being orphaned in the cache.
+            $script:PhysicalCacheRows = @(
+                [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = 'big'; OriginalEntityId = 'big' }
+                [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = 'big-part1'; OriginalEntityId = 'big' }
+                [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = 'big-part2'; OriginalEntityId = 'big' }
+                [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = 'other'; OriginalEntityId = $null }
+            )
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow -Id 'big')
+
+            $removed = @($script:RemovedRows).RowKey
+            $removed | Should -Contain 'big'
+            $removed | Should -Contain 'big-part1'
+            $removed | Should -Contain 'big-part2'
+            $removed | Should -Not -Contain 'other'
+        }
+
+        It 'deletes each record as it is processed, not in one batch at the end' {
+            # Intentional, and worth protecting: removing a record from the cache the moment
+            # it is processed means a failure part-way through a batch cannot cause
+            # already-processed records to be picked up again and re-alerted. Batching these
+            # would save round trips but give that up, so this asserts the per-record shape.
+            $rows = @(1..5 | ForEach-Object { New-AuditRow -Id "rec-$_" })
+            $script:PhysicalCacheRows = @(
+                1..5 | ForEach-Object { [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = "rec-$_"; OriginalEntityId = $null } }
+            )
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows $rows
+
+            # 5 per-record deletes, plus the end-of-run sweep.
+            Should -Invoke Remove-AzDataTableEntity -Times 6 -Exactly
+            @($script:RemovedRows).RowKey | Should -Contain 'rec-1'
+            @($script:RemovedRows).RowKey | Should -Contain 'rec-5'
+        }
+
+        It 'never removes a cached row belonging to another record' {
+            # Deletion runs in two stages - a per-record delete by id, then this sweep.
+            # Neither may touch an unrelated row.
+            $script:PhysicalCacheRows = @(
+                [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = 'unrelated'; OriginalEntityId = $null }
+            )
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow -Id 'rec-1')
+            @($script:RemovedRows).RowKey | Should -Not -Contain 'unrelated'
+        }
+    }
+
+    Context 'a record that matches no rule' {
+        BeforeEach {
+            Mock -CommandName Test-CIPPConditionFilter -MockWith { '$_.Operation -eq ''Never-Matches''' }
+        }
+
+        It 'matches nothing and dispatches nothing' {
+            $result = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows @(New-AuditRow)
+            $result.MatchedLogs | Should -Be 0
+            Should -Invoke Invoke-CippWebhookProcessing -Times 0
+        }
+    }
+}

--- a/backend/Tests/Webhooks/Test-CIPPAuditLogRules.Tests.ps1
+++ b/backend/Tests/Webhooks/Test-CIPPAuditLogRules.Tests.ps1
@@ -304,21 +304,33 @@ Describe 'Test-CIPPAuditLogRules record shaping' {
             $removed | Should -Not -Contain 'other'
         }
 
-        It 'deletes each record as it is processed, not in one batch at the end' {
-            # Intentional, and worth protecting: removing a record from the cache the moment
-            # it is processed means a failure part-way through a batch cannot cause
-            # already-processed records to be picked up again and re-alerted. Batching these
-            # would save round trips but give that up, so this asserts the per-record shape.
+        It 'flushes deletes in batches rather than one call per record' {
             $rows = @(1..5 | ForEach-Object { New-AuditRow -Id "rec-$_" })
             $script:PhysicalCacheRows = @(
                 1..5 | ForEach-Object { [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = "rec-$_"; OriginalEntityId = $null } }
             )
             $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows $rows
 
-            # 5 per-record deletes, plus the end-of-run sweep.
-            Should -Invoke Remove-AzDataTableEntity -Times 6 -Exactly
+            # Under the flush size, so one flush after the loop plus the end-of-run sweep.
+            Should -Invoke Remove-AzDataTableEntity -Times 2 -Exactly
             @($script:RemovedRows).RowKey | Should -Contain 'rec-1'
             @($script:RemovedRows).RowKey | Should -Contain 'rec-5'
+        }
+
+        It 'flushes mid-loop so a poison batch still makes forward progress' {
+            # The reason deletes are not deferred to the end: if a record kills the worker,
+            # everything already flushed is gone from the cache, so the retry starts further
+            # in and the run converges instead of looping on the same rows forever.
+            $rows = @(1..60 | ForEach-Object { New-AuditRow -Id "rec-$_" })
+            $script:PhysicalCacheRows = @(
+                1..60 | ForEach-Object { [pscustomobject]@{ PartitionKey = 'contoso.com'; RowKey = "rec-$_"; OriginalEntityId = $null } }
+            )
+            $null = Test-CIPPAuditLogRules -TenantFilter 'contoso.com' -Rows $rows
+
+            # 60 records at a flush size of 25: two mid-loop flushes, a remainder flush,
+            # and the sweep - not 60 individual calls.
+            Should -Invoke Remove-AzDataTableEntity -Times 4 -Exactly
+            @($script:RemovedRows).RowKey.Count | Should -Be 120  # 60 flushed + 60 swept
         }
 
         It 'never removes a cached row belonging to another record' {


### PR DESCRIPTION
Stream audit search results instead of sorting/materializing full windows, and process tenant cache rows in bounded chunks to reduce peak memory and avoid oversized table filters. Update cache fetch/delete logic to correctly handle split entities via OriginalEntityId so multi-part records are reassembled and fully removed. Refactor rule-shaping property flattening to avoid per-property Add-Member overhead and fix ignore-list flow so records are not dropped. Add focused Pester coverage for search results, download, tenant processing, and rule-shaping/cleanup paths.