### PR TITLE
Chore: Add AGENTS.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ localfiles/
 graphify-out/
 .claude/
 CLAUDE.md
+AGENTS.md


### PR DESCRIPTION
Ensure that AGENTS.md is ignored by Git to prevent it from being tracked in the repository.