### PR TITLE
Feat: Add MFA method management to user page

### DIFF
--- a/backend/Modules/CIPPCore/Public/Remove-CIPPUserMFA.ps1
+++ b/backend/Modules/CIPPCore/Public/Remove-CIPPUserMFA.ps1
@@ -12,8 +12,14 @@ function Remove-CIPPUserMFA {
     .PARAMETER TenantFilter
     Tenant where the user resides
 
+    .PARAMETER MethodId
+    Id of a single authentication method to remove. When omitted, all removable methods are removed.
+
     .EXAMPLE
     Remove-CIPPUserMFA -UserPrincipalName testuser@contoso.com -TenantFilter contoso.com
+
+    .EXAMPLE
+    Remove-CIPPUserMFA -UserPrincipalName testuser@contoso.com -TenantFilter contoso.com -MethodId 3179e48a-750b-4051-897c-87b9720928f7
 
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
@@ -23,14 +29,19 @@ function Remove-CIPPUserMFA {
         [Parameter(Mandatory = $true)]
         [string]$TenantFilter,
         [Parameter(Mandatory = $false)]
+        [string]$MethodId,
+        [Parameter(Mandatory = $false)]
         $Headers,
         [Parameter(Mandatory = $false)]
         $APIName = 'Remove MFA Methods'
     )
 
+    # Guest UPNs contain '#EXT#'; unencoded, the '#' starts a URI fragment and truncates the Graph path.
+    $EncodedUser = [System.Uri]::EscapeDataString($UserPrincipalName)
+
     Write-Information "Getting auth methods for $UserPrincipalName"
     try {
-        $AuthMethods = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/users/$UserPrincipalName/authentication/methods" -tenantid $TenantFilter -AsApp $true
+        $AuthMethods = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/users/$EncodedUser/authentication/methods" -tenantid $TenantFilter -AsApp $true
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
         $Message = "Failed to get MFA methods for user $UserPrincipalName. Error: $($ErrorMessage.NormalizedError)"
@@ -40,8 +51,16 @@ function Remove-CIPPUserMFA {
 
     $RemovableMethods = $AuthMethods | Where-Object { $_.'@odata.type' -and $_.'@odata.type' -ne '#microsoft.graph.passwordAuthenticationMethod' }
 
+    if ($MethodId) {
+        $RemovableMethods = $RemovableMethods | Where-Object { $_.id -eq $MethodId }
+    }
+
     if (($RemovableMethods | Measure-Object).Count -eq 0) {
-        $Results = "No MFA methods found for user $UserPrincipalName"
+        $Results = if ($MethodId) {
+            "No removable MFA method with id $MethodId found for user $UserPrincipalName"
+        } else {
+            "No MFA methods found for user $UserPrincipalName"
+        }
         Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Results -sev 'Info'
         return $Results
     }
@@ -53,11 +72,11 @@ function Remove-CIPPUserMFA {
             $MethodType = ($Method.'@odata.type' -split '\.')[-1] -replace 'Authentication', ''
             switch ($MethodType) {
                 'qrCodePinMethod' {
-                    $Uri = 'https://graph.microsoft.com/beta/users/{0}/authentication/{1}' -f $UserPrincipalName, $MethodType
+                    $Uri = 'https://graph.microsoft.com/beta/users/{0}/authentication/{1}' -f $EncodedUser, $MethodType
                     break
                 }
                 default {
-                    $Uri = 'https://graph.microsoft.com/v1.0/users/{0}/authentication/{1}s/{2}' -f $UserPrincipalName, $MethodType, $Method.id
+                    $Uri = 'https://graph.microsoft.com/v1.0/users/{0}/authentication/{1}s/{2}' -f $EncodedUser, $MethodType, $Method.id
                 }
             }
             try {
@@ -79,7 +98,11 @@ function Remove-CIPPUserMFA {
             throw $Message
         }
 
-        $Message = "Successfully removed MFA methods ($($Succeeded -join ', ')) for user $UserPrincipalName. User must supply MFA at next logon"
+        $Message = if ($MethodId) {
+            "Successfully removed MFA method ($($Succeeded -join ', ')) for user $UserPrincipalName"
+        } else {
+            "Successfully removed MFA methods ($($Succeeded -join ', ')) for user $UserPrincipalName. User must supply MFA at next logon"
+        }
         Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Message -sev 'Info'
         return $Message
     }

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecResetMFA.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecResetMFA.ps1
@@ -11,10 +11,20 @@ function Invoke-ExecResetMFA {
     $Headers = $Request.Headers
 
     # Interact with query parameters or the body of the request.
-    $TenantFilter = $Request.Query.tenantFilter ?? $Request.Body.tenantFilter
-    $UserID = $Request.Query.ID ?? $Request.Body.ID
+    $TenantFilter = $Request.Body.tenantFilter
+    $UserID = $Request.Body.ID
+    # When supplied, only this single authentication method is removed instead of all of them.
+    $MethodId = $Request.Body.MethodId
+
+    $MFAParams = @{
+        UserPrincipalName = $UserID
+        TenantFilter      = $TenantFilter
+        Headers           = $Headers
+    }
+    if ($MethodId) { $MFAParams.MethodId = $MethodId }
+
     try {
-        $Result = Remove-CIPPUserMFA -UserPrincipalName $UserID -TenantFilter $TenantFilter -Headers $Headers
+        $Result = Remove-CIPPUserMFA @MFAParams
         $StatusCode = [HttpStatusCode]::OK
     } catch {
         $Result = $_.Exception.Message

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecSetDefaultMFAMethod.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecSetDefaultMFAMethod.ps1
@@ -1,0 +1,60 @@
+function Invoke-ExecSetDefaultMFAMethod {
+    <#
+    .FUNCTIONALITY
+    Entrypoint
+
+    .ROLE
+    Identity.User.ReadWrite
+
+    .DESCRIPTION
+    Sets the default second factor a user is prompted with, by patching signInPreferences.
+    Note this is ignored at sign-in while system-preferred MFA is enabled for the user.
+    #>
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+
+    $TenantFilter = $Request.Body.tenantFilter
+    $UserId = $Request.Body.ID
+    $MethodType = $Request.Body.MethodType.value ? $Request.Body.MethodType.value : $Request.Body.MethodType
+
+    # Graph only accepts these six values for userPreferredMethodForSecondaryAuthentication.
+    $ValidMethods = @('push', 'oath', 'voiceMobile', 'voiceAlternateMobile', 'voiceOffice', 'sms')
+
+    if (-not $UserId -or -not $TenantFilter -or -not $MethodType) {
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::BadRequest
+                Body       = @{ 'Results' = @('tenantFilter, ID and MethodType are required') }
+            })
+    }
+
+    if ($MethodType -notin $ValidMethods) {
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::BadRequest
+                Body       = @{ 'Results' = @("'$MethodType' is not a valid default MFA method. Valid values are: $($ValidMethods -join ', ')") }
+            })
+    }
+
+    try {
+        # signInPreferences only exists on the beta endpoint.
+        # Guest UPNs contain '#EXT#'; unencoded, the '#' starts a URI fragment and truncates the Graph path.
+        $Uri = 'https://graph.microsoft.com/beta/users/{0}/authentication/signInPreferences' -f [System.Uri]::EscapeDataString($UserId)
+        $Body = @{ userPreferredMethodForSecondaryAuthentication = $MethodType } | ConvertTo-Json -Compress
+        $null = New-GraphPOSTRequest -uri $Uri -tenantid $TenantFilter -type PATCH -body $Body -AsApp $true
+
+        $Result = "Successfully set the default MFA method to $MethodType for user $UserId"
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Result -sev 'Info'
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Result = "Failed to set the default MFA method for user $UserId. Error: $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message $Result -sev 'Error' -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::InternalServerError
+    }
+
+    return ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{ 'Results' = @($Result) }
+        })
+}

