### PR TITLE
feat(alerts): raise an alert when CIPP has new permissions to apply

### DIFF
--- a/backend/Config/CIPPTimers.json
+++ b/backend/Config/CIPPTimers.json
@@ -139,6 +139,16 @@
     "IsSystem": true
   },
   {
+    "Id": "f3a1c7d2-9b64-4e58-8a07-1d5e2c9b4f36",
+    "Command": "Start-CIPPPermissionCheck",
+    "Description": "Check the CIPP application for permissions that need to be applied",
+    "Cron": "0 30 0 * * *",
+    "Priority": 10,
+    "RunOnProcessor": true,
+    "TZOffset": true,
+    "IsSystem": true
+  },
+  {
     "Id": "467787cf-01c5-4d20-8097-c2eef691a20e",
     "Command": "Start-BillingTimer",
     "Description": "Timer to process billing",

--- a/backend/Modules/CIPPCore/Public/Entrypoints/Timer Functions/Start-CIPPPermissionCheck.ps1
+++ b/backend/Modules/CIPPCore/Public/Entrypoints/Timer Functions/Start-CIPPPermissionCheck.ps1
@@ -1,0 +1,23 @@
+function Start-CIPPPermissionCheck {
+    <#
+    .SYNOPSIS
+        Run the CIPP permissions check on a schedule.
+    .DESCRIPTION
+        The permissions check only ran when someone opened the permissions page, so an instance
+        that needed new consent stayed that way until a human happened to look. Running it on a
+        timer means Test-CIPPAccessPermissions raises its alert on its own, and the page's cached
+        result stays current as a side effect.
+    .FUNCTIONALITY
+        Entrypoint
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param()
+
+    if ($PSCmdlet.ShouldProcess('Start-CIPPPermissionCheck', 'Check for permissions that need to be applied')) {
+        try {
+            $null = Test-CIPPAccessPermissions -TenantFilter $env:TenantID -APIName 'Permissions Check'
+        } catch {
+            Write-LogMessage -API 'Permissions Check' -message "Scheduled permissions check failed: $($_.Exception.Message)" -sev Error -LogData (Get-CippException -Exception $_)
+        }
+    }
+}

--- a/backend/Modules/CIPPCore/Public/Test-CIPPAccessPermissions.ps1
+++ b/backend/Modules/CIPPCore/Public/Test-CIPPAccessPermissions.ps1
@@ -115,6 +115,20 @@ function Test-CIPPAccessPermissions {
                 }
             }
             $Success = $false
+
+            # Until now this only ever surfaced on the permissions page, so the only way to find
+            # out that CIPP needs new consent was to go and look. Log it so it reaches the
+            # notification pipeline like any other alert. Write-AlertMessage de-duplicates per
+            # day, so a check that runs on every page load doesn't repeat itself.
+            # Logged against the partner tenant - it's the CIPP application that needs consent,
+            # not a customer's tenant.
+            $MissingCount = ($MissingPermissions | Measure-Object).Count
+            $MissingSummary = ($MissingPermissions | ForEach-Object { $_.Permission } | Sort-Object -Unique) -join ', '
+            # Select-Object -First 1 because an empty TenantFilter makes Get-Tenants return every
+            # tenant, which would otherwise land every domain in the alert's Tenant field.
+            $PartnerTenant = Get-Tenants -TenantFilter $TenantFilter | Select-Object -First 1
+            $AlertTenant = if ($PartnerTenant.defaultDomainName) { $PartnerTenant.defaultDomainName } else { 'None' }
+            Write-AlertMessage -tenant $AlertTenant -tenantId $PartnerTenant.customerId -message "CIPP has $MissingCount new permission(s) to apply: $MissingSummary. Review and apply them under CIPP > Application Settings > Permissions."
         } else {
             $Messages.Add('You have all the required permissions.') | Out-Null
         }

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-GetCippAlerts.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-GetCippAlerts.ps1
@@ -53,6 +53,33 @@ function Invoke-GetCippAlerts {
                 type  = 'error'
             })
     }
+
+    # Outstanding SAM permissions are only visible by opening the permissions page, so an
+    # instance can sit needing consent without anyone noticing. Surface it here like the other
+    # instance health warnings. Only shown to roles that can actually grant the consent.
+    if ($Role | Where-Object { $_ -in @('admin', 'superadmin') }) {
+        try {
+            # Cached result only - this endpoint runs on every page load, and running the
+            # permissions check itself makes a Graph call per service principal.
+            $AccessTable = Get-CIPPTable -TableName 'AccessChecks'
+            $PermissionCache = Get-CIPPAzDataTableEntity @AccessTable -Filter "PartitionKey eq 'AccessCheck' and RowKey eq 'AccessPermissions'"
+            if ($PermissionCache.Data) {
+                $MissingPermissions = ($PermissionCache.Data | ConvertFrom-Json -ErrorAction Stop).MissingPermissions
+                $MissingCount = ($MissingPermissions | Measure-Object).Count
+                if ($MissingCount -gt 0) {
+                    $Alerts.Add(@{
+                            title = 'Permissions to Apply'
+                            Alert = ('CIPP has {0} new permission(s) to apply. Review and apply them on the permissions page: ' -f $MissingCount)
+                            link  = '/cipp/settings/permissions'
+                            type  = 'warning'
+                        })
+                }
+            }
+        } catch {
+            # A missing or unreadable cache just means no banner - never break the alert list.
+            Write-Information "Could not read the cached permissions check: $($_.Exception.Message)"
+        }
+    }
     $PSMinVersion = [Version]'7.4.0'
     if ($PSVersionTable.PSVersion -lt $PSMinVersion) {
         $Alerts.Add(@{


### PR DESCRIPTION
The permissions page tells you when CIPP has new permissions to consent to, and nothing else does. `Test-CIPPAccessPermissions` works out what's missing, hands it to the page, and doesn't log it — so it never reaches the notification pipeline. Nothing runs the check on a schedule either; it only executes when someone opens Application Settings > Permissions. An instance can sit needing consent for weeks and the only way to find out is to go and look.

The check now raises an alert when permissions are outstanding, and a timer runs it daily at 00:30. It already writes its result to the AccessChecks cache, so the permissions page stays current as a side effect of the timer rather than only being refreshed when someone visits it.

The alert goes through `Write-AlertMessage` so it de-duplicates per day — the check runs on every page load, and without that it would write a row each time. It's logged against the partner tenant rather than a customer tenant, because it's the CIPP application that needs the consent, not anyone's M365.

Tested against an instance with 21 outstanding permissions: the alert is raised with the permission names in the message, repeat runs are correctly skipped as duplicates, and it reached the partner tenant's mapped PSA client. Also checked the timer registers — `Get-CIPPTimerFunctions` picks the new entry up from CIPPTimers.json without anything else being touched.

00:30 so it doesn't overlap the CPV permission push at 00:00.
