### PR TITLE
fix(tests): Correct Spelling on ScubaGear References

### DIFF
--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO101.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO101.md
@@ -14,7 +14,7 @@ Set-MalwareFilterPolicy -Identity "Default" -EnableFileFilter $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.10.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo101v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.10.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo101v1)
 - [Configure anti-malware policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-malware-protection-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO102.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO102.md
@@ -16,7 +16,7 @@ Set-MalwareFilterPolicy -Identity "Default" -Action DeleteMessage
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.10.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo102v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.10.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo102v1)
 - [Configure anti-malware policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-malware-protection-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO103.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO103.md
@@ -14,7 +14,7 @@ Set-MalwareFilterPolicy -Identity "Default" -ZapEnabled $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.10.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo103v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.10.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo103v1)
 - [Zero-hour auto purge (ZAP) in Microsoft Defender for Office 365](https://learn.microsoft.com/microsoft-365/security/office-365-security/zero-hour-auto-purge)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO11.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO11.md
@@ -15,7 +15,7 @@ Get-RemoteDomain | Set-RemoteDomain -AutoForwardEnabled $false
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.1.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo11v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.1.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo11v1)
 - [Configure remote domain settings](https://learn.microsoft.com/exchange/mail-flow-best-practices/remote-domains/remote-domains)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO111.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO111.md
@@ -15,7 +15,7 @@ Enable-ATPProtectionPolicyRule -Identity "Standard Preset Security Policy"
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.11.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo111v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.11.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo111v1)
 - [Preset security policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/preset-security-policies)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO112.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO112.md