--- a/backend/Tests/Endpoint/Invoke-ExecSetDefaultMFAMethod.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ExecSetDefaultMFAMethod.Tests.ps1
@@ -1,0 +1,91 @@
+# Pester tests for Invoke-ExecSetDefaultMFAMethod input validation and Graph PATCH shape.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-ExecSetDefaultMFAMethod.ps1' -File |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    ([PSObject].Assembly.GetType('System.Management.Automation.TypeAccelerators')).GetMethod('Add').Invoke(
+        $null, @('HttpStatusCode', [System.Net.HttpStatusCode]))
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    function New-GraphPOSTRequest { param($uri, $tenantid, $type, $body, $AsApp) }
+    function Write-LogMessage { param($headers, $API, $message, $Sev, $tenant, $LogData) }
+    function Get-CippException { param($Exception) }
+
+    function New-TestRequest {
+        param($MethodType, $UserId = 'user@contoso.com', $TenantFilter = 'contoso.com')
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ExecSetDefaultMFAMethod' }
+            Headers = @{}
+            Query   = [pscustomobject]@{}
+            Body    = [pscustomobject]@{
+                tenantFilter = $TenantFilter
+                ID           = $UserId
+                MethodType   = $MethodType
+            }
+        }
+    }
+
+    . $FunctionPath
+}
+
+Describe 'Invoke-ExecSetDefaultMFAMethod' {
+    BeforeEach {
+        $script:patchUri = $null
+        $script:patchBody = $null
+        $script:patchType = $null
+
+        Mock -CommandName New-GraphPOSTRequest -MockWith {
+            $script:patchUri = $uri
+            $script:patchBody = $body
+            $script:patchType = $type
+        }
+        Mock -CommandName Write-LogMessage -MockWith {}
+    }
+
+    It 'patches signInPreferences on beta with the selected method' {
+        $response = Invoke-ExecSetDefaultMFAMethod -Request (New-TestRequest -MethodType 'oath') -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        $script:patchType | Should -Be 'PATCH'
+        $script:patchUri | Should -Be 'https://graph.microsoft.com/beta/users/user%40contoso.com/authentication/signInPreferences'
+        ($script:patchBody | ConvertFrom-Json).userPreferredMethodForSecondaryAuthentication | Should -Be 'oath'
+    }
+
+    It 'encodes a guest UPN so the #EXT# fragment does not truncate the Graph path' {
+        $Request = New-TestRequest -MethodType 'push' -UserId 'alice_fabrikam.com#EXT#@contoso.onmicrosoft.com'
+
+        $null = Invoke-ExecSetDefaultMFAMethod -Request $Request -TriggerMetadata $null
+
+        $script:patchUri | Should -Be 'https://graph.microsoft.com/beta/users/alice_fabrikam.com%23EXT%23%40contoso.onmicrosoft.com/authentication/signInPreferences'
+        $script:patchUri | Should -Not -Match '#'
+    }
+
+    It 'unwraps the autoComplete {label,value} shape from the frontend' {
+        $Request = New-TestRequest -MethodType ([pscustomobject]@{ label = 'SMS'; value = 'sms' })
+
+        $null = Invoke-ExecSetDefaultMFAMethod -Request $Request -TriggerMetadata $null
+
+        ($script:patchBody | ConvertFrom-Json).userPreferredMethodForSecondaryAuthentication | Should -Be 'sms'
+    }
+
+    It 'rejects a method type Graph does not accept' {
+        $response = Invoke-ExecSetDefaultMFAMethod -Request (New-TestRequest -MethodType 'fido2') -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
+        $script:patchUri | Should -BeNullOrEmpty
+        Should -Invoke New-GraphPOSTRequest -Times 0
+    }
+
+    It 'rejects a request with no method type' {
+        $response = Invoke-ExecSetDefaultMFAMethod -Request (New-TestRequest -MethodType $null) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
+        Should -Invoke New-GraphPOSTRequest -Times 0
+    }
+}

