### PR TITLE
Fix: Align cached Intune policy reports with live data

### DIFF
--- a/backend/Modules/CIPPCore/Public/Add-CIPPDbItem.ps1
+++ b/backend/Modules/CIPPCore/Public/Add-CIPPDbItem.ps1
@@ -4,6 +4,11 @@ function Add-CIPPDbItem {
         Add items to the CIPP Reporting database
     .FUNCTIONALITY
         Internal
+
+    .PARAMETER ClearOnEmpty
+        Authorizes removal of existing rows when InputObject is an authoritative empty
+        collection and exact row-key cleanup for a non-empty authoritative collection.
+        Callers must only use this after a successful source response.
     #>
     [CmdletBinding()]
     param(
@@ -22,6 +27,7 @@ function Add-CIPPDbItem {
         [switch]$Count,
         [switch]$AddCount,
         [switch]$Append,
+        [switch]$ClearOnEmpty,
 
         [ValidateRange(0, 60)]
         [int]$SkewMarginMinutes = 5
@@ -31,7 +37,10 @@ function Add-CIPPDbItem {
         $Table = Get-CippTable -tablename 'CippReportingDB'
         $BatchSize = 100
         $Batch = [System.Collections.Generic.List[hashtable]]::new($BatchSize)
+        # Track batch duplicates separately from the full authoritative run used for cleanup.
         $SeenInBatch = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $SeenRowKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        # Allow for storage timestamp lag before considering untouched rows stale.
         $RunStartUtc = [DateTimeOffset]::UtcNow.AddMinutes(-$SkewMarginMinutes)
 
         $TotalProcessed = 0
@@ -61,6 +70,7 @@ function Add-CIPPDbItem {
             $ItemId = $Item.ExternalDirectoryObjectId ?? $Item.id ?? $Item.Identity ?? $Item.skuId ?? $Item.userPrincipalName ?? [guid]::NewGuid().ToString()
             $RowKey = $RowKeyControlRegex.Replace($RowKeyPathRegex.Replace("$Type-$ItemId", '_'), '')
             if ($SeenInBatch.Add($RowKey)) {
+                $null = $SeenRowKeys.Add($RowKey)
                 $Batch.Add(@{
                         PartitionKey = $TenantFilter
                         RowKey       = $RowKey
@@ -84,13 +94,20 @@ function Add-CIPPDbItem {
         }
 
         # Clean up orphaned rows (entities that no longer exist in the new dataset).
-        if (-not $Count.IsPresent -and -not $Append.IsPresent -and $TotalProcessed -gt 0) {
+        # Empty collections only clear existing data when the caller explicitly confirms
+        # the response was authoritative by passing -ClearOnEmpty.
+        if (-not $Count.IsPresent -and -not $Append.IsPresent -and ($TotalProcessed -gt 0 -or $ClearOnEmpty.IsPresent)) {
             $Filter = "PartitionKey eq '{0}' and RowKey ge '{1}-' and RowKey lt '{1}0'" -f $TenantFilter, $Type
             $Existing = Get-CIPPAzDataTableEntity @Table -Filter $Filter -Property PartitionKey, RowKey, ETag, OriginalEntityId, Timestamp
             if ($Existing) {
                 $Undated = 0
                 $Orphans = foreach ($Row in @($Existing)) {
                     if ($Row.RowKey -eq "$Type-Count") { continue }
+
+                    if ($ClearOnEmpty.IsPresent) {
+                        if (-not $SeenRowKeys.Contains($Row.RowKey)) { $Row }
+                        continue
+                    }
 
                     $Stamp = $Row.Timestamp -as [datetimeoffset]
                     if ($null -eq $Stamp) { $Undated++; continue }

--- a/backend/Modules/CIPPCore/Public/ConvertTo-CIPPIntunePolicyListItem.ps1
+++ b/backend/Modules/CIPPCore/Public/ConvertTo-CIPPIntunePolicyListItem.ps1
@@ -1,0 +1,104 @@
+function ConvertTo-CIPPIntunePolicyListItem {
+    <#
+    .SYNOPSIS
+        Normalizes one Intune policy for the live or cached policy list.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        # Empty Graph family responses can reach the shared normalizer as an explicit null.
+        [AllowNull()]
+        $Policy,
+
+        [Parameter(Mandatory)]
+        [string]$URLName,
+
+        [AllowNull()]
+        [string]$DefaultPolicyTypeName,
+
+        [hashtable]$GroupLookup = @{}
+    )
+
+    process {
+        if ($null -eq $Policy) { return }
+        # Keep the shared live/cache filtering rules at the normalization boundary.
+        if ($Policy.platforms -eq 'linux' -or $Policy.templateReference.templateFamily -eq 'deviceConfigurationScripts') { return }
+
+        if ($null -eq $Policy.displayName) {
+            $Policy | Add-Member -NotePropertyName displayName -NotePropertyValue $Policy.name -Force
+        }
+        if ($null -eq $Policy.displayName) { return }
+
+        $AssignmentContext = $Policy.'assignments@odata.context'
+        $PolicyODataType = $Policy.'@odata.type'
+        # Prefer Graph's assignment context, then fall back to family-specific metadata.
+        $PolicyTypeName = switch -Wildcard ($AssignmentContext) {
+            '*microsoft.graph.windowsIdentityProtectionConfiguration*' { 'Identity Protection' }
+            '*microsoft.graph.windows10EndpointProtectionConfiguration*' { 'Endpoint Protection' }
+            '*microsoft.graph.windows10CustomConfiguration*' { 'Custom' }
+            '*microsoft.graph.windows10DeviceFirmwareConfigurationInterface*' { 'Firmware Configuration' }
+            '*groupPolicyConfigurations*' { 'Administrative Templates' }
+            '*windowsDomainJoinConfiguration*' { 'Domain Join configuration' }
+            '*windowsUpdateForBusinessConfiguration*' { 'Update Configuration' }
+            '*windowsHealthMonitoringConfiguration*' { 'Health Monitoring' }
+            '*microsoft.graph.macOSGeneralDeviceConfiguration*' { 'MacOS Configuration' }
+            '*microsoft.graph.macOSEndpointProtectionConfiguration*' { 'MacOS Endpoint Protection' }
+            '*microsoft.graph.androidWorkProfileGeneralDeviceConfiguration*' { 'Android Configuration' }
+            '*windowsFeatureUpdateProfiles*' { 'Feature Update' }
+            '*windowsQualityUpdatePolicies*' { 'Quality Update' }
+            '*windowsQualityUpdateProfiles*' { 'Quality Update' }
+            '*iosUpdateConfiguration*' { 'iOS Update Configuration' }
+            '*windowsDriverUpdateProfiles*' { 'Driver Update' }
+            '*configurationPolicies*' { 'Device Configuration' }
+            '*deviceCompliancePolicies*' { 'Compliance Policy' }
+            '*intents*' { 'Endpoint Security' }
+            default { $null }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($PolicyTypeName)) {
+            if ($URLName -eq 'ManagedAppPolicies') {
+                $PolicyTypeName = switch -Wildcard ($PolicyODataType) {
+                    '*iosManagedAppProtection*' { 'iOS App Protection' }
+                    '*androidManagedAppProtection*' { 'Android App Protection' }
+                    '*windowsManagedAppProtection*' { 'Windows App Protection' }
+                    default { $DefaultPolicyTypeName }
+                }
+            } elseif (-not [string]::IsNullOrWhiteSpace($DefaultPolicyTypeName)) {
+                $PolicyTypeName = $DefaultPolicyTypeName
+            } else {
+                $PolicyTypeName = $AssignmentContext
+            }
+        }
+
+        $PolicyAssignment = [System.Collections.Generic.List[string]]::new()
+        $PolicyExclude = [System.Collections.Generic.List[string]]::new()
+        foreach ($Target in @($Policy.assignments.target)) {
+            # Malformed or deleted group targets can omit groupId; unresolved names stay blank.
+            switch ($Target.'@odata.type') {
+                '#microsoft.graph.allDevicesAssignmentTarget' { $PolicyAssignment.Add('All Devices') }
+                '#microsoft.graph.exclusionallDevicesAssignmentTarget' { $PolicyExclude.Add('All Devices') }
+                '#microsoft.graph.allUsersAssignmentTarget' { $PolicyAssignment.Add('All Users') }
+                '#microsoft.graph.allLicensedUsersAssignmentTarget' { $PolicyAssignment.Add('All Licenced Users') }
+                '#microsoft.graph.exclusionallUsersAssignmentTarget' { $PolicyExclude.Add('All Users') }
+                '#microsoft.graph.groupAssignmentTarget' {
+                    $GroupId = [string]$Target.groupId
+                    $PolicyAssignment.Add($(if ([string]::IsNullOrWhiteSpace($GroupId)) { $null } else { $GroupLookup[$GroupId] }))
+                }
+                '#microsoft.graph.exclusionGroupAssignmentTarget' {
+                    $GroupId = [string]$Target.groupId
+                    $PolicyExclude.Add($(if ([string]::IsNullOrWhiteSpace($GroupId)) { $null } else { $GroupLookup[$GroupId] }))
+                }
+                default {
+                    $PolicyAssignment.Add($null)
+                    $PolicyExclude.Add($null)
+                }
+            }
+        }
+
+        $Policy | Add-Member -NotePropertyName PolicyTypeName -NotePropertyValue $PolicyTypeName -Force
+        $Policy | Add-Member -NotePropertyName URLName -NotePropertyValue $URLName -Force
+        $Policy | Add-Member -NotePropertyName PolicyAssignment -NotePropertyValue ($PolicyAssignment -join ', ') -Force
+        $Policy | Add-Member -NotePropertyName PolicyExclude -NotePropertyValue ($PolicyExclude -join ', ') -Force
+        $Policy
+    }
+}

--- a/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicyListDefinitions.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicyListDefinitions.ps1
@@ -1,0 +1,99 @@
+function Get-CIPPIntunePolicyListDefinitions {
+    <#
+    .SYNOPSIS
+        Returns the canonical Intune policy families shown by ListIntunePolicy.
+
+    .DESCRIPTION
+        Keeps the live endpoint, reporting cache collector, and cached report reader
+        aligned on policy family identifiers, cache keys, Graph requests, and fallback
+        policy type labels. CacheUri may request additional fields needed by standards
+        and reports while preserving the same collection and filters as GraphUri.
+    #>
+    [CmdletBinding()]
+    param()
+
+    @(
+        [PSCustomObject]@{
+            Id                  = 'DeviceConfigurations'
+            CacheType           = 'IntuneDeviceConfigurations'
+            GraphUri            = '/deviceManagement/deviceConfigurations?$select=id,displayName,lastModifiedDateTime,roleScopeTagIds,microsoft.graph.unsupportedDeviceConfiguration/originalEntityTypeName,description&$expand=assignments&$top=1000'
+            CacheUri            = '/deviceManagement/deviceConfigurations?$top=999&$expand=assignments'
+            PolicyTypeName      = $null
+            FetchDeviceStatuses = $true
+        }
+        [PSCustomObject]@{
+            Id             = 'WindowsDriverUpdateProfiles'
+            CacheType      = 'IntuneWindowsDriverUpdateProfiles'
+            GraphUri       = '/deviceManagement/windowsDriverUpdateProfiles?$expand=assignments&$top=200'
+            CacheUri       = '/deviceManagement/windowsDriverUpdateProfiles?$expand=assignments&$top=200'
+            PolicyTypeName = 'Driver Update'
+        }
+        [PSCustomObject]@{
+            Id             = 'WindowsFeatureUpdateProfiles'
+            CacheType      = 'IntuneWindowsFeatureUpdateProfiles'
+            GraphUri       = '/deviceManagement/windowsFeatureUpdateProfiles?$expand=assignments&$top=200'
+            CacheUri       = '/deviceManagement/windowsFeatureUpdateProfiles?$expand=assignments&$top=200'
+            PolicyTypeName = 'Feature Update'
+        }
+        [PSCustomObject]@{
+            Id             = 'windowsQualityUpdatePolicies'
+            CacheType      = 'IntuneWindowsQualityUpdatePolicies'
+            GraphUri       = '/deviceManagement/windowsQualityUpdatePolicies?$expand=assignments&$top=200'
+            CacheUri       = '/deviceManagement/windowsQualityUpdatePolicies?$expand=assignments&$top=200'
+            PolicyTypeName = 'Quality Update'
+        }
+        [PSCustomObject]@{
+            Id             = 'windowsQualityUpdateProfiles'
+            CacheType      = 'IntuneWindowsQualityUpdateProfiles'
+            GraphUri       = '/deviceManagement/windowsQualityUpdateProfiles?$expand=assignments&$top=200'
+            CacheUri       = '/deviceManagement/windowsQualityUpdateProfiles?$expand=assignments&$top=200'
+            PolicyTypeName = 'Quality Update'
+        }
+        [PSCustomObject]@{
+            Id             = 'GroupPolicyConfigurations'
+            CacheType      = 'IntuneGroupPolicyConfigurations'
+            GraphUri       = '/deviceManagement/groupPolicyConfigurations?$expand=assignments&$top=1000'
+            CacheUri       = '/deviceManagement/groupPolicyConfigurations?$expand=assignments&$top=1000'
+            PolicyTypeName = 'Administrative Templates'
+        }
+        [PSCustomObject]@{
+            Id             = 'MobileAppConfigurations'
+            CacheType      = 'IntuneMobileAppConfigurations'
+            GraphUri       = '/deviceAppManagement/mobileAppConfigurations?$expand=assignments&$filter=microsoft.graph.androidManagedStoreAppConfiguration/appSupportsOemConfig%20eq%20true'
+            CacheUri       = '/deviceAppManagement/mobileAppConfigurations?$expand=assignments&$filter=microsoft.graph.androidManagedStoreAppConfiguration/appSupportsOemConfig%20eq%20true'
+            PolicyTypeName = $null
+        }
+        [PSCustomObject]@{
+            Id             = 'ConfigurationPolicies'
+            CacheType      = 'IntuneConfigurationPolicies'
+            GraphUri       = '/deviceManagement/configurationPolicies?$expand=assignments&$top=1000'
+            CacheUri       = '/deviceManagement/configurationPolicies?$expand=assignments,settings&$top=1000'
+            PolicyTypeName = 'Device Configuration'
+        }
+        [PSCustomObject]@{
+            Id                  = 'deviceCompliancePolicies'
+            CacheType           = 'IntuneDeviceCompliancePolicies'
+            GraphUri            = '/deviceManagement/deviceCompliancePolicies?$expand=assignments&$top=1000'
+            CacheUri            = '/deviceManagement/deviceCompliancePolicies?$expand=assignments&$top=1000'
+            PolicyTypeName      = 'Compliance Policy'
+            FetchDeviceStatuses = $true
+        }
+        [PSCustomObject]@{
+            Id             = 'Intents'
+            CacheType      = 'IntuneIntents'
+            GraphUri       = '/deviceManagement/intents?$top=1000'
+            CacheUri       = '/deviceManagement/intents?$top=1000'
+            PolicyTypeName = 'Endpoint Security'
+        }
+        [PSCustomObject]@{
+            Id               = 'ManagedAppPolicies'
+            CacheType        = 'IntuneAppProtectionPolicies'
+            GraphUri         = '/deviceAppManagement/managedAppPolicies?$orderby=displayName'
+            CacheUri         = '/deviceAppManagement/managedAppPolicies?$orderby=displayName'
+            PolicyTypeName   = 'App Protection'
+            # Assignments are exposed by the concrete managed app policy resources,
+            # not the generic collection used by the live policy list.
+            FetchAssignments = $false
+        }
+    )
+}

--- a/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicyReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicyReport.ps1
@@ -4,26 +4,11 @@ function Get-CIPPIntunePolicyReport {
         Returns the Intune configuration policy list from the CIPP reporting database
 
     .DESCRIPTION
-        Retrieves cached Intune policy data for a tenant, applies the same assignment name
-        resolution and PolicyTypeName enrichment as the live Invoke-ListIntunePolicy endpoint,
-        and returns a payload in the same shape.
-
-        Note: The Windows update profile types (WindowsDriverUpdateProfiles,
-        WindowsFeatureUpdateProfiles, windowsQualityUpdatePolicies, windowsQualityUpdateProfiles)
-        are not currently cached; only the four types below are retrieved from cache:
-            - DeviceConfigurations
-            - ConfigurationPolicies
-            - GroupPolicyConfigurations
-            - MobileAppConfigurations
+        Retrieves every policy family defined by Get-CIPPIntunePolicyListDefinitions,
+        then applies the same normalization used by the live ListIntunePolicy endpoint.
 
     .PARAMETER TenantFilter
         Tenant domain name or 'AllTenants'
-
-    .EXAMPLE
-        Get-CIPPIntunePolicyReport -TenantFilter 'contoso.onmicrosoft.com'
-
-    .EXAMPLE
-        Get-CIPPIntunePolicyReport -TenantFilter 'AllTenants'
     #>
     [CmdletBinding()]
     param(
@@ -31,20 +16,10 @@ function Get-CIPPIntunePolicyReport {
         [string]$TenantFilter
     )
 
-    # Maps DB cache type key -> Graph URL segment (URLName used by actions/deploy)
-    $PolicyTypeMap = [ordered]@{
-        IntuneDeviceConfigurations         = 'DeviceConfigurations'
-        IntuneConfigurationPolicies        = 'ConfigurationPolicies'
-        IntuneGroupPolicyConfigurations    = 'GroupPolicyConfigurations'
-        IntuneMobileAppConfigurations      = 'MobileAppConfigurations'
-        IntuneWindowsDriverUpdateProfiles  = 'WindowsDriverUpdateProfiles'
-        IntuneWindowsFeatureUpdateProfiles = 'WindowsFeatureUpdateProfiles'
-        IntuneWindowsQualityUpdatePolicies = 'WindowsQualityUpdatePolicies'
-        IntuneWindowsQualityUpdateProfiles = 'WindowsQualityUpdateProfiles'
-    }
-
+    $PolicyDefinitions = @(Get-CIPPIntunePolicyListDefinitions)
     $IsAllTenants = $TenantFilter -eq 'AllTenants'
     if ($IsAllTenants) {
+        # Cross-partition cache scans can retain rows for tenants no longer in scope.
         $TenantList = Get-Tenants -IncludeErrors
         $ValidTenants = [System.Collections.Generic.HashSet[string]]::new(
             [string[]]@($TenantList.defaultDomainName),
@@ -56,103 +31,110 @@ function Get-CIPPIntunePolicyReport {
     }
 
     try {
-        # Load group display names into a hashtable for O(1) lookups
-        $GroupLookup = @{}
-        $GroupItems = @(Get-CIPPDbItem -TenantFilter $DbTenantFilter -Type 'Groups' |
-            Where-Object { $_.RowKey -notlike '*-Count' })
-        foreach ($GroupItem in $GroupItems) {
+        # Prefer the group snapshot collected with IntunePolicies so assignment
+        # names match live immediately after a policy sync. Read the normal Groups
+        # cache only for tenants that do not have an Intune policy group snapshot.
+        $GroupLookupByTenant = @{}
+        $SnapshotTenants = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $IntuneGroupItems = @(Get-CIPPDbItem -TenantFilter $DbTenantFilter -Type 'IntunePolicyGroups')
+        foreach ($GroupItem in $IntuneGroupItems) {
+            if ($IsAllTenants -and -not $ValidTenants.Contains($GroupItem.PartitionKey)) { continue }
+
+            $GroupTenant = if ($IsAllTenants) { $GroupItem.PartitionKey } else { $TenantFilter }
+            [void]$SnapshotTenants.Add($GroupTenant)
+            # A count row also marks a completed, authoritative empty snapshot.
+            if ($GroupItem.RowKey -like '*-Count') { continue }
+
             $GroupObj = try { $GroupItem.Data | ConvertFrom-Json -ErrorAction Stop } catch { $null }
-            if ($GroupObj.id) { $GroupLookup[$GroupObj.id] = $GroupObj.displayName }
+            if (-not $GroupObj.id) { continue }
+            if (-not $GroupLookupByTenant.ContainsKey($GroupTenant)) {
+                $GroupLookupByTenant[$GroupTenant] = @{}
+            }
+            $GroupLookupByTenant[$GroupTenant][$GroupObj.id] = $GroupObj.displayName
         }
 
+        $FallbackTenants = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        if ($IsAllTenants) {
+            foreach ($Tenant in $ValidTenants) {
+                if (-not $SnapshotTenants.Contains($Tenant)) { [void]$FallbackTenants.Add($Tenant) }
+            }
+        } elseif (-not $SnapshotTenants.Contains($TenantFilter)) {
+            [void]$FallbackTenants.Add($TenantFilter)
+        }
+
+        if ($FallbackTenants.Count -gt 0) {
+            # One cross-partition fallback read is cheaper than one query per missing tenant.
+            $GroupItems = @(Get-CIPPDbItem -TenantFilter $DbTenantFilter -Type 'Groups')
+            foreach ($GroupItem in $GroupItems) {
+                if ($GroupItem.RowKey -like '*-Count') { continue }
+
+                $GroupTenant = if ($IsAllTenants) { $GroupItem.PartitionKey } else { $TenantFilter }
+                if (-not $FallbackTenants.Contains($GroupTenant)) { continue }
+
+                $GroupObj = try { $GroupItem.Data | ConvertFrom-Json -ErrorAction Stop } catch { $null }
+                if (-not $GroupObj.id) { continue }
+                if (-not $GroupLookupByTenant.ContainsKey($GroupTenant)) {
+                    $GroupLookupByTenant[$GroupTenant] = @{}
+                }
+                $GroupLookupByTenant[$GroupTenant][$GroupObj.id] = $GroupObj.displayName
+            }
+        }
+
+        $CachedFamilies = [System.Collections.Generic.List[object]]::new()
         $CacheTimestamp = $null
-        $AllPolicies = [System.Collections.Generic.List[PSCustomObject]]::new()
-
-        foreach ($TypeKey in $PolicyTypeMap.Keys) {
-            $URLNameValue = $PolicyTypeMap[$TypeKey]
-
-            $Items = @(Get-CIPPDbItem -TenantFilter $DbTenantFilter -Type $TypeKey |
-                Where-Object { $_.RowKey -notlike '*-Count' })
+        # Collect families first so every returned row receives the same latest timestamp.
+        foreach ($Definition in $PolicyDefinitions) {
+            $Items = @(Get-CIPPDbItem -TenantFilter $DbTenantFilter -Type $Definition.CacheType |
+                    Where-Object { $_.RowKey -notlike '*-Count' })
 
             if (-not $Items) { continue }
+            $CachedFamilies.Add([PSCustomObject]@{
+                    Definition = $Definition
+                    Items      = $Items
+                })
 
-            # Track cache timestamp for single-tenant requests
             if (-not $IsAllTenants) {
                 $TypeTimestamp = ($Items | Where-Object { $_.Timestamp } | Sort-Object Timestamp -Descending | Select-Object -First 1).Timestamp
                 if ($null -eq $CacheTimestamp -or ($TypeTimestamp -and $TypeTimestamp -gt $CacheTimestamp)) {
                     $CacheTimestamp = $TypeTimestamp
                 }
             }
+        }
 
-            foreach ($Item in $Items) {
+        $AllPolicies = [System.Collections.Generic.List[PSCustomObject]]::new()
+        foreach ($Family in $CachedFamilies) {
+            foreach ($Item in $Family.Items) {
                 if ($IsAllTenants -and -not $ValidTenants.Contains($Item.PartitionKey)) { continue }
 
-                $Policy = try { $Item.Data | ConvertFrom-Json -Depth 10 -ErrorAction Stop } catch { continue }
+                # Keep assignment lookups isolated by tenant during AllTenants reports.
+                $PolicyTenant = if ($IsAllTenants) { $Item.PartitionKey } else { $TenantFilter }
+                try {
+                    $Policy = $Item.Data | ConvertFrom-Json -Depth 25 -ErrorAction Stop
+                } catch {
+                    Write-LogMessage -API 'IntunePolicyReport' -tenant $PolicyTenant -message "Failed to parse cached Intune policy item '$($Item.RowKey)' from '$($Family.Definition.CacheType)': $($_.Exception.Message)" -sev Warning -LogData (Get-CippException -Exception $_)
+                    continue
+                }
                 if ($null -eq $Policy) { continue }
 
-                # Determine PolicyTypeName using the same switch as the live endpoint
-                $policyTypeName = switch -Wildcard ($Policy.'assignments@odata.context') {
-                    '*microsoft.graph.windowsIdentityProtectionConfiguration*' { 'Identity Protection' }
-                    '*microsoft.graph.windows10EndpointProtectionConfiguration*' { 'Endpoint Protection' }
-                    '*microsoft.graph.windows10CustomConfiguration*' { 'Custom' }
-                    '*microsoft.graph.windows10DeviceFirmwareConfigurationInterface*' { 'Firmware Configuration' }
-                    '*groupPolicyConfigurations*' { 'Administrative Templates' }
-                    '*windowsDomainJoinConfiguration*' { 'Domain Join configuration' }
-                    '*windowsUpdateForBusinessConfiguration*' { 'Update Configuration' }
-                    '*windowsHealthMonitoringConfiguration*' { 'Health Monitoring' }
-                    '*microsoft.graph.macOSGeneralDeviceConfiguration*' { 'MacOS Configuration' }
-                    '*microsoft.graph.macOSEndpointProtectionConfiguration*' { 'MacOS Endpoint Protection' }
-                    '*microsoft.graph.androidWorkProfileGeneralDeviceConfiguration*' { 'Android Configuration' }
-                    '*windowsFeatureUpdateProfiles*' { 'Feature Update' }
-                    '*windowsQualityUpdatePolicies*' { 'Quality Update' }
-                    '*windowsQualityUpdateProfiles*' { 'Quality Update' }
-                    '*iosUpdateConfiguration*' { 'iOS Update Configuration' }
-                    '*windowsDriverUpdateProfiles*' { 'Driver Update' }
-                    '*configurationPolicies*' { 'Device Configuration' }
-                    default { $Policy.'assignments@odata.context' }
-                }
-
-                # Resolve assignment names from cached group data
-                $Assignments = $Policy.assignments.target | Select-Object -Property '@odata.type', groupId
-                $PolicyAssignment = [System.Collections.Generic.List[string]]::new()
-                $PolicyExclude = [System.Collections.Generic.List[string]]::new()
-
-                foreach ($target in $Assignments) {
-                    switch ($target.'@odata.type') {
-                        '#microsoft.graph.allDevicesAssignmentTarget' { $PolicyAssignment.Add('All Devices') }
-                        '#microsoft.graph.exclusionallDevicesAssignmentTarget' { $PolicyExclude.Add('All Devices') }
-                        '#microsoft.graph.allUsersAssignmentTarget' { $PolicyAssignment.Add('All Users') }
-                        '#microsoft.graph.allLicensedUsersAssignmentTarget' { $PolicyAssignment.Add('All Licenced Users') }
-                        '#microsoft.graph.exclusionallUsersAssignmentTarget' { $PolicyExclude.Add('All Users') }
-                        '#microsoft.graph.groupAssignmentTarget' { $PolicyAssignment.Add($GroupLookup[$target.groupId]) }
-                        '#microsoft.graph.exclusionGroupAssignmentTarget' { $PolicyExclude.Add($GroupLookup[$target.groupId]) }
-                        default {
-                            $PolicyAssignment.Add($null)
-                            $PolicyExclude.Add($null)
-                        }
-                    }
-                }
-
-                if ($null -eq $Policy.displayName) {
-                    $Policy | Add-Member -NotePropertyName displayName -NotePropertyValue $Policy.name -Force
-                }
-                $Policy | Add-Member -NotePropertyName PolicyTypeName -NotePropertyValue $policyTypeName -Force
-                $Policy | Add-Member -NotePropertyName URLName -NotePropertyValue $URLNameValue -Force
-                $Policy | Add-Member -NotePropertyName PolicyAssignment -NotePropertyValue ($PolicyAssignment -join ', ') -Force
-                $Policy | Add-Member -NotePropertyName PolicyExclude -NotePropertyValue ($PolicyExclude -join ', ') -Force
-                if ($IsAllTenants) {
-                    $Policy | Add-Member -NotePropertyName Tenant -NotePropertyValue $Item.PartitionKey -Force
+                $GroupLookup = if ($GroupLookupByTenant.ContainsKey($PolicyTenant)) {
+                    $GroupLookupByTenant[$PolicyTenant]
                 } else {
-                    $Policy | Add-Member -NotePropertyName CacheTimestamp -NotePropertyValue $CacheTimestamp -Force
+                    @{}
                 }
 
-                $AllPolicies.Add($Policy)
+                $NormalizedPolicy = ConvertTo-CIPPIntunePolicyListItem -Policy $Policy -URLName $Family.Definition.Id -DefaultPolicyTypeName $Family.Definition.PolicyTypeName -GroupLookup $GroupLookup
+                if ($null -eq $NormalizedPolicy) { continue }
+
+                if ($IsAllTenants) {
+                    $NormalizedPolicy | Add-Member -NotePropertyName Tenant -NotePropertyValue $Item.PartitionKey -Force
+                } else {
+                    $NormalizedPolicy | Add-Member -NotePropertyName CacheTimestamp -NotePropertyValue $CacheTimestamp -Force
+                }
+                $AllPolicies.Add($NormalizedPolicy)
             }
         }
 
-        # Apply the same filters as the live endpoint
-        return ($AllPolicies | Where-Object { $_.platforms -ne 'linux' -and $_.templateReference.templateFamily -ne 'deviceConfigurationScripts' -and $null -ne $_.displayName } | Sort-Object -Property displayName)
-
+        return ($AllPolicies | Sort-Object -Property displayName)
     } catch {
         Write-LogMessage -API 'IntunePolicyReport' -tenant $TenantFilter -message "Failed to generate Intune policy report: $($_.Exception.Message)" -sev Error -LogData (Get-CippException -Exception $_)
         throw

--- a/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheIntunePolicies.ps1
+++ b/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheIntunePolicies.ps1
@@ -26,129 +26,197 @@ function Set-CIPPDBCacheIntunePolicies {
 
         Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Caching Intune policies' -sev Debug
 
-        $PolicyTypes = @(
-            @{ Type = 'DeviceCompliancePolicies'; Uri = '/deviceManagement/deviceCompliancePolicies?$top=999&$expand=assignments'; FetchDeviceStatuses = $true }
-            @{ Type = 'DeviceConfigurations'; Uri = '/deviceManagement/deviceConfigurations?$top=999&$expand=assignments'; FetchDeviceStatuses = $true }
-            @{ Type = 'ConfigurationPolicies'; Uri = '/deviceManagement/configurationPolicies?$top=999&$expand=assignments,settings' }
-            @{ Type = 'GroupPolicyConfigurations'; Uri = '/deviceManagement/groupPolicyConfigurations?$top=999&$expand=assignments' }
-            @{ Type = 'MobileAppConfigurations'; Uri = '/deviceManagement/mobileAppConfigurations?$top=999&$expand=assignments' }
-            @{ Type = 'AppProtectionPolicies'; Uri = '/deviceAppManagement/managedAppPolicies?$top=999'; FetchAssignments = $true }
-            @{ Type = 'WindowsAutopilotDeploymentProfiles'; Uri = '/deviceManagement/windowsAutopilotDeploymentProfiles?$top=999&$expand=assignments' }
-            @{ Type = 'DeviceEnrollmentConfigurations'; Uri = '/deviceManagement/deviceEnrollmentConfigurations?$top=999'; FetchAssignments = $true }
-            @{ Type = 'DeviceManagementScripts'; Uri = '/deviceManagement/deviceManagementScripts?$top=999&$expand=assignments' }
-            @{ Type = 'MobileApps'; Uri = '/deviceAppManagement/mobileApps?$top=999&$select=id,displayName,description,publisher,isAssigned,createdDateTime,lastModifiedDateTime'; FetchAssignments = $true }
-            @{ Type = 'WindowsDriverUpdateProfiles'; Uri = '/deviceManagement/windowsDriverUpdateProfiles?$top=200&$expand=assignments' }
-            @{ Type = 'WindowsFeatureUpdateProfiles'; Uri = '/deviceManagement/windowsFeatureUpdateProfiles?$top=200&$expand=assignments' }
-            @{ Type = 'WindowsQualityUpdatePolicies'; Uri = '/deviceManagement/windowsQualityUpdatePolicies?$top=200&$expand=assignments' }
-            @{ Type = 'WindowsQualityUpdateProfiles'; Uri = '/deviceManagement/windowsQualityUpdateProfiles?$top=200&$expand=assignments' }
-        )
+        # Family failures are accumulated so healthy families can still refresh.
+        $Warnings = [System.Collections.Generic.List[string]]::new()
+        $AddWarning = {
+            param([string]$Message)
+            $Warnings.Add($Message)
+            Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message $Message -sev Warning
+        }
 
-        # Build bulk requests for all policy types
-        Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Fetching all policy types using bulk request' -sev Debug
-        $PolicyRequests = foreach ($PolicyType in $PolicyTypes) {
-            [PSCustomObject]@{
-                id     = $PolicyType.Type
+        # The report-backed families come from the same canonical definition as
+        # Invoke-ListIntunePolicy and Get-CIPPIntunePolicyReport.
+        $PolicyTypes = [System.Collections.Generic.List[object]]::new()
+        foreach ($Definition in @(Get-CIPPIntunePolicyListDefinitions)) {
+            $PolicyTypes.Add([PSCustomObject]@{
+                    Type                  = $Definition.Id
+                    CacheType             = $Definition.CacheType
+                    Uri                   = $Definition.CacheUri
+                    FetchDeviceStatuses   = [bool]$Definition.FetchDeviceStatuses
+                    FetchAssignments      = [bool]$Definition.FetchAssignments
+                    IncludeInPolicyReport = $true
+                })
+        }
+
+        # Preserve the additional datasets historically collected by IntunePolicies.
+        foreach ($LegacyType in @(
+                [PSCustomObject]@{ Type = 'WindowsAutopilotDeploymentProfiles'; CacheType = 'IntuneWindowsAutopilotDeploymentProfiles'; Uri = '/deviceManagement/windowsAutopilotDeploymentProfiles?$top=999&$expand=assignments' }
+                [PSCustomObject]@{ Type = 'DeviceEnrollmentConfigurations'; CacheType = 'IntuneDeviceEnrollmentConfigurations'; Uri = '/deviceManagement/deviceEnrollmentConfigurations?$top=999'; FetchAssignments = $true }
+                [PSCustomObject]@{ Type = 'DeviceManagementScripts'; CacheType = 'IntuneDeviceManagementScripts'; Uri = '/deviceManagement/deviceManagementScripts?$top=999&$expand=assignments' }
+                [PSCustomObject]@{ Type = 'MobileApps'; CacheType = 'IntuneMobileApps'; Uri = '/deviceAppManagement/mobileApps?$top=999&$select=id,displayName,description,publisher,isAssigned,createdDateTime,lastModifiedDateTime'; FetchAssignments = $true }
+            )) {
+            $PolicyTypes.Add($LegacyType)
+        }
+
+        $PolicyRequests = [System.Collections.Generic.List[object]]::new()
+        $PolicyRequests.Add([PSCustomObject]@{
+                id     = 'Groups'
                 method = 'GET'
-                url    = $PolicyType.Uri
-            }
+                url    = '/groups?$top=999&$select=id,displayName'
+            })
+        foreach ($PolicyType in $PolicyTypes) {
+            $PolicyRequests.Add([PSCustomObject]@{
+                    id     = $PolicyType.Type
+                    method = 'GET'
+                    url    = $PolicyType.Uri
+                })
         }
 
         try {
-            $PolicyResults = New-GraphBulkRequest -Requests @($PolicyRequests) -tenantid $TenantFilter
+            $PolicyResults = @(New-GraphBulkRequest -Requests @($PolicyRequests) -tenantid $TenantFilter)
         } catch {
             Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Failed to fetch policies in bulk: $($_.Exception.Message)" -sev Error
             throw
         }
 
-        # Process each policy type result
-        foreach ($Result in $PolicyResults) {
-            $PolicyType = $PolicyTypes | Where-Object { $_.Type -eq $Result.id }
-            if (-not $PolicyType) { continue }
+        # Cache the group snapshot used by this report without overwriting the richer,
+        # tenant-wide Groups cache used elsewhere.
+        $GroupResult = $PolicyResults | Where-Object { $_.id -eq 'Groups' } | Select-Object -First 1
+        # Replace cached rows only after Graph confirms a successful 2xx response.
+        if (-not $GroupResult) {
+            & $AddWarning 'Intune policy group lookup returned no batch response; preserving the previous group snapshot'
+        } elseif ($null -eq $GroupResult.status) {
+            & $AddWarning 'Intune policy group lookup returned no HTTP status; preserving the previous group snapshot'
+        } elseif ([int]$GroupResult.status -lt 200 -or [int]$GroupResult.status -ge 300) {
+            $GroupError = $GroupResult.body.error.message ?? $GroupResult.body.message ?? 'Unknown Graph error'
+            & $AddWarning "Intune policy group lookup failed with HTTP $($GroupResult.status): $GroupError; preserving the previous group snapshot"
+        } else {
+            $Groups = @($GroupResult.body.value)
+            Add-CIPPDbItem -TenantFilter $TenantFilter -Type 'IntunePolicyGroups' -Data $Groups -AddCount -ClearOnEmpty
+        }
+
+        $SuccessfulPolicyTypes = 0
+        $SuccessfulReportTypes = 0
+        foreach ($PolicyType in $PolicyTypes) {
+            $Result = $PolicyResults | Where-Object { $_.id -eq $PolicyType.Type } | Select-Object -First 1
+            if (-not $Result) {
+                & $AddWarning "No Graph batch response was returned for $($PolicyType.Type); preserving the previous cache"
+                continue
+            }
+
+            # A missing status is not authoritative; retain the last good family cache.
+            if ($null -eq $Result.status) {
+                & $AddWarning "No HTTP status was returned for $($PolicyType.Type); preserving the previous cache"
+                continue
+            }
+
+            if ([int]$Result.status -lt 200 -or [int]$Result.status -ge 300) {
+                $GraphError = $Result.body.error.message ?? $Result.body.message ?? 'Unknown Graph error'
+                & $AddWarning "Failed to cache $($PolicyType.Type): HTTP $($Result.status) - $GraphError; preserving the previous cache"
+                continue
+            }
 
             try {
-                $Policies = $Result.body.value ?? $Result.body
-
-                if (-not $Policies) {
-                    Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "No policies found for $($PolicyType.Type)" -sev Debug
-                    continue
+                # Most Graph results wrap rows in value; retain direct-body support for legacy types.
+                $Policies = if ($Result.body.PSObject.Properties.Name -contains 'value') {
+                    @($Result.body.value)
+                } elseif ($null -ne $Result.body) {
+                    @($Result.body)
+                } else {
+                    @()
                 }
 
-                # Get assignments for policies that don't support expand using bulk requests
-                if ($PolicyType.FetchAssignments -and ($Policies | Measure-Object).Count -gt 0) {
-                    Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Fetching assignments for $($Policies.Count) $($PolicyType.Type) using bulk request" -sev Debug
-
+                # Get assignments only for legacy collections whose list endpoints do
+                # not support expand. Report-backed ManagedAppPolicies intentionally
+                # remains identical to the live endpoint and does not use this fan-out.
+                if ($PolicyType.FetchAssignments -and $Policies.Count -gt 0) {
                     $BaseUri = ($PolicyType.Uri -split '\?')[0]
-                    # Build bulk request array for assignments
-                    $AssignmentRequests = $Policies | ForEach-Object {
-                        [PSCustomObject]@{
-                            id     = $_.id
-                            method = 'GET'
-                            url    = "$BaseUri/$($_.id)/assignments"
-                        }
-                    }
+                    $AssignmentRequests = @($Policies | ForEach-Object {
+                            [PSCustomObject]@{
+                                id     = $_.id
+                                method = 'GET'
+                                url    = "$BaseUri/$($_.id)/assignments"
+                            }
+                        })
 
                     try {
-                        $AssignmentResults = New-GraphBulkRequest -Requests @($AssignmentRequests) -tenantid $TenantFilter
+                        $AssignmentResults = @(New-GraphBulkRequest -Requests $AssignmentRequests -tenantid $TenantFilter)
+                        foreach ($AssignResult in $AssignmentResults) {
+                            if ($null -eq $AssignResult.status) {
+                                & $AddWarning "No HTTP status was returned while fetching assignments for $($PolicyType.Type) policy $($AssignResult.id)"
+                                continue
+                            } elseif ([int]$AssignResult.status -lt 200 -or [int]$AssignResult.status -ge 300) {
+                                & $AddWarning "Failed to fetch assignments for $($PolicyType.Type) policy $($AssignResult.id): HTTP $($AssignResult.status)"
+                                continue
+                            }
 
-                        if ($AssignmentResults) {
-                            foreach ($AssignResult in $AssignmentResults) {
-                                $Policy = $Policies | Where-Object { $_.id -eq $AssignResult.id }
-                                if ($Policy) {
-                                    $Assignments = $AssignResult.body.value ?? $AssignResult.body
-                                    $Policy | Add-Member -NotePropertyName 'assignments' -NotePropertyValue $Assignments -Force
-                                }
+                            $Policy = $Policies | Where-Object { $_.id -eq $AssignResult.id } | Select-Object -First 1
+                            if ($Policy) {
+                                $Assignments = @($AssignResult.body.value)
+                                $Policy | Add-Member -NotePropertyName assignments -NotePropertyValue $Assignments -Force
                             }
                         }
                     } catch {
-                        Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Failed to fetch assignments in bulk for $($PolicyType.Type): $($_.Exception.Message)" -sev Warning
+                        & $AddWarning "Failed to fetch assignments for $($PolicyType.Type): $($_.Exception.Message)"
                     }
                 }
 
-                Add-CIPPDbItem -TenantFilter $TenantFilter -Type "Intune$($PolicyType.Type)" -Data $Policies -AddCount
+                Add-CIPPDbItem -TenantFilter $TenantFilter -Type $PolicyType.CacheType -Data $Policies -AddCount -ClearOnEmpty
+                $SuccessfulPolicyTypes++
+                # Legacy-only success must not make an empty policy report look healthy.
+                if ($PolicyType.IncludeInPolicyReport) { $SuccessfulReportTypes++ }
                 Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Cached $($Policies.Count) $($PolicyType.Type)" -sev Debug
 
-                if ($PolicyType.FetchDeviceStatuses -and ($Policies | Measure-Object).Count -gt 0) {
-                    Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Fetching device statuses for $($Policies.Count) $($PolicyType.Type) using bulk request" -sev Debug
-
+                if ($PolicyType.FetchDeviceStatuses -and $Policies.Count -gt 0) {
                     $BaseUri = ($PolicyType.Uri -split '\?')[0]
-                    # Build bulk request array
-                    $DeviceStatusRequests = $Policies | ForEach-Object {
-                        [PSCustomObject]@{
-                            id     = $_.id
-                            method = 'GET'
-                            url    = "$BaseUri/$($_.id)/deviceStatuses?`$top=999"
-                        }
-                    }
+                    $DeviceStatusRequests = @($Policies | ForEach-Object {
+                            [PSCustomObject]@{
+                                id     = $_.id
+                                method = 'GET'
+                                url    = "$BaseUri/$($_.id)/deviceStatuses?`$top=999"
+                            }
+                        })
 
                     try {
-                        $DeviceStatusResults = New-GraphBulkRequest -Requests @($DeviceStatusRequests) -tenantid $TenantFilter
+                        $DeviceStatusResults = @(New-GraphBulkRequest -Requests $DeviceStatusRequests -tenantid $TenantFilter)
+                        foreach ($StatusResult in $DeviceStatusResults) {
+                            if ($null -eq $StatusResult.status) {
+                                & $AddWarning "No HTTP status was returned while fetching device statuses for $($PolicyType.Type) policy $($StatusResult.id)"
+                                continue
+                            } elseif ([int]$StatusResult.status -lt 200 -or [int]$StatusResult.status -ge 300) {
+                                & $AddWarning "Failed to fetch device statuses for $($PolicyType.Type) policy $($StatusResult.id): HTTP $($StatusResult.status)"
+                                continue
+                            }
 
-                        if ($DeviceStatusResults) {
-                            foreach ($StatusResult in $DeviceStatusResults) {
-                                $Data = $StatusResult.body.value ?? $StatusResult.body
-                                if ($Data) {
-                                    # Store device statuses with policy ID in the type name (matching extension cache pattern)
-                                    $StatusType = "Intune$($PolicyType.Type)_$($StatusResult.id)"
-                                    Add-CIPPDbItem -TenantFilter $TenantFilter -Type $StatusType -Data $Data
-                                    Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Cached $(($Data | Measure-Object).Count) device statuses for policy ID $($StatusResult.id)" -sev Debug
-                                }
+                            $Data = @($StatusResult.body.value)
+                            if ($Data.Count -gt 0) {
+                                $StatusType = "$($PolicyType.CacheType)_$($StatusResult.id)"
+                                Add-CIPPDbItem -TenantFilter $TenantFilter -Type $StatusType -Data $Data
+                                Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Cached $($Data.Count) device statuses for policy ID $($StatusResult.id)" -sev Debug
                             }
                         }
                     } catch {
-                        Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Failed to fetch device statuses in bulk: $($_.Exception.Message)" -sev Warning
+                        & $AddWarning "Failed to fetch device statuses for $($PolicyType.Type): $($_.Exception.Message)"
                     }
                 }
-
-                $Policies = $null
-
             } catch {
-                Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Failed to cache $($PolicyType.Type): $($_.Exception.Message)" -sev Warning
+                & $AddWarning "Failed to process $($PolicyType.Type): $($_.Exception.Message); preserving any rows not replaced by this run"
             }
         }
 
-        Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Cached Intune policies successfully' -sev Debug
+        if ($SuccessfulPolicyTypes -eq 0 -or $SuccessfulReportTypes -eq 0) {
+            throw 'No report-backed Intune policy families were cached successfully'
+        }
 
+        if ($Warnings.Count -gt 0) {
+            $Summary = "Cached Intune policies with $($Warnings.Count) warning(s): $($Warnings -join '; ')"
+            Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message $Summary -sev Warning
+            Write-Warning $Summary
+        } else {
+            Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message 'Cached Intune policies successfully' -sev Debug
+        }
     } catch {
         Write-LogMessage -API 'CIPPDBCache' -tenant $TenantFilter -message "Failed to cache Intune policies: $($_.Exception.Message)" -sev Error
+        throw
     }
 }

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListIntunePolicy.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListIntunePolicy.ps1
@@ -169,143 +169,40 @@ function Invoke-ListIntunePolicy {
                 $GraphRequest = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/deviceManagement/$($URLName)('$ID')" -tenantid $TenantFilter
             }
         } else {
-            $BulkRequests = [PSCustomObject]@(
-                @{
+            $PolicyDefinitions = @(Get-CIPPIntunePolicyListDefinitions)
+            $BulkRequests = [System.Collections.Generic.List[object]]::new()
+            # Fetch group names in the same batch snapshot used to render policy assignments.
+            $BulkRequests.Add([PSCustomObject]@{
                     id     = 'Groups'
                     method = 'GET'
                     url    = '/groups?$top=999&$select=id,displayName'
-                }
-                @{
-                    id     = 'DeviceConfigurations'
-                    method = 'GET'
-                    url    = "/deviceManagement/deviceConfigurations?`$select=id,displayName,lastModifiedDateTime,roleScopeTagIds,microsoft.graph.unsupportedDeviceConfiguration/originalEntityTypeName,description&`$expand=assignments&`$top=1000"
-                }
-                @{
-                    id     = 'WindowsDriverUpdateProfiles'
-                    method = 'GET'
-                    url    = "/deviceManagement/windowsDriverUpdateProfiles?`$expand=assignments&`$top=200"
-                }
-                @{
-                    id     = 'WindowsFeatureUpdateProfiles'
-                    method = 'GET'
-                    url    = "/deviceManagement/windowsFeatureUpdateProfiles?`$expand=assignments&`$top=200"
-                }
-                @{
-                    id     = 'windowsQualityUpdatePolicies'
-                    method = 'GET'
-                    url    = "/deviceManagement/windowsQualityUpdatePolicies?`$expand=assignments&`$top=200"
-                }
-                @{
-                    id     = 'windowsQualityUpdateProfiles'
-                    method = 'GET'
-                    url    = "/deviceManagement/windowsQualityUpdateProfiles?`$expand=assignments&`$top=200"
-                }
-                @{
-                    id     = 'GroupPolicyConfigurations'
-                    method = 'GET'
-                    url    = "/deviceManagement/groupPolicyConfigurations?`$expand=assignments&`$top=1000"
-                }
-                @{
-                    id     = 'MobileAppConfigurations'
-                    method = 'GET'
-                    url    = "/deviceAppManagement/mobileAppConfigurations?`$expand=assignments&`$filter=microsoft.graph.androidManagedStoreAppConfiguration/appSupportsOemConfig%20eq%20true"
-                }
-                @{
-                    id     = 'ConfigurationPolicies'
-                    method = 'GET'
-                    url    = "/deviceManagement/configurationPolicies?`$expand=assignments&`$top=1000"
-                }
-                @{
-                    id     = 'deviceCompliancePolicies'
-                    method = 'GET'
-                    url    = "/deviceManagement/deviceCompliancePolicies?`$expand=assignments&`$top=1000"
-                }
-                @{
-                    id     = 'Intents'
-                    method = 'GET'
-                    url    = "/deviceManagement/intents?`$top=1000"
-                }
-                @{
-                    id     = 'ManagedAppPolicies'
-                    method = 'GET'
-                    url    = '/deviceAppManagement/managedAppPolicies?$orderby=displayName'
-                }
-            )
+                })
+            foreach ($Definition in $PolicyDefinitions) {
+                $BulkRequests.Add([PSCustomObject]@{
+                        id     = $Definition.Id
+                        method = 'GET'
+                        url    = $Definition.GraphUri
+                    })
+            }
 
-            $BulkResults = New-GraphBulkRequest -Requests $BulkRequests -tenantid $TenantFilter
+            $BulkResults = New-GraphBulkRequest -Requests @($BulkRequests) -tenantid $TenantFilter
 
-            # Extract groups for resolving assignment names
-            $Groups = ($BulkResults | Where-Object { $_.id -eq 'Groups' }).body.value
+            $GroupLookup = @{}
+            $GroupResult = $BulkResults | Where-Object { $_.id -eq 'Groups' } | Select-Object -First 1
+            foreach ($Group in @($GroupResult.body.value)) {
+                if ($Group.id) { $GroupLookup[$Group.id] = $Group.displayName }
+            }
 
-            $GraphRequest = $BulkResults | Where-Object { $_.id -ne 'Groups' } | ForEach-Object {
-                $URLName = $_.Id
-                $_.body.Value | ForEach-Object {
-                    $AssignmentContext = $_.'assignments@odata.context'
-                    $PolicyODataType = $_.'@odata.type'
-                    $policyTypeName = switch -Wildcard ($AssignmentContext) {
-                        '*microsoft.graph.windowsIdentityProtectionConfiguration*' { 'Identity Protection' }
-                        '*microsoft.graph.windows10EndpointProtectionConfiguration*' { 'Endpoint Protection' }
-                        '*microsoft.graph.windows10CustomConfiguration*' { 'Custom' }
-                        '*microsoft.graph.windows10DeviceFirmwareConfigurationInterface*' { 'Firmware Configuration' }
-                        '*groupPolicyConfigurations*' { 'Administrative Templates' }
-                        '*windowsDomainJoinConfiguration*' { 'Domain Join configuration' }
-                        '*windowsUpdateForBusinessConfiguration*' { 'Update Configuration' }
-                        '*windowsHealthMonitoringConfiguration*' { 'Health Monitoring' }
-                        '*microsoft.graph.macOSGeneralDeviceConfiguration*' { 'MacOS Configuration' }
-                        '*microsoft.graph.macOSEndpointProtectionConfiguration*' { 'MacOS Endpoint Protection' }
-                        '*microsoft.graph.androidWorkProfileGeneralDeviceConfiguration*' { 'Android Configuration' }
-                        '*windowsFeatureUpdateProfiles*' { 'Feature Update' }
-                        '*windowsQualityUpdatePolicies*' { 'Quality Update' }
-                        '*windowsQualityUpdateProfiles*' { 'Quality Update' }
-                        '*iosUpdateConfiguration*' { 'iOS Update Configuration' }
-                        '*windowsDriverUpdateProfiles*' { 'Driver Update' }
-                        '*configurationPolicies*' { 'Device Configuration' }
-                        '*deviceCompliancePolicies*' { 'Compliance Policy' }
-                        '*intents*' { 'Endpoint Security' }
-                        default { $null }
-                    }
-                    # Fall back to the request type when the assignment context does not identify the policy
-                    # (e.g. Intents are listed without expanding assignments).
-                    if ([string]::IsNullOrWhiteSpace($policyTypeName)) {
-                        $policyTypeName = switch ($URLName) {
-                            'deviceCompliancePolicies' { 'Compliance Policy' }
-                            'Intents' { 'Endpoint Security' }
-                            'ManagedAppPolicies' {
-                                switch -Wildcard ($PolicyODataType) {
-                                    '*iosManagedAppProtection*' { 'iOS App Protection' }
-                                    '*androidManagedAppProtection*' { 'Android App Protection' }
-                                    '*windowsManagedAppProtection*' { 'Windows App Protection' }
-                                    default { 'App Protection' }
-                                }
-                            }
-                            default { $AssignmentContext }
-                        }
-                    }
-                    $Assignments = $_.assignments.target | Select-Object -Property '@odata.type', groupId
-                    $PolicyAssignment = [System.Collections.Generic.List[string]]::new()
-                    $PolicyExclude = [System.Collections.Generic.List[string]]::new()
-                    foreach ($target in $Assignments) {
-                        switch ($target.'@odata.type') {
-                            '#microsoft.graph.allDevicesAssignmentTarget' { $PolicyAssignment.Add('All Devices') }
-                            '#microsoft.graph.exclusionallDevicesAssignmentTarget' { $PolicyExclude.Add('All Devices') }
-                            '#microsoft.graph.allUsersAssignmentTarget' { $PolicyAssignment.Add('All Users') }
-                            '#microsoft.graph.allLicensedUsersAssignmentTarget' { $PolicyAssignment.Add('All Licenced Users') }
-                            '#microsoft.graph.exclusionallUsersAssignmentTarget' { $PolicyExclude.Add('All Users') }
-                            '#microsoft.graph.groupAssignmentTarget' { $PolicyAssignment.Add($Groups.Where({ $_.id -eq $target.groupId }).displayName) }
-                            '#microsoft.graph.exclusionGroupAssignmentTarget' { $PolicyExclude.Add($Groups.Where({ $_.id -eq $target.groupId }).displayName) }
-                            default {
-                                $PolicyAssignment.Add($null)
-                                $PolicyExclude.Add($null)
-                            }
-                        }
-                    }
-                    if ($null -eq $_.displayname) { $_ | Add-Member -NotePropertyName displayName -NotePropertyValue $_.name }
-                    $_ | Add-Member -NotePropertyName PolicyTypeName -NotePropertyValue $policyTypeName
-                    $_ | Add-Member -NotePropertyName URLName -NotePropertyValue $URLName
-                    $_ | Add-Member -NotePropertyName PolicyAssignment -NotePropertyValue ($PolicyAssignment -join ', ')
-                    $_ | Add-Member -NotePropertyName PolicyExclude -NotePropertyValue ($PolicyExclude -join ', ')
-                    $_
-                } | Where-Object { $null -ne $_.DisplayName }
+            $GraphRequest = foreach ($Definition in $PolicyDefinitions) {
+                $Result = $BulkResults | Where-Object { $_.id -eq $Definition.Id } | Select-Object -First 1
+                if (-not $Result) { continue }
+                if ($null -ne $Result.status -and ($Result.status -lt 200 -or $Result.status -ge 300)) { continue }
+
+                foreach ($Policy in @($Result.body.value)) {
+                    # @($null) contains one null element, so guard before parameter binding.
+                    if ($null -eq $Policy) { continue }
+                    ConvertTo-CIPPIntunePolicyListItem -Policy $Policy -URLName $Definition.Id -DefaultPolicyTypeName $Definition.PolicyTypeName -GroupLookup $GroupLookup
+                }
             }
         }
 

--- a/backend/Tests/Endpoint/Invoke-ListIntunePolicy.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListIntunePolicy.Tests.ps1
@@ -1,0 +1,110 @@
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    function Get-CIPPIntunePolicyReport { param($TenantFilter) }
+    function New-GraphBulkRequest { param($Requests, $tenantid) }
+    function New-GraphGetRequest { param($uri, $tenantid) }
+    function Test-IsGuid { param($String) $true }
+    function Get-NormalizedError { param($Message) $Message }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntunePolicyListDefinitions.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/ConvertTo-CIPPIntunePolicyListItem.ps1')
+    $EndpointPath = Join-Path $RepoRoot 'Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListIntunePolicy.ps1'
+    $EndpointScript = [ScriptBlock]::Create("using namespace System.Net`n" + (Get-Content -LiteralPath $EndpointPath -Raw))
+    . $EndpointScript
+}
+
+Describe 'Invoke-ListIntunePolicy family parity' {
+    BeforeEach {
+        $script:EmptyFamily = $null
+        Mock New-GraphBulkRequest {
+            @($Requests | ForEach-Object {
+                    $Value = if ($_.id -eq 'Groups') {
+                        @([PSCustomObject]@{ id = 'group-1'; displayName = 'Group One' })
+                    } elseif ($_.id -eq $script:EmptyFamily) {
+                        $null
+                    } else {
+                        $Policy = [PSCustomObject]@{
+                            id          = "$($_.id)-1"
+                            displayName = "$($_.id) policy"
+                            assignments = @(
+                                [PSCustomObject]@{
+                                    target = [PSCustomObject]@{
+                                        '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                                        groupId       = 'group-1'
+                                    }
+                                }
+                            )
+                        }
+                        if ($_.id -eq 'ManagedAppPolicies') {
+                            $Policy | Add-Member -NotePropertyName '@odata.type' -NotePropertyValue '#microsoft.graph.androidManagedAppProtection'
+                        }
+                        @($Policy)
+                    }
+
+                    [PSCustomObject]@{
+                        id     = $_.id
+                        status = 200
+                        body   = [PSCustomObject]@{ value = $Value }
+                    }
+                })
+        }
+    }
+
+    It 'uses the canonical eleven families for live mode' {
+        $Request = [PSCustomObject]@{
+            Query = [PSCustomObject]@{
+                TenantFilter = 'contoso.onmicrosoft.com'
+            }
+        }
+
+        $Response = Invoke-ListIntunePolicy -Request $Request -TriggerMetadata $null
+
+        $Response.StatusCode | Should -Be 200
+        $Response.Body | Should -HaveCount 11
+        $Response.Body.URLName | Sort-Object | Should -Be ((Get-CIPPIntunePolicyListDefinitions).Id | Sort-Object)
+        $Response.Body.PolicyAssignment | Select-Object -Unique | Should -Be 'Group One'
+    }
+
+    It 'continues when one successful family has no value collection' {
+        $script:EmptyFamily = 'Intents'
+        $Request = [PSCustomObject]@{
+            Query = [PSCustomObject]@{
+                TenantFilter = 'contoso.onmicrosoft.com'
+            }
+        }
+
+        $Response = Invoke-ListIntunePolicy -Request $Request -TriggerMetadata $null
+
+        $Response.StatusCode | Should -Be 200
+        $Response.Body | Should -HaveCount 10
+        $Response.Body.URLName | Should -Not -Contain 'Intents'
+        $Response.Body.URLName | Should -Contain 'ConfigurationPolicies'
+    }
+
+    It 'routes cached mode through the report reader without calling Graph' {
+        Mock Get-CIPPIntunePolicyReport {
+            @([PSCustomObject]@{ id = 'cached-1'; displayName = 'Cached policy' })
+        }
+        Mock New-GraphBulkRequest { throw 'Graph should not be called' }
+
+        $Request = [PSCustomObject]@{
+            Query = [PSCustomObject]@{
+                TenantFilter = 'contoso.onmicrosoft.com'
+                UseReportDB  = 'true'
+            }
+        }
+
+        $Response = Invoke-ListIntunePolicy -Request $Request -TriggerMetadata $null
+
+        $Response.StatusCode | Should -Be 200
+        $Response.Body.id | Should -Be 'cached-1'
+        Should -Invoke Get-CIPPIntunePolicyReport -Times 1
+        Should -Invoke New-GraphBulkRequest -Times 0
+    }
+}

--- a/backend/Tests/Private/Add-CIPPDbItem.Tests.ps1
+++ b/backend/Tests/Private/Add-CIPPDbItem.Tests.ps1
@@ -1,0 +1,62 @@
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    function Get-CippTable { param($tablename) @{} }
+    function Get-CIPPAzDataTableEntity { param($Filter, $Property) }
+    function Add-CIPPAzDataTableEntity { param($Entity, [switch]$Force) }
+    function Remove-CIPPAzDataTableEntity { param($Entity, [switch]$Force) }
+    function Write-LogMessage { param($API, $tenant, $message, $sev) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Add-CIPPDbItem.ps1')
+}
+
+Describe 'Add-CIPPDbItem authoritative empty collections' {
+    BeforeEach {
+        Mock Write-LogMessage {}
+        Mock Add-CIPPAzDataTableEntity {}
+        Mock Remove-CIPPAzDataTableEntity {}
+        Mock Get-CIPPAzDataTableEntity {
+            @(
+                [PSCustomObject]@{
+                    PartitionKey = 'contoso.onmicrosoft.com'
+                    RowKey       = 'IntuneIntents-old-policy'
+                    ETag         = '*'
+                    Timestamp    = [DateTimeOffset]::UtcNow.AddSeconds(-1)
+                }
+                [PSCustomObject]@{
+                    PartitionKey = 'contoso.onmicrosoft.com'
+                    RowKey       = 'IntuneIntents-Count'
+                    ETag         = '*'
+                    Timestamp    = [DateTimeOffset]::UtcNow.AddSeconds(-1)
+                }
+            )
+        }
+    }
+
+    It 'clears existing rows and writes count zero when ClearOnEmpty is explicit' {
+        Add-CIPPDbItem -TenantFilter 'contoso.onmicrosoft.com' -Type 'IntuneIntents' -Data @() -AddCount -ClearOnEmpty
+
+        Should -Invoke Remove-CIPPAzDataTableEntity -Times 1 -ParameterFilter {
+            $Entity.RowKey -eq 'IntuneIntents-old-policy'
+        }
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -ParameterFilter {
+            $Entity.RowKey -eq 'IntuneIntents-Count' -and $Entity.DataCount -eq 0
+        }
+    }
+
+    It 'preserves existing rows for an empty collection without ClearOnEmpty' {
+        Add-CIPPDbItem -TenantFilter 'contoso.onmicrosoft.com' -Type 'IntuneIntents' -Data @() -AddCount
+
+        Should -Invoke Remove-CIPPAzDataTableEntity -Times 0
+    }
+
+    It 'removes recently stale rows from a non-empty authoritative collection' {
+        $Policy = [PSCustomObject]@{ id = 'new-policy'; displayName = 'New policy' }
+
+        Add-CIPPDbItem -TenantFilter 'contoso.onmicrosoft.com' -Type 'IntuneIntents' -Data @($Policy) -AddCount -ClearOnEmpty
+
+        Should -Invoke Remove-CIPPAzDataTableEntity -Times 1 -ParameterFilter {
+            $Entity.RowKey -eq 'IntuneIntents-old-policy'
+        }
+    }
+}

--- a/backend/Tests/Private/IntunePolicyListHelpers.Tests.ps1
+++ b/backend/Tests/Private/IntunePolicyListHelpers.Tests.ps1
@@ -1,0 +1,125 @@
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntunePolicyListDefinitions.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/ConvertTo-CIPPIntunePolicyListItem.ps1')
+}
+
+Describe 'Intune policy list helpers' {
+    It 'defines the same eleven policy families for live and cached views' {
+        $Definitions = @(Get-CIPPIntunePolicyListDefinitions)
+
+        $Definitions | Should -HaveCount 11
+        $Definitions.Id | Should -Be @(
+            'DeviceConfigurations'
+            'WindowsDriverUpdateProfiles'
+            'WindowsFeatureUpdateProfiles'
+            'windowsQualityUpdatePolicies'
+            'windowsQualityUpdateProfiles'
+            'GroupPolicyConfigurations'
+            'MobileAppConfigurations'
+            'ConfigurationPolicies'
+            'deviceCompliancePolicies'
+            'Intents'
+            'ManagedAppPolicies'
+        )
+        $Definitions.CacheType | Should -Contain 'IntuneDeviceCompliancePolicies'
+        $Definitions.CacheType | Should -Contain 'IntuneIntents'
+        $Definitions.CacheType | Should -Contain 'IntuneAppProtectionPolicies'
+        ($Definitions | Where-Object Id -eq 'ManagedAppPolicies').FetchAssignments | Should -BeFalse
+    }
+
+    It 'uses the correct mobile app management resource and live OEMConfig filter' {
+        $Definition = Get-CIPPIntunePolicyListDefinitions | Where-Object Id -eq 'MobileAppConfigurations'
+
+        $Definition.GraphUri | Should -Be '/deviceAppManagement/mobileAppConfigurations?$expand=assignments&$filter=microsoft.graph.androidManagedStoreAppConfiguration/appSupportsOemConfig%20eq%20true'
+        $Definition.CacheUri | Should -Be $Definition.GraphUri
+    }
+
+    It 'normalizes assignments and policy labels consistently' {
+        $Policy = [PSCustomObject]@{
+            id                          = 'policy-1'
+            displayName                 = 'Policy One'
+            'assignments@odata.context' = 'https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/assignments'
+            assignments                 = @(
+                [PSCustomObject]@{
+                    target = [PSCustomObject]@{
+                        '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                        groupId       = 'group-1'
+                    }
+                }
+                [PSCustomObject]@{
+                    target = [PSCustomObject]@{
+                        '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                        groupId       = 'group-2'
+                    }
+                }
+            )
+        }
+
+        $Result = ConvertTo-CIPPIntunePolicyListItem -Policy $Policy -URLName 'ConfigurationPolicies' -DefaultPolicyTypeName 'Device Configuration' -GroupLookup @{
+            'group-1' = 'Included Group'
+            'group-2' = 'Excluded Group'
+        }
+
+        $Result.PolicyTypeName | Should -Be 'Device Configuration'
+        $Result.URLName | Should -Be 'ConfigurationPolicies'
+        $Result.PolicyAssignment | Should -Be 'Included Group'
+        $Result.PolicyExclude | Should -Be 'Excluded Group'
+    }
+
+    It 'accepts and skips an explicit null policy' {
+        $Result = ConvertTo-CIPPIntunePolicyListItem -Policy $null -URLName 'ConfigurationPolicies' -DefaultPolicyTypeName 'Device Configuration'
+
+        $Result | Should -BeNullOrEmpty
+    }
+
+    It 'tolerates group assignment targets without a group ID' {
+        $Policy = [PSCustomObject]@{
+            id          = 'malformed-assignments'
+            displayName = 'Malformed assignments'
+            assignments = @(
+                [PSCustomObject]@{
+                    target = [PSCustomObject]@{
+                        '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                    }
+                }
+                [PSCustomObject]@{
+                    target = [PSCustomObject]@{
+                        '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                        groupId       = ''
+                    }
+                }
+            )
+        }
+
+        { $script:MalformedAssignmentResult = ConvertTo-CIPPIntunePolicyListItem -Policy $Policy -URLName 'ConfigurationPolicies' -DefaultPolicyTypeName 'Device Configuration' } |
+            Should -Not -Throw
+        $script:MalformedAssignmentResult.PolicyAssignment | Should -Be ''
+        $script:MalformedAssignmentResult.PolicyExclude | Should -Be ''
+    }
+
+    It 'labels each managed app protection platform' -ForEach @(
+        @{ ODataType = '#microsoft.graph.iosManagedAppProtection'; Expected = 'iOS App Protection' }
+        @{ ODataType = '#microsoft.graph.androidManagedAppProtection'; Expected = 'Android App Protection' }
+        @{ ODataType = '#microsoft.graph.windowsManagedAppProtection'; Expected = 'Windows App Protection' }
+    ) {
+        $Policy = [PSCustomObject]@{
+            id            = 'managed-policy'
+            displayName   = 'Managed policy'
+            '@odata.type' = $ODataType
+        }
+
+        $Result = ConvertTo-CIPPIntunePolicyListItem -Policy $Policy -URLName 'ManagedAppPolicies' -DefaultPolicyTypeName 'App Protection'
+
+        $Result.PolicyTypeName | Should -Be $Expected
+    }
+
+    It 'filters Linux and device configuration script rows' -ForEach @(
+        @{ Policy = [PSCustomObject]@{ id = 'linux'; displayName = 'Linux'; platforms = 'linux' } }
+        @{ Policy = [PSCustomObject]@{ id = 'script'; displayName = 'Script'; templateReference = [PSCustomObject]@{ templateFamily = 'deviceConfigurationScripts' } } }
+    ) {
+        $Result = ConvertTo-CIPPIntunePolicyListItem -Policy $Policy -URLName 'ConfigurationPolicies' -DefaultPolicyTypeName 'Device Configuration'
+
+        $Result | Should -BeNullOrEmpty
+    }
+}

--- a/backend/Tests/Private/Set-CIPPDBCacheIntunePolicies.Tests.ps1
+++ b/backend/Tests/Private/Set-CIPPDBCacheIntunePolicies.Tests.ps1
@@ -1,0 +1,188 @@
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    function Test-CIPPStandardLicense { param($StandardName, $TenantFilter, $Preset, [switch]$SkipLog) }
+    function New-GraphBulkRequest { param($Requests, $tenantid) }
+    function Add-CIPPDbItem {
+        param(
+            $TenantFilter,
+            $Type,
+            [Alias('Data')]$InputObject,
+            [switch]$AddCount,
+            [switch]$ClearOnEmpty
+        )
+    }
+    function Write-LogMessage { param($API, $tenant, $message, $sev) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntunePolicyListDefinitions.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/ConvertTo-CIPPIntunePolicyListItem.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheIntunePolicies.ps1')
+}
+
+Describe 'Set-CIPPDBCacheIntunePolicies' {
+    BeforeEach {
+        $script:BulkRequestSets = [System.Collections.Generic.List[object]]::new()
+        $script:CacheWrites = [System.Collections.Generic.List[object]]::new()
+        $script:Logs = [System.Collections.Generic.List[object]]::new()
+        $script:MissingInitialStatuses = @()
+        $script:MissingSubresponseStatuses = $false
+
+        Mock Test-CIPPStandardLicense { $true }
+        Mock Write-LogMessage {
+            $script:Logs.Add([PSCustomObject]@{ Severity = $sev; Message = $message })
+        }
+        Mock Add-CIPPDbItem {
+            $script:CacheWrites.Add([PSCustomObject]@{
+                    Type         = $Type
+                    Data         = @($InputObject)
+                    AddCount     = $AddCount.IsPresent
+                    ClearOnEmpty = $ClearOnEmpty.IsPresent
+                })
+        }
+        Mock New-GraphBulkRequest {
+            $script:BulkRequestSets.Add(@($Requests))
+
+            if (@($Requests)[0].url -like '*/deviceStatuses*') {
+                return @($Requests | ForEach-Object {
+                        $Response = [PSCustomObject]@{
+                            id     = $_.id
+                            body   = [PSCustomObject]@{ value = @() }
+                        }
+                        if (-not $script:MissingSubresponseStatuses) {
+                            $Response | Add-Member -NotePropertyName status -NotePropertyValue 200
+                        }
+                        $Response
+                    })
+            }
+            if (@($Requests)[0].url -like '*/assignments') {
+                return @($Requests | ForEach-Object {
+                        $Response = [PSCustomObject]@{
+                            id     = $_.id
+                            body   = [PSCustomObject]@{ value = @() }
+                        }
+                        if (-not $script:MissingSubresponseStatuses) {
+                            $Response | Add-Member -NotePropertyName status -NotePropertyValue 200
+                        }
+                        $Response
+                    })
+            }
+
+            return @($Requests | ForEach-Object {
+                    $Value = if ($_.id -eq 'Groups') {
+                        @([PSCustomObject]@{ id = 'group-1'; displayName = 'Group One' })
+                    } else {
+                        @([PSCustomObject]@{ id = "$($_.id)-1"; displayName = "$($_.id) policy" })
+                    }
+                    $Response = [PSCustomObject]@{
+                        id     = $_.id
+                        body   = [PSCustomObject]@{ value = $Value }
+                    }
+                    if ($script:MissingInitialStatuses -notcontains $_.id) {
+                        $Response | Add-Member -NotePropertyName status -NotePropertyValue 200
+                    }
+                    $Response
+                })
+        }
+    }
+
+    It 'caches all live families, the group snapshot, and legacy datasets' {
+        Set-CIPPDBCacheIntunePolicies -TenantFilter 'contoso.onmicrosoft.com'
+
+        $InitialRequests = @($script:BulkRequestSets[0])
+        $InitialRequests.id | Should -Contain 'Intents'
+        ($InitialRequests | Where-Object id -eq 'MobileAppConfigurations').url |
+            Should -Be '/deviceAppManagement/mobileAppConfigurations?$expand=assignments&$filter=microsoft.graph.androidManagedStoreAppConfiguration/appSupportsOemConfig%20eq%20true'
+
+        $script:CacheWrites.Type | Should -Contain 'IntunePolicyGroups'
+        $script:CacheWrites.Type | Should -Contain 'IntuneDeviceCompliancePolicies'
+        $script:CacheWrites.Type | Should -Contain 'IntuneIntents'
+        $script:CacheWrites.Type | Should -Contain 'IntuneAppProtectionPolicies'
+        $script:CacheWrites.Type | Should -Contain 'IntuneDeviceEnrollmentConfigurations'
+        $script:CacheWrites.Type | Should -Contain 'IntuneMobileApps'
+        ($script:CacheWrites | Where-Object Type -eq 'IntuneIntents').ClearOnEmpty | Should -BeTrue
+
+        $AllRequestedUrls = @($script:BulkRequestSets | ForEach-Object { $_.url })
+        $AllRequestedUrls | Where-Object { $_ -like '/deviceAppManagement/managedAppPolicies/*/assignments' } | Should -BeNullOrEmpty
+    }
+
+    It 'preserves a failed family and completes with warning logs' {
+        Mock New-GraphBulkRequest {
+            if (@($Requests)[0].url -like '*/deviceStatuses*' -or @($Requests)[0].url -like '*/assignments') {
+                return @()
+            }
+
+            return @($Requests | ForEach-Object {
+                    if ($_.id -eq 'Intents') {
+                        [PSCustomObject]@{
+                            id     = $_.id
+                            status = 403
+                            body   = [PSCustomObject]@{ error = [PSCustomObject]@{ message = 'Forbidden' } }
+                        }
+                    } else {
+                        [PSCustomObject]@{
+                            id     = $_.id
+                            status = 200
+                            body   = [PSCustomObject]@{ value = @() }
+                        }
+                    }
+                })
+        }
+
+        { Set-CIPPDBCacheIntunePolicies -TenantFilter 'contoso.onmicrosoft.com' } | Should -Not -Throw
+
+        $script:CacheWrites.Type | Should -Not -Contain 'IntuneIntents'
+        $script:Logs | Where-Object {
+            $_.Severity -eq 'Warning' -and $_.Message -match 'Intents.*HTTP 403'
+        } | Should -Not -BeNullOrEmpty
+    }
+
+    It 'preserves group and family caches when their batch responses omit status' {
+        $script:MissingInitialStatuses = @('Groups', 'Intents')
+
+        { Set-CIPPDBCacheIntunePolicies -TenantFilter 'contoso.onmicrosoft.com' } | Should -Not -Throw
+
+        $script:CacheWrites.Type | Should -Not -Contain 'IntunePolicyGroups'
+        $script:CacheWrites.Type | Should -Not -Contain 'IntuneIntents'
+        $script:Logs | Where-Object {
+            $_.Severity -eq 'Warning' -and $_.Message -match 'group lookup returned no HTTP status'
+        } | Should -Not -BeNullOrEmpty
+        $script:Logs | Where-Object {
+            $_.Severity -eq 'Warning' -and $_.Message -match 'No HTTP status was returned for Intents'
+        } | Should -Not -BeNullOrEmpty
+    }
+
+    It 'warns and skips assignment and device status responses without status' {
+        $script:MissingSubresponseStatuses = $true
+
+        { Set-CIPPDBCacheIntunePolicies -TenantFilter 'contoso.onmicrosoft.com' } | Should -Not -Throw
+
+        $script:Logs | Where-Object {
+            $_.Severity -eq 'Warning' -and $_.Message -match 'No HTTP status.*fetching assignments'
+        } | Should -Not -BeNullOrEmpty
+        $script:Logs | Where-Object {
+            $_.Severity -eq 'Warning' -and $_.Message -match 'No HTTP status.*fetching device statuses'
+        } | Should -Not -BeNullOrEmpty
+    }
+
+    It 'still fails when no report family has a valid status' {
+        $script:MissingInitialStatuses = @(
+            'Groups'
+            (Get-CIPPIntunePolicyListDefinitions).Id
+            'WindowsAutopilotDeploymentProfiles'
+            'DeviceEnrollmentConfigurations'
+            'DeviceManagementScripts'
+            'MobileApps'
+        )
+
+        { Set-CIPPDBCacheIntunePolicies -TenantFilter 'contoso.onmicrosoft.com' } |
+            Should -Throw '*No report-backed Intune policy families were cached successfully*'
+        $script:CacheWrites | Should -BeNullOrEmpty
+    }
+
+    It 'throws when the initial Graph batch fails completely' {
+        Mock New-GraphBulkRequest { throw 'Authentication failed' }
+
+        { Set-CIPPDBCacheIntunePolicies -TenantFilter 'contoso.onmicrosoft.com' } |
+            Should -Throw '*Authentication failed*'
+    }
+}

--- a/backend/Tests/Reports/Get-CIPPIntunePolicyReport.Tests.ps1
+++ b/backend/Tests/Reports/Get-CIPPIntunePolicyReport.Tests.ps1
@@ -1,0 +1,204 @@
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    function Get-CIPPDbItem { param($TenantFilter, $Type) }
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function Write-LogMessage { param($API, $tenant, $message, $sev, $LogData) }
+    function Get-CippException { param($Exception) $Exception }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntunePolicyListDefinitions.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/ConvertTo-CIPPIntunePolicyListItem.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntunePolicyReport.ps1')
+
+    function New-IntunePolicyDbItem {
+        param(
+            [string]$Tenant,
+            [string]$Type,
+            $Data,
+            [DateTimeOffset]$Timestamp = [DateTimeOffset]::UtcNow
+        )
+
+        [PSCustomObject]@{
+            PartitionKey = $Tenant
+            RowKey       = "$Type-$($Data.id)"
+            Timestamp    = $Timestamp
+            Data         = $Data | ConvertTo-Json -Depth 10 -Compress -WarningAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Get-CIPPIntunePolicyReport' {
+    BeforeEach {
+        $script:Tenant = 'contoso.onmicrosoft.com'
+        $script:Definitions = @(Get-CIPPIntunePolicyListDefinitions)
+        $script:RowsByType = @{}
+        $script:Timestamp = [DateTimeOffset]::UtcNow
+        $script:IntuneGroupItems = @(
+            New-IntunePolicyDbItem -Tenant $script:Tenant -Type 'IntunePolicyGroups' -Data ([PSCustomObject]@{
+                    id          = 'group-1'
+                    displayName = 'Current group name'
+                }) -Timestamp $script:Timestamp
+        )
+
+        foreach ($Definition in $script:Definitions) {
+            $Policy = [PSCustomObject]@{
+                id          = "$($Definition.Id)-1"
+                displayName = "$($Definition.Id) policy"
+                assignments = @(
+                    [PSCustomObject]@{
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                            groupId       = 'group-1'
+                        }
+                    }
+                )
+            }
+            if ($Definition.Id -eq 'ManagedAppPolicies') {
+                $Policy | Add-Member -NotePropertyName '@odata.type' -NotePropertyValue '#microsoft.graph.iosManagedAppProtection'
+            }
+
+            $script:RowsByType[$Definition.CacheType] = @(
+                New-IntunePolicyDbItem -Tenant $script:Tenant -Type $Definition.CacheType -Data $Policy -Timestamp $script:Timestamp
+            )
+        }
+
+        $ConfigurationType = ($script:Definitions | Where-Object Id -eq 'ConfigurationPolicies').CacheType
+        $script:RowsByType[$ConfigurationType] += @(
+            New-IntunePolicyDbItem -Tenant $script:Tenant -Type $ConfigurationType -Data ([PSCustomObject]@{
+                    id          = 'linux-policy'
+                    displayName = 'Linux policy'
+                    platforms   = 'linux'
+                }) -Timestamp $script:Timestamp
+            New-IntunePolicyDbItem -Tenant $script:Tenant -Type $ConfigurationType -Data ([PSCustomObject]@{
+                    id                = 'script-policy'
+                    displayName       = 'Script policy'
+                    templateReference = [PSCustomObject]@{ templateFamily = 'deviceConfigurationScripts' }
+                }) -Timestamp $script:Timestamp
+        )
+
+        Mock Write-LogMessage {}
+        Mock Get-Tenants {
+            @([PSCustomObject]@{ defaultDomainName = $script:Tenant })
+        }
+        Mock Get-CIPPDbItem {
+            if ($Type -eq 'Groups') {
+                return @(New-IntunePolicyDbItem -Tenant $script:Tenant -Type 'Groups' -Data ([PSCustomObject]@{
+                            id          = 'group-1'
+                            displayName = 'Old group name'
+                        }) -Timestamp $script:Timestamp)
+            }
+            if ($Type -eq 'IntunePolicyGroups') {
+                return @($script:IntuneGroupItems)
+            }
+            return @($script:RowsByType[$Type])
+        }
+    }
+
+    It 'returns every live policy family with the shared normalization' {
+        $Result = @(Get-CIPPIntunePolicyReport -TenantFilter $script:Tenant)
+
+        $Result | Should -HaveCount 11
+        $Result.id | Should -Contain 'deviceCompliancePolicies-1'
+        $Result.id | Should -Contain 'Intents-1'
+        $Result.id | Should -Contain 'ManagedAppPolicies-1'
+        $Result.URLName | Sort-Object | Should -Be ($script:Definitions.Id | Sort-Object)
+        ($Result | Where-Object id -eq 'Intents-1').PolicyTypeName | Should -Be 'Endpoint Security'
+        ($Result | Where-Object id -eq 'ManagedAppPolicies-1').PolicyTypeName | Should -Be 'iOS App Protection'
+        $Result.PolicyAssignment | Select-Object -Unique | Should -Be 'Current group name'
+        $Result.CacheTimestamp | Select-Object -Unique | Should -Be $script:Timestamp
+        Should -Invoke Get-CIPPDbItem -Times 0 -Exactly -ParameterFilter { $Type -eq 'Groups' }
+    }
+
+    It 'adds Tenant for AllTenants and excludes cache timestamp metadata' {
+        $Result = @(Get-CIPPIntunePolicyReport -TenantFilter 'AllTenants')
+
+        $Result | Should -HaveCount 11
+        $Result.Tenant | Select-Object -Unique | Should -Be $script:Tenant
+        $Result[0].PSObject.Properties.Name | Should -Not -Contain 'CacheTimestamp'
+        Should -Invoke Get-CIPPDbItem -Times 0 -Exactly -ParameterFilter { $Type -eq 'Groups' }
+    }
+
+    It 'falls back to the normal Groups cache when no Intune snapshot exists' {
+        $script:IntuneGroupItems = @()
+
+        $Result = @(Get-CIPPIntunePolicyReport -TenantFilter $script:Tenant)
+
+        $Result | Should -HaveCount 11
+        $Result.PolicyAssignment | Select-Object -Unique | Should -Be 'Old group name'
+        Should -Invoke Get-CIPPDbItem -Times 1 -Exactly -ParameterFilter {
+            $TenantFilter -eq $script:Tenant -and $Type -eq 'Groups'
+        }
+    }
+
+    It 'treats a count-only Intune snapshot as authoritative' {
+        $script:IntuneGroupItems = @(
+            [PSCustomObject]@{
+                PartitionKey = $script:Tenant
+                RowKey       = 'IntunePolicyGroups-Count'
+                Timestamp    = $script:Timestamp
+                DataCount    = 0
+            }
+        )
+
+        $Result = @(Get-CIPPIntunePolicyReport -TenantFilter $script:Tenant)
+
+        $Result | Should -HaveCount 11
+        $Result.PolicyAssignment | Select-Object -Unique | Should -Be ''
+        Should -Invoke Get-CIPPDbItem -Times 0 -Exactly -ParameterFilter { $Type -eq 'Groups' }
+    }
+
+    It 'returns a configuration policy whose cached settings exceed JSON depth 10' {
+        $NestedSetting = [PSCustomObject]@{ value = 'leaf' }
+        foreach ($Level in 1..12) {
+            $NestedSetting = [PSCustomObject]@{ child = $NestedSetting }
+        }
+
+        $ConfigurationType = ($script:Definitions | Where-Object Id -eq 'ConfigurationPolicies').CacheType
+        $DeepPolicyRow = New-IntunePolicyDbItem -Tenant $script:Tenant -Type $ConfigurationType -Data ([PSCustomObject]@{
+                id          = 'deep-settings-policy'
+                displayName = 'Deep settings policy'
+                settings    = @($NestedSetting)
+                assignments = @(
+                    [PSCustomObject]@{
+                        target = [PSCustomObject]@{
+                            '@odata.type' = '#microsoft.graph.groupAssignmentTarget'
+                            groupId       = 'group-1'
+                        }
+                    }
+                )
+            }) -Timestamp $script:Timestamp
+
+        { $DeepPolicyRow.Data | ConvertFrom-Json -Depth 10 -ErrorAction Stop } | Should -Throw
+        $script:RowsByType[$ConfigurationType] += $DeepPolicyRow
+
+        $Result = @(Get-CIPPIntunePolicyReport -TenantFilter $script:Tenant)
+        $DeepPolicy = $Result | Where-Object id -eq 'deep-settings-policy'
+
+        $Result | Should -HaveCount 12
+        $DeepPolicy | Should -Not -BeNullOrEmpty
+        $DeepPolicy.URLName | Should -Be 'ConfigurationPolicies'
+        $DeepPolicy.PolicyTypeName | Should -Be 'Device Configuration'
+        $DeepPolicy.PolicyAssignment | Should -Be 'Current group name'
+    }
+
+    It 'logs and skips only the malformed cached policy row' {
+        $ConfigurationType = ($script:Definitions | Where-Object Id -eq 'ConfigurationPolicies').CacheType
+        $script:RowsByType[$ConfigurationType] += [PSCustomObject]@{
+            PartitionKey = $script:Tenant
+            RowKey       = "$ConfigurationType-malformed-policy"
+            Timestamp    = $script:Timestamp
+            Data         = '{malformed-json'
+        }
+
+        $Result = @(Get-CIPPIntunePolicyReport -TenantFilter $script:Tenant)
+
+        $Result | Should -HaveCount 11
+        Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter {
+            $API -eq 'IntunePolicyReport' -and
+            $tenant -eq $script:Tenant -and
+            $sev -eq 'Warning' -and
+            $message -like "*$ConfigurationType*" -and
+            $message -like '*malformed-policy*'
+        }
+    }
+}


### PR DESCRIPTION
Unify the handling of cached policy reports and live data to prevent discrepancies.