@@ -19,7 +19,7 @@ Set-AntiPhishPolicy -Identity "Standard Preset Security Policy" `
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.11.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo112v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.11.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo112v1)
 - [Safety tips in email messages](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-phishing-protection-about#safety-tips-in-email-messages)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO113.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO113.md
@@ -17,7 +17,7 @@ Set-AntiPhishPolicy -Identity "Standard Preset Security Policy" `
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.11.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo113v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.11.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo113v1)
 - [Mailbox intelligence in anti-phishing policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-phishing-policies-about#impersonation-settings-in-anti-phishing-policies-in-microsoft-defender-for-office-365)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO121.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO121.md
@@ -16,7 +16,7 @@ Remove-TenantAllowBlockListItems -ListType Sender -Ids <submission-id>
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.12.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo121v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.12.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo121v1)
 - [Manage the Tenant Allow/Block List](https://learn.microsoft.com/microsoft-365/security/office-365-security/tenant-allow-block-list-about)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO122.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO122.md
@@ -15,7 +15,7 @@ Set-HostedContentFilterPolicy -Identity "Default" -EnableSafeList $false
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.12.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo122v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.12.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo122v1)
 - [Configure anti-spam policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-spam-policies-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO131.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO131.md
@@ -12,7 +12,7 @@ Set-OrganizationConfig -AuditDisabled $false
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.13.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo131v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.13.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo131v1)
 - [Manage mailbox auditing](https://learn.microsoft.com/purview/audit-mailboxes)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO141.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO141.md
@@ -14,7 +14,7 @@ Set-HostedContentFilterPolicy -Identity "Default" -HighConfidenceSpamAction Quar
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.14.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo141v2)
+- [CISA ScubaGear EXO Baseline - MS.EXO.14.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo141v2)
 - [Configure anti-spam policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-spam-policies-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO142.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO142.md
@@ -16,7 +16,7 @@ Set-HostedContentFilterPolicy -Identity "Default" -SpamAction Quarantine
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.14.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo142v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.14.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo142v1)
 - [Configure anti-spam policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-spam-policies-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO143.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO143.md
@@ -15,7 +15,7 @@ Set-HostedContentFilterPolicy -Identity "Default" -AllowedSenders @() -AllowedSe
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.14.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo143v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.14.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo143v1)
 - [Configure allowed and blocked senders](https://learn.microsoft.com/microsoft-365/security/office-365-security/create-safe-sender-lists-in-office-365)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO151.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO151.md
@@ -14,7 +14,7 @@ Set-SafeLinksPolicy -Identity "Default" -EnableSafeLinksForEmail $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.15.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo151v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.15.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo151v1)
 - [Set up Safe Links policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/safe-links-policies-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO152.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO152.md
@@ -15,7 +15,7 @@ Set-SafeLinksPolicy -Identity "Default" -ScanUrls $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.15.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo152v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.15.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo152v1)
 - [Set up Safe Links policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/safe-links-policies-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO153.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO153.md
@@ -14,7 +14,7 @@ Set-SafeLinksPolicy -Identity "Default" -TrackUserClicks $false
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.15.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo153v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.15.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo153v1)
 - [Set up Safe Links policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/safe-links-policies-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO171.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO171.md
@@ -12,7 +12,7 @@ Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.17.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo171v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.17.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo171v1)
 - [Turn audit log search on or off](https://learn.microsoft.com/purview/audit-log-enable-disable)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO173.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO173.md
@@ -15,7 +15,7 @@ Set-AdminAuditLogConfig -AdminAuditLogEnabled $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.17.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo173v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.17.3](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo173v1)
 - [Audit log retention policies](https://learn.microsoft.com/purview/audit-log-retention-policies)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO31.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO31.md
@@ -20,7 +20,7 @@ Set-DkimSigningConfig -Identity "contoso.com" -Enabled $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.3.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo31v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.3.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo31v1)
 - [Use DKIM to validate outbound email](https://learn.microsoft.com/microsoft-365/security/office-365-security/email-authentication-dkim-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO51.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO51.md
@@ -16,7 +16,7 @@ Set-CASMailbox -Identity user@domain.com -SmtpClientAuthenticationDisabled $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.5.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo51v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.5.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo51v1)
 - [Disable SMTP AUTH](https://learn.microsoft.com/exchange/clients-and-mobile-in-exchange-online/authenticated-client-smtp-submission)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO61.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO61.md
@@ -13,7 +13,7 @@ Set-SharingPolicy -Identity "Default Sharing Policy" -Domains @{Remove="*:Contac
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.6.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo61v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.6.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo61v1)
 - [Sharing policies in Exchange Online](https://learn.microsoft.com/exchange/sharing/sharing-policies/sharing-policies)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO62.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO62.md
@@ -17,7 +17,7 @@ Set-SharingPolicy -Identity "Default Sharing Policy" -Domains @{Add="partner.com
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.6.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo62v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.6.2](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo62v1)
 - [Sharing policies in Exchange Online](https://learn.microsoft.com/exchange/sharing/sharing-policies/sharing-policies)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO71.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO71.md
@@ -13,7 +13,7 @@ Set-ExternalInOutlook -Enabled $true
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.7.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo71v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.7.1](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo71v1)
 - [External sender warnings](https://learn.microsoft.com/microsoft-365/security/office-365-security/external-email-forwarding)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO95.md
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/Identity/Invoke-CippTestCISAMSEXO95.md
@@ -15,7 +15,7 @@ Set-MalwareFilterPolicy -Identity "Default" -EnableFileFilter $true -FileTypes @
 ```
 
 **Links:**
-- [CISA SCubaGear EXO Baseline - MS.EXO.9.5](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo95v1)
+- [CISA ScubaGear EXO Baseline - MS.EXO.9.5](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/baselines/exo.md#msexo95v1)
 - [Configure anti-malware policies](https://learn.microsoft.com/microsoft-365/security/office-365-security/anti-malware-protection-configure)
 
 <!--- Results --->

--- a/backend/Modules/CIPPTests/Public/Tests/CISA/report.json
+++ b/backend/Modules/CIPPTests/Public/Tests/CISA/report.json
@@ -1,6 +1,6 @@
 {
-  "name": "CISA SCubaGear Tests for Exchange Online",
-  "description": "Security configuration assessment tests based on CISA's Secure Cloud Business Applications (SCubaGear) project for Microsoft Exchange Online. These tests validate compliance with federal security baselines.",
+  "name": "CISA ScubaGear Tests for Exchange Online",
+  "description": "Security configuration assessment tests based on CISA's Secure Cloud Business Applications (ScubaGear) project for Microsoft Exchange Online. These tests validate compliance with federal security baselines.",
   "version": "1.0",
   "source": "https://github.com/cisagov/ScubaGear",
   "category": "CISA Security Baselines",


### PR DESCRIPTION
## Summary

Corrects the spelling of "SCubaGear" to "ScubaGear" (matching the official CISA project name) across:

- The CISA EXO test suite name and description in `report.json`
- The baseline reference link text in the 24 CISA `MS.EXO` test docs

Text-only change — no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)