--- a/backend/Tests/Private/Remove-CIPPUserMFA.Tests.ps1
+++ b/backend/Tests/Private/Remove-CIPPUserMFA.Tests.ps1
@@ -1,0 +1,64 @@
+# Pester tests for the optional single-method filter and UPN encoding on Remove-CIPPUserMFA.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Remove-CIPPUserMFA.ps1' -File |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    function New-GraphGetRequest { param($uri, $tenantid, $AsApp) }
+    function New-GraphPOSTRequest { param($uri, $tenantid, $type, $AsApp) }
+    function Write-LogMessage { param($headers, $API, $message, $Sev, $tenant, $LogData) }
+    function Get-CippException { param($Exception) }
+
+    . $FunctionPath
+}
+
+Describe 'Remove-CIPPUserMFA -MethodId' {
+    BeforeEach {
+        $script:deletedUris = [System.Collections.Generic.List[string]]::new()
+
+        Mock -CommandName New-GraphGetRequest -MockWith {
+            @(
+                [pscustomobject]@{ '@odata.type' = '#microsoft.graph.passwordAuthenticationMethod'; id = 'pwd-id' }
+                [pscustomobject]@{ '@odata.type' = '#microsoft.graph.phoneAuthenticationMethod'; id = 'phone-id' }
+                [pscustomobject]@{ '@odata.type' = '#microsoft.graph.fido2AuthenticationMethod'; id = 'fido-id' }
+            )
+        }
+        Mock -CommandName New-GraphPOSTRequest -MockWith { $script:deletedUris.Add($uri) }
+        Mock -CommandName Write-LogMessage -MockWith {}
+    }
+
+    It 'deletes only the requested method when MethodId is supplied' {
+        $Result = Remove-CIPPUserMFA -UserPrincipalName 'user@contoso.com' -TenantFilter 'contoso.com' -MethodId 'fido-id'
+
+        $script:deletedUris.Count | Should -Be 1
+        $script:deletedUris[0] | Should -Be 'https://graph.microsoft.com/v1.0/users/user%40contoso.com/authentication/fido2Methods/fido-id'
+        $Result | Should -BeLike 'Successfully removed MFA method*'
+    }
+
+    It 'encodes a guest UPN so the #EXT# fragment does not truncate the Graph path' {
+        $null = Remove-CIPPUserMFA -UserPrincipalName 'alice_fabrikam.com#EXT#@contoso.onmicrosoft.com' -TenantFilter 'contoso.com' -MethodId 'fido-id'
+
+        $script:deletedUris[0] | Should -Be 'https://graph.microsoft.com/v1.0/users/alice_fabrikam.com%23EXT%23%40contoso.onmicrosoft.com/authentication/fido2Methods/fido-id'
+        $script:deletedUris[0] | Should -Not -Match '#'
+    }
+
+    It 'deletes every removable method when MethodId is omitted' {
+        $null = Remove-CIPPUserMFA -UserPrincipalName 'user@contoso.com' -TenantFilter 'contoso.com'
+
+        $script:deletedUris.Count | Should -Be 2
+    }
+
+    It 'never deletes the password method' {
+        $null = Remove-CIPPUserMFA -UserPrincipalName 'user@contoso.com' -TenantFilter 'contoso.com' -MethodId 'pwd-id'
+
+        $script:deletedUris.Count | Should -Be 0
+    }
+
+    It 'reports the unknown id when MethodId matches nothing' {
+        $Result = Remove-CIPPUserMFA -UserPrincipalName 'user@contoso.com' -TenantFilter 'contoso.com' -MethodId 'does-not-exist'
+
+        $script:deletedUris.Count | Should -Be 0
+        $Result | Should -BeLike '*does-not-exist*'
+    }
+}

--- a/docs/user-documentation/identity/administration/users/user/README.md
+++ b/docs/user-documentation/identity/administration/users/user/README.md
@@ -4,15 +4,15 @@ The View User page provides a comprehensive overview of user details and setting
 
 ## Overview
 
-* Primary display of user information including a quick link to view the user in Entra
-* Additional tabs at top for extended functionality (Edit, Compromise Remediation, etc.)
-* Inherits Actions dropdown from list users page
+- Primary display of user information including a quick link to view the user in Entra
+- Additional tabs at top for extended functionality (Edit, Compromise Remediation, etc.)
+- Inherits Actions dropdown from list users page
 
 ## Actions
 
 The actions dropdown carries forward the same [#table-actions](../#table-actions "mention") from the main Users page.
 
-***
+---
 
 ## User Information Fields
 
@@ -54,11 +54,11 @@ The actions dropdown carries forward the same [#table-actions](../#table-actions
 
 ### Security & Access
 
-| Field                               | Description                                                                                 |
-| ----------------------------------- | ------------------------------------------------------------------------------------------- |
-| Last Logon                          | <p>Most recent sign-in information<br>• Expandable for additional details (click arrow)</p> |
-| Applied Conditional Access Policies | <p>Active security policies<br>• Expandable for policy details (click arrow)</p>            |
-| Multi-Factor Authentication Devices | <p>Registered MFA devices<br>• Expandable for device details (click arrow)</p>              |
+| Field                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Last Logon                          | <p>Most recent sign-in information<br>• Expandable for additional details (click arrow)</p>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Applied Conditional Access Policies | <p>Active security policies<br>• Expandable for policy details (click arrow)</p>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Multi-Factor Authentication Devices | <p>Registered MFA methods. Each card shows the method type and the identifier that distinguishes it (device name, phone number, security key model, email address), plus when the method was last used<br>• The method matching the user's preferred second factor is marked <strong>User default</strong><br>• The method Microsoft selects while system-preferred MFA is enabled is marked <strong>System-preferred</strong><br>• Remove an individual method with the bin icon<br>• <strong>Set Default MFA Method</strong> sets the preferred second factor, offering only methods the user has registered<br>• Expandable for method details (click arrow)</p> |
 
 ### Group & Role Memberships
 
@@ -73,14 +73,15 @@ This card will display the devices the user is associated with.
 
 ## Notes
 
-* Information is read-only in this view
-* Use Edit tab to modify information
-* Expandable sections (▼) provide additional details
-* Direct links to related management pages
-* Real-time data from Entra ID
+- Information is read-only in this view, apart from the user photo and the MFA method actions described above
+- When system-preferred MFA is enabled, Microsoft selects the strongest registered method at sign-in and the user's default second factor is ignored
+- Use Edit tab to modify information
+- Expandable sections (▼) provide additional details
+- Direct links to related management pages
+- Real-time data from Entra ID
 
 This view serves as the central hub for user information, providing quick access to both basic details and advanced management options through the tabbed interface.
 
-***
+---
 
 {% include "../../../../../../.gitbook/includes/feature-request.md" %}

--- a/frontend/src/pages/identity/administration/users/user/index.jsx
+++ b/frontend/src/pages/identity/administration/users/user/index.jsx
@@ -7,12 +7,23 @@ import CalendarIcon from '@heroicons/react/24/outline/CalendarIcon'
 import {
   AdminPanelSettings,
   Check,
+  Delete,
+  Dialpad,
   Group,
+  Key,
+  Language,
+  Laptop,
+  LockPerson,
   Mail,
   Fingerprint,
   Launch,
   Devices,
+  Password,
   PersonRemove,
+  PhoneIphone,
+  QrCode,
+  Smartphone,
+  VpnKey,
 } from '@mui/icons-material'
 import { HeaderedTabbedLayout } from '../../../../../layouts/HeaderedTabbedLayout'
 import tabOptions from './tabOptions'
@@ -28,16 +39,181 @@ import { useCippUserActions } from '../../../../../components/CippComponents/Cip
 import { EyeIcon, PencilIcon } from '@heroicons/react/24/outline'
 import { CippDataTable } from '../../../../../components/CippTable/CippDataTable'
 import dynamic from 'next/dynamic'
-const CippMap = dynamic(() => import('../../../../../components/CippComponents/CippMap'), {
-  ssr: false,
-})
+const CippMap = dynamic(
+  () => import('../../../../../components/CippComponents/CippMap'),
+  {
+    ssr: false,
+  }
+)
 
-import { Button, Dialog, DialogTitle, DialogContent, IconButton } from '@mui/material'
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+} from '@mui/material'
 import { Close } from '@mui/icons-material'
 import { CippPropertyList } from '../../../../../components/CippComponents/CippPropertyList'
 import { CippCodeBlock } from '../../../../../components/CippComponents/CippCodeBlock'
 import { CippHead } from '../../../../../components/CippComponents/CippHead'
 import { usePermissions } from '../../../../../hooks/use-permissions'
+import { useDialog } from '../../../../../hooks/use-dialog'
+import { CippApiDialog } from '../../../../../components/CippComponents/CippApiDialog'
+
+// The only six values Graph accepts for userPreferredMethodForSecondaryAuthentication.
+// Shared by the "Set Default" dropdown, the default marker, and the system-preferred alert.
+const MFA_PREF_LABELS = {
+  push: 'Microsoft Authenticator (push)',
+  oath: 'Authenticator app or hardware token (OATH code)',
+  sms: 'SMS',
+  voiceMobile: 'Voice call - mobile',
+  voiceAlternateMobile: 'Voice call - alternate mobile',
+  voiceOffice: 'Voice call - office',
+}
+
+// systemPreferredAuthenticationMethod is undocumented on signInPreferences and comes
+// back in the legacy MFA vocabulary ("SoftwareOTP"), NOT the six values above, so it
+// maps to @odata.type suffixes rather than to a preference value.
+// Keyed lowercase so a casing change upstream doesn't silently break matching; an
+// unrecognised value simply marks no card.
+const SYSTEM_PREF_METHOD_TYPES = {
+  phoneappnotification: [
+    'microsoftAuthenticatorAuthenticationMethod',
+    'passwordlessMicrosoftAuthenticatorAuthenticationMethod',
+  ],
+  phoneappotp: [
+    'microsoftAuthenticatorAuthenticationMethod',
+    'softwareOathAuthenticationMethod',
+  ],
+  softwareotp: ['softwareOathAuthenticationMethod'],
+  hardwareotp: ['hardwareOathAuthenticationMethod'],
+  onewaysms: ['phoneAuthenticationMethod'],
+  twowayvoicemobile: ['phoneAuthenticationMethod'],
+  twowayvoicealternatemobile: ['phoneAuthenticationMethod'],
+  twowayvoiceoffice: ['phoneAuthenticationMethod'],
+  fido2: ['fido2AuthenticationMethod'],
+  temporaryaccesspass: ['temporaryAccessPassAuthenticationMethod'],
+  windowshelloforbusiness: ['windowsHelloForBusinessAuthenticationMethod'],
+  qrcodepin: ['qrCodePinAuthenticationMethod'],
+  externalmethod: ['externalAuthenticationMethod'],
+}
+
+// Keyed by the @odata.type suffix Graph returns. /authentication/methods is a
+// polymorphic collection, so the identifying field differs per method type.
+const MFA_METHOD_TYPES = {
+  microsoftAuthenticatorAuthenticationMethod: {
+    label: 'Microsoft Authenticator',
+    icon: <PhoneIphone />,
+    identifier: (method) => method.displayName || method.deviceTag,
+  },
+  passwordlessMicrosoftAuthenticatorAuthenticationMethod: {
+    // Deprecated by Graph, but still present on users registered before the merge.
+    label: 'Microsoft Authenticator (passwordless)',
+    icon: <PhoneIphone />,
+    identifier: (method) => method.displayName,
+  },
+  phoneAuthenticationMethod: {
+    // SMS and voice are the same registration — phoneType is what separates them.
+    label: 'Phone',
+    icon: <Smartphone />,
+    identifier: (method) =>
+      method.phoneNumber && method.phoneType
+        ? `${method.phoneNumber} (${method.phoneType})`
+        : method.phoneNumber,
+  },
+  fido2AuthenticationMethod: {
+    label: 'Passkey (FIDO2)',
+    icon: <VpnKey />,
+    identifier: (method) => method.model || method.displayName,
+  },
+  softwareOathAuthenticationMethod: {
+    // Any TOTP-capable app, not just Microsoft Authenticator — password managers included.
+    label: 'Software OATH token',
+    icon: <Dialpad />,
+    identifier: (method) => method.displayName,
+  },
+  hardwareOathAuthenticationMethod: {
+    // This type has no displayName; the serial number lives on the device
+    // relationship, which Graph only returns when explicitly expanded.
+    label: 'Hardware OATH token',
+    icon: <Password />,
+    identifier: (method) => method.device?.serialNumber,
+  },
+  emailAuthenticationMethod: {
+    label: 'Email',
+    icon: <Mail />,
+    identifier: (method) => method.emailAddress,
+  },
+  windowsHelloForBusinessAuthenticationMethod: {
+    label: 'Windows Hello for Business',
+    icon: <Fingerprint />,
+    identifier: (method) => method.displayName,
+  },
+  platformCredentialAuthenticationMethod: {
+    label: 'Platform credential',
+    icon: <Laptop />,
+    identifier: (method) => method.displayName || method.platform,
+  },
+  temporaryAccessPassAuthenticationMethod: {
+    label: 'Temporary Access Pass',
+    icon: <Key />,
+    identifier: () => null,
+  },
+  qrCodePinAuthenticationMethod: {
+    // Only id and lastUsedDateTime come back on this type — nothing to identify it by.
+    label: 'QR code',
+    icon: <QrCode />,
+    identifier: () => null,
+  },
+  externalAuthenticationMethod: {
+    label: 'External provider',
+    icon: <Language />,
+    identifier: (method) => method.displayName,
+  },
+}
+
+const getMethodType = (method) =>
+  method['@odata.type']?.split('.').pop() || 'N/A'
+
+// A method type Graph adds later still renders: raw suffix as label, generic icon.
+const getMethodMeta = (method) =>
+  MFA_METHOD_TYPES[getMethodType(method)] ?? {
+    label: getMethodType(method),
+    icon: <Check />,
+    identifier: () => null,
+  }
+
+// Which of the six preference values this specific method can satisfy. Graph stores
+// the default by method *type*, not by method id. A mobile number backs both SMS and
+// voice; FIDO2/Hello/email/TAP back none, so they can never be the default.
+const prefValuesForMethod = (method) => {
+  const type = getMethodType(method)
+  if (type === 'phoneAuthenticationMethod') {
+    if (method.phoneType === 'mobile') return ['sms', 'voiceMobile']
+    if (method.phoneType === 'alternateMobile') return ['voiceAlternateMobile']
+    if (method.phoneType === 'office') return ['voiceOffice']
+    return []
+  }
+  // The Authenticator app always shows a verification code alongside push, and Graph
+  // does not surface that as a separate softwareOathAuthenticationMethod entity — so an
+  // Authenticator registration backs 'oath' too. Omitting it left Authenticator-only
+  // users unable to select a preference they can actually satisfy.
+  if (
+    type === 'microsoftAuthenticatorAuthenticationMethod' ||
+    type === 'passwordlessMicrosoftAuthenticatorAuthenticationMethod'
+  ) {
+    return ['push', 'oath']
+  }
+  // The 'oath' preference covers both software and hardware OATH tokens.
+  if (
+    type === 'softwareOathAuthenticationMethod' ||
+    type === 'hardwareOathAuthenticationMethod'
+  ) {
+    return ['oath']
+  }
+  return []
+}
 
 const SignInLogsDialog = ({ open, onClose, userId, tenantFilter }) => {
   return (
@@ -89,6 +265,10 @@ const Page = () => {
   const userActions = useCippUserActions()
   const { checkPermissions } = usePermissions()
   const canWriteRole = checkPermissions(['Identity.Role.ReadWrite'])
+  const canWriteUser = checkPermissions(['Identity.User.ReadWrite'])
+  const removeMethodDialog = useDialog()
+  const defaultMethodDialog = useDialog()
+  const [selectedMethod, setSelectedMethod] = useState(null)
 
   useEffect(() => {
     if (userId) {
@@ -108,8 +288,9 @@ const Page = () => {
     urlFromData: true,
   })
 
+  const userPrincipalName = userRequest.data?.[0]?.userPrincipalName
+
   function refreshFunction() {
-    const userPrincipalName = userRequest.data?.[0]?.userPrincipalName
     const requests = [
       {
         id: 'userMemberOf',
@@ -124,6 +305,11 @@ const Page = () => {
       {
         id: 'signInLogs',
         url: `/auditLogs/signIns?$filter=(userId eq '${userId}')&$top=1`,
+        method: 'GET',
+      },
+      {
+        id: 'signInPreferences',
+        url: `/users/${userId}/authentication/signInPreferences`,
         method: 'GET',
       },
     ]
@@ -142,7 +328,7 @@ const Page = () => {
       data: {
         Requests: requests,
         tenantFilter: userSettingsDefaults.currentTenant,
-        noPaginateIds: ['signInLogs'],
+        noPaginateIds: ['signInLogs', 'signInPreferences'],
       },
     })
   }
@@ -156,13 +342,27 @@ const Page = () => {
     ) {
       refreshFunction()
     }
-  }, [userId, userSettingsDefaults.currentTenant, userRequest.isSuccess, userBulkRequest.isSuccess])
+  }, [
+    userId,
+    userSettingsDefaults.currentTenant,
+    userRequest.isSuccess,
+    userBulkRequest.isSuccess,
+  ])
 
   const bulkData = userBulkRequest?.data?.data ?? []
   const signInLogsData = bulkData?.find((item) => item.id === 'signInLogs')
   const userMemberOfData = bulkData?.find((item) => item.id === 'userMemberOf')
   const mfaDevicesData = bulkData?.find((item) => item.id === 'mfaDevices')
-  const managedDevicesData = bulkData?.find((item) => item.id === 'managedDevices')
+  const managedDevicesData = bulkData?.find(
+    (item) => item.id === 'managedDevices'
+  )
+  const signInPrefsData = bulkData?.find(
+    (item) => item.id === 'signInPreferences'
+  )
+
+  // signInPreferences is a singleton resource, so the payload is .body itself, not .body.value.
+  // It can 403/404 on some tenants; everything downstream falls back to the unmarked state.
+  const signInPrefs = signInPrefsData?.body ?? {}
 
   const signInLogs = signInLogsData?.body?.value || []
   const userMemberOf = userMemberOfData?.body?.value || []
@@ -170,23 +370,33 @@ const Page = () => {
   const managedDevices = managedDevicesData?.body?.value || []
 
   // Set the title and subtitle for the layout
-  const title = userRequest.isSuccess ? userRequest.data?.[0]?.displayName : 'Loading...'
+  const title = userRequest.isSuccess
+    ? userRequest.data?.[0]?.displayName
+    : 'Loading...'
 
   const subtitle = userRequest.isSuccess
     ? [
         {
           icon: <Mail />,
-          text: <CippCopyToClipBoard type="chip" text={userRequest.data?.[0]?.userPrincipalName} />,
+          text: (
+            <CippCopyToClipBoard
+              type="chip"
+              text={userRequest.data?.[0]?.userPrincipalName}
+            />
+          ),
         },
         {
           icon: <Fingerprint />,
-          text: <CippCopyToClipBoard type="chip" text={userRequest.data?.[0]?.id} />,
+          text: (
+            <CippCopyToClipBoard type="chip" text={userRequest.data?.[0]?.id} />
+          ),
         },
         {
           icon: <CalendarIcon />,
           text: (
             <>
-              Created: <CippTimeAgo data={userRequest.data?.[0]?.createdDateTime} />
+              Created:{' '}
+              <CippTimeAgo data={userRequest.data?.[0]?.createdDateTime} />
             </>
           ),
         },
@@ -221,17 +431,23 @@ const Page = () => {
     signInLogItem = {
       id: 1,
       cardLabelBox: {
-        cardLabelBoxHeader: new Date(signInData.createdDateTime).getDate().toString(),
-        cardLabelBoxText: new Date(signInData.createdDateTime).toLocaleString('default', {
-          month: 'short',
-          year: 'numeric',
-        }),
+        cardLabelBoxHeader: new Date(signInData.createdDateTime)
+          .getDate()
+          .toString(),
+        cardLabelBoxText: new Date(signInData.createdDateTime).toLocaleString(
+          'default',
+          {
+            month: 'short',
+            year: 'numeric',
+          }
+        ),
       },
       text: `Login ${signInData.status.errorCode === 0 ? 'successful' : 'failed'} from ${
         signInData.ipAddress || 'unknown location'
       }`,
       subtext: `Logged into application ${signInData.resourceDisplayName || 'Unknown Application'}`,
-      statusColor: signInData.status.errorCode === 0 ? 'success.main' : 'error.main',
+      statusColor:
+        signInData.status.errorCode === 0 ? 'success.main' : 'error.main',
       statusText: signInData.status.errorCode === 0 ? 'Success' : 'Failed',
       actionButton: (
         <Button
@@ -255,7 +471,9 @@ const Page = () => {
         {
           label: 'Device Detail',
           value:
-            signInData.deviceDetail?.operatingSystem || signInData.deviceDetail?.browser || 'N/A',
+            signInData.deviceDetail?.operatingSystem ||
+            signInData.deviceDetail?.browser ||
+            'N/A',
         },
         {
           label: 'MFA Type used',
@@ -290,7 +508,10 @@ const Page = () => {
                     propertyItems={[
                       { label: 'City', value: signInData.location.city },
                       { label: 'State', value: signInData.location.state },
-                      { label: 'Country/Region', value: signInData.location.countryOrRegion },
+                      {
+                        label: 'Country/Region',
+                        value: signInData.location.countryOrRegion,
+                      },
                     ]}
                   />
                 </Grid>
@@ -307,16 +528,21 @@ const Page = () => {
       Array.isArray(signInData.appliedConditionalAccessPolicies)
     ) {
       // Filter policies where result is "success"
-      const appliedPolicies = signInData.appliedConditionalAccessPolicies.filter(
-        (policy) => policy.result === 'success'
-      )
+      const appliedPolicies =
+        signInData.appliedConditionalAccessPolicies.filter(
+          (policy) => policy.result === 'success'
+        )
 
       if (appliedPolicies.length > 0) {
         conditionalAccessPoliciesItems = appliedPolicies.map((policy) => ({
           id: policy.id,
           cardLabelBox: {
-            cardLabelBoxHeader: new Date(signInData.createdDateTime).getDate().toString(),
-            cardLabelBoxText: new Date(signInData.createdDateTime).toLocaleString('default', {
+            cardLabelBoxHeader: new Date(signInData.createdDateTime)
+              .getDate()
+              .toString(),
+            cardLabelBoxText: new Date(
+              signInData.createdDateTime
+            ).toLocaleString('default', {
               month: 'short',
               year: 'numeric',
             }),
@@ -352,14 +578,19 @@ const Page = () => {
           {
             id: 1,
             cardLabelBox: {
-              cardLabelBoxHeader: new Date(signInData.createdDateTime).getDate().toString(),
-              cardLabelBoxText: new Date(signInData.createdDateTime).toLocaleString('default', {
+              cardLabelBoxHeader: new Date(signInData.createdDateTime)
+                .getDate()
+                .toString(),
+              cardLabelBoxText: new Date(
+                signInData.createdDateTime
+              ).toLocaleString('default', {
                 month: 'short',
                 year: 'numeric',
               }),
             },
             text: 'No conditional access policies applied',
-            subtext: 'No conditional access policies were applied during this sign-in.',
+            subtext:
+              'No conditional access policies were applied during this sign-in.',
             statusColor: 'warning.main',
             statusText: 'No Policies Applied',
             propertyItems: [],
@@ -372,14 +603,19 @@ const Page = () => {
         {
           id: 1,
           cardLabelBox: {
-            cardLabelBoxHeader: new Date(signInData.createdDateTime).getDate().toString(),
-            cardLabelBoxText: new Date(signInData.createdDateTime).toLocaleString('default', {
+            cardLabelBoxHeader: new Date(signInData.createdDateTime)
+              .getDate()
+              .toString(),
+            cardLabelBoxText: new Date(
+              signInData.createdDateTime
+            ).toLocaleString('default', {
               month: 'short',
               year: 'numeric',
             }),
           },
           text: 'No conditional access policies available',
-          subtext: 'No conditional access policies data is available for this sign-in.',
+          subtext:
+            'No conditional access policies data is available for this sign-in.',
           statusColor: 'warning.main',
           statusText: 'No Data',
           propertyItems: [],
@@ -428,7 +664,10 @@ const Page = () => {
           value: (
             <CippCodeBlock
               language="json"
-              code={JSON.stringify(signInLogsData?.error?.innerError, null, 2) || 'Unknown error'}
+              code={
+                JSON.stringify(signInLogsData?.error?.innerError, null, 2) ||
+                'Unknown error'
+              }
             />
           ),
         },
@@ -449,44 +688,99 @@ const Page = () => {
     ]
   }
 
+  // Exclude password authentication method. Hoisted out of the block below so the
+  // "Set Default MFA Method" dropdown can be filtered to what the user actually has.
+  const mfaDevicesFiltered = mfaDevices.filter(
+    (method) =>
+      method['@odata.type'] !== '#microsoft.graph.passwordAuthenticationMethod'
+  )
+
+  const userPreferredMethod =
+    signInPrefs.userPreferredMethodForSecondaryAuthentication
+  // Only meaningful while system-preferred MFA is on; the field can be populated but inert.
+  const systemPreferredTypes =
+    (signInPrefs.isSystemPreferredAuthenticationMethodEnabled &&
+      SYSTEM_PREF_METHOD_TYPES[
+        String(signInPrefs.systemPreferredAuthenticationMethod ?? '').toLowerCase()
+      ]) ||
+    []
+  const availablePrefValues = [
+    ...new Set(mfaDevicesFiltered.flatMap(prefValuesForMethod)),
+  ]
+  const defaultMethodOptions = Object.entries(MFA_PREF_LABELS)
+    .filter(([value]) => availablePrefValues.includes(value))
+    .map(([value, label]) => ({ label, value }))
+
   // Prepare MFA devices items
   if (mfaDevices.length > 0) {
-    // Exclude password authentication method
-    const mfaDevicesFiltered = mfaDevices.filter(
-      (method) => method['@odata.type'] !== '#microsoft.graph.passwordAuthenticationMethod'
-    )
-
     if (mfaDevicesFiltered.length > 0) {
-      mfaDevicesItems = mfaDevicesFiltered.map((device, index) => ({
-        id: index,
-        cardLabelBox: {
-          cardLabelBoxHeader: <Check />,
-        },
-        text: device.displayName || 'MFA Device',
-        subtext: device.deviceTag || device.clientAppName || 'Unknown device',
-        statusColor: 'success.main',
-        statusText: 'Enabled',
-        propertyItems: [
-          {
-            label: 'Device Name',
-            value: device.displayName || 'N/A',
+      mfaDevicesItems = mfaDevicesFiltered.map((device, index) => {
+        const methodType = getMethodType(device)
+        const meta = getMethodMeta(device)
+        const identifier = meta.identifier(device)
+        // Both preferences are type-level, so every method of a preferred type is marked.
+        const methodPrefValues = prefValuesForMethod(device)
+        const statusLabels = []
+        if (
+          userPreferredMethod &&
+          methodPrefValues.includes(userPreferredMethod)
+        ) {
+          statusLabels.push('User default')
+        }
+        // Matched by @odata.type, since the system value uses a different vocabulary.
+        if (systemPreferredTypes.includes(methodType)) {
+          statusLabels.push('System-preferred')
+        }
+        return {
+          id: index,
+          cardLabelBox: {
+            cardLabelBoxHeader: meta.icon,
           },
-          {
-            label: 'App Version',
-            value: device.phoneAppVersion || 'N/A',
-          },
-          {
-            label: 'Created Date',
-            value: device.createdDateTime
-              ? new Date(device.createdDateTime).toLocaleString()
-              : 'N/A',
-          },
-          {
-            label: 'Authentication Method',
-            value: device['@odata.type']?.split('.').pop() || 'N/A',
-          },
-        ],
-      }))
+          text: identifier ? `${meta.label} · ${identifier}` : meta.label,
+          // lastUsedDateTime is beta-only and optional — Graph nulls it for method
+          // types that don't populate it, so keep a fallback.
+          subtext: device.lastUsedDateTime
+            ? `Last used ${new Date(device.lastUsedDateTime).toLocaleDateString()}`
+            : 'Last used unknown',
+          statusColor:
+            statusLabels.length > 0 ? 'primary.main' : 'success.main',
+          statusText:
+            statusLabels.length > 0 ? statusLabels.join(' · ') : 'Enabled',
+          // The card id is the collapse key, so the Graph method id travels via selectedMethod.
+          cardLabelBoxActions: canWriteUser ? (
+            <IconButton
+              size="small"
+              title="Remove this MFA method"
+              onClick={() => {
+                setSelectedMethod({ ...device, methodType: meta.label })
+                removeMethodDialog.handleOpen()
+              }}
+            >
+              <Delete fontSize="small" />
+            </IconButton>
+          ) : undefined,
+          propertyItems: [
+            {
+              label: 'Device Name',
+              value: device.displayName || 'N/A',
+            },
+            {
+              label: 'App Version',
+              value: device.phoneAppVersion || 'N/A',
+            },
+            {
+              label: 'Created Date',
+              value: device.createdDateTime
+                ? new Date(device.createdDateTime).toLocaleString()
+                : 'N/A',
+            },
+            {
+              label: 'Authentication Method',
+              value: methodType,
+            },
+          ],
+        }
+      })
     } else {
       // No MFA devices other than password
       mfaDevicesItems = [
@@ -522,8 +816,11 @@ const Page = () => {
               <CippCodeBlock
                 language="json"
                 code={
-                  JSON.stringify(mfaDevicesData?.body?.error?.innerError, null, 2) ||
-                  'Unknown Error'
+                  JSON.stringify(
+                    mfaDevicesData?.body?.error?.innerError,
+                    null,
+                    2
+                  ) || 'Unknown Error'
                 }
               />
             ),
@@ -556,8 +853,9 @@ const Page = () => {
           text: 'Groups',
           subtext: 'List of groups the user is a member of',
           statusText: ` ${
-            userMemberOf?.filter((item) => item?.['@odata.type'] === '#microsoft.graph.group')
-              .length
+            userMemberOf?.filter(
+              (item) => item?.['@odata.type'] === '#microsoft.graph.group'
+            ).length
           } Group(s)`,
           statusColor: 'info.main',
           table: {
@@ -574,7 +872,12 @@ const Page = () => {
               (item) => item?.['@odata.type'] === '#microsoft.graph.group'
             ),
             refreshFunction: refreshFunction,
-            simpleColumns: ['displayName', 'groupTypes', 'securityEnabled', 'mailEnabled'],
+            simpleColumns: [
+              'displayName',
+              'groupTypes',
+              'securityEnabled',
+              'mailEnabled',
+            ],
           },
         },
       ]
@@ -591,7 +894,8 @@ const Page = () => {
           subtext: 'List of roles the user is a member of',
           statusText: ` ${
             userMemberOf?.filter(
-              (item) => item?.['@odata.type'] === '#microsoft.graph.directoryRole'
+              (item) =>
+                item?.['@odata.type'] === '#microsoft.graph.directoryRole'
             ).length
           } Role(s)`,
           statusColor: 'info.main',
@@ -609,14 +913,18 @@ const Page = () => {
                   RoleName: 'displayName',
                   Users: 'Users',
                 },
-                confirmText: 'Are you sure you want to remove this user from [displayName]?',
+                confirmText:
+                  'Are you sure you want to remove this user from [displayName]?',
                 allowResubmit: true,
                 onSuccess: refreshFunction,
                 condition: (row) => canWriteRole && !!row?.id,
               },
             ],
             data: userMemberOf
-              ?.filter((item) => item?.['@odata.type'] === '#microsoft.graph.directoryRole')
+              ?.filter(
+                (item) =>
+                  item?.['@odata.type'] === '#microsoft.graph.directoryRole'
+              )
               .map((role) => ({
                 ...role,
                 Users: [
@@ -653,7 +961,12 @@ const Page = () => {
               hideTitle: true,
               data: managedDevices,
               refreshFunction: refreshFunction,
-              simpleColumns: ['deviceName', 'operatingSystem', 'osVersion', 'managementType'],
+              simpleColumns: [
+                'deviceName',
+                'operatingSystem',
+                'osVersion',
+                'managementType',
+              ],
               actions: [
                 {
                   icon: <EyeIcon />,
@@ -722,13 +1035,41 @@ const Page = () => {
                   items={signInLogItem ? [signInLogItem] : []}
                   isCollapsible={signInLogItem ? true : false}
                 />
-                <Typography variant="h6">Applied Conditional Access Policies</Typography>
+                <Typography variant="h6">
+                  Applied Conditional Access Policies
+                </Typography>
                 <CippBannerListCard
                   isFetching={userBulkRequest.isPending}
                   items={conditionalAccessPoliciesItems}
-                  isCollapsible={conditionalAccessPoliciesItems.length > 0 ? true : false}
+                  isCollapsible={
+                    conditionalAccessPoliciesItems.length > 0 ? true : false
+                  }
                 />
-                <Typography variant="h6">Multi-Factor Authentication Devices</Typography>
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                >
+                  <Typography variant="h6">
+                    Multi-Factor Authentication Devices
+                  </Typography>
+                  {canWriteUser && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<LockPerson />}
+                      disabled={defaultMethodOptions.length === 0}
+                      title={
+                        defaultMethodOptions.length === 0
+                          ? 'This user has no registered method that can be set as the default second factor.'
+                          : undefined
+                      }
+                      onClick={() => defaultMethodDialog.handleOpen()}
+                    >
+                      Set Default MFA Method
+                    </Button>
+                  )}
+                </Stack>
                 <CippBannerListCard
                   isFetching={userBulkRequest.isPending}
                   items={mfaDevicesItems}
@@ -761,6 +1102,42 @@ const Page = () => {
         onClose={() => setSignInLogsDialogOpen(false)}
         userId={userId}
         tenantFilter={userSettingsDefaults.currentTenant}
+      />
+      <CippApiDialog
+        createDialog={removeMethodDialog}
+        title="Remove MFA Method"
+        row={selectedMethod ?? {}}
+        allowResubmit={true}
+        api={{
+          type: 'POST',
+          url: '/api/ExecResetMFA',
+          data: { ID: `!${userPrincipalName}`, MethodId: 'id' },
+          confirmText:
+            'Are you sure you want to remove the [methodType] method from this user?',
+          onSuccess: refreshFunction,
+        }}
+      />
+      <CippApiDialog
+        createDialog={defaultMethodDialog}
+        title="Set Default MFA Method"
+        row={{}}
+        fields={[
+          {
+            type: 'autoComplete',
+            name: 'MethodType',
+            label: 'Default method',
+            options: defaultMethodOptions,
+            multiple: false,
+            creatable: false,
+            validators: { required: 'Please select a default MFA method' },
+          },
+        ]}
+        api={{
+          type: 'POST',
+          url: '/api/ExecSetDefaultMFAMethod',
+          data: { ID: `!${userPrincipalName}` },
+          onSuccess: refreshFunction,
+        }}
       />
     </HeaderedTabbedLayout>
   )


### PR DESCRIPTION
Enhance user experience by allowing management of multi-factor authentication (MFA) methods on the user detail page. Introduce functionality to set a default MFA method(pretty much only for NPS extension usage) and remove specific methods,. Address issues with guest UPN encoding to ensure proper functionality.
<img width="928" height="383" alt="image" src="https://github.com/user-attachments/assets/3d25719a-2d00-41da-88a1-359ed7045f4b" />

Damn it's nice having the docs in the main repo now, makes it hard to forget to update docs! \o/