### PR TITLE
feat(standards): add TAP lifetime and length configuration

### DIFF
--- a/backend/Config/standards.json
+++ b/backend/Config/standards.json
@@ -1212,15 +1212,55 @@
     "cat": "Entra (AAD) Standards",
     "tag": [],
     "appliesToTest": ["EIDSCAAT01", "EIDSCAAT02", "ZTNA21845", "ZTNA21846"],
-    "helpText": "Enables TAP and sets the default TAP lifetime to 1 hour. This configuration also allows you to select if a TAP is single use or multi-logon.",
+    "helpText": "Enable TAP with the specified configuration settings.",
     "docsDescription": "Enables Temporary Access Pass generation for the tenant.",
-    "executiveText": "Enables temporary access passes that IT administrators can generate for employees who are locked out or need emergency access to systems. These time-limited passs provide a secure way to restore access without compromising long-term security policies.",
+    "executiveText": "Enables temporary access passes that IT administrators can generate for employees who are locked out or need emergency access to systems. These time-limited passes provide a secure way to restore access without compromising long-term security policies.",
     "addedComponent": [
+      {
+        "type": "number",
+        "name": "standards.TAP.MinimumLifetime",
+        "label": "Minimum Lifetime (minutes)",
+        "defaultValue": 60,
+        "validators": {
+          "min": { "value": 10, "message": "Minimum value is 10" },
+          "max": { "value": 43200, "message": "Maximum value is 43200" }
+        }
+      },
+      {
+        "type": "number",
+        "name": "standards.TAP.MaximumLifetime",
+        "label": "Maximum Lifetime (minutes)",
+        "defaultValue": 480,
+        "validators": {
+          "min": { "value": 10, "message": "Minimum value is 10" },
+          "max": { "value": 43200, "message": "Maximum value is 43200" }
+        }
+      },
+      {
+        "type": "number",
+        "name": "standards.TAP.DefaultLifetime",
+        "label": "Default Lifetime (minutes)",
+        "defaultValue": 60,
+        "validators": {
+          "min": { "value": 10, "message": "Minimum value is 10" },
+          "max": { "value": 43200, "message": "Maximum value is 43200" }
+        }
+      },
+      {
+        "type": "number",
+        "name": "standards.TAP.TAPLength",
+        "label": "Length (characters)",
+        "defaultValue": 8,
+        "validators": {
+          "min": { "value": 8, "message": "Minimum value is 8" },
+          "max": { "value": 48, "message": "Maximum value is 48" }
+        }
+      },
       {
         "type": "autoComplete",
         "multiple": false,
         "creatable": false,
-        "label": "Select TAP Lifetime",
+        "label": "Number of Times Usable",
         "name": "standards.TAP.config",
         "options": [
           { "label": "Only Once", "value": "true" },

--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTAP.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardTAP.ps1
@@ -5,22 +5,27 @@ function Invoke-CIPPStandardTAP {
     .COMPONENT
         (APIName) TAP
     .SYNOPSIS
-        (Label) Enable Temporary Access Passwords
+        (Label) Enable Temporary Access Passes (TAP)
     .DESCRIPTION
-        (Helptext) Enables TAP and sets the default TAP lifetime to 1 hour. This configuration also allows you to select if a TAP is single use or multi-logon.
-        (DocsDescription) Enables Temporary Password generation for the tenant.
+        (Helptext) Enable TAP with the specified configuration settings.
+        (DocsDescription) Enables Temporary Access Pass generation for the tenant.
     .NOTES
         CAT
             Entra (AAD) Standards
         TAG
-            "ZTNA21845"
-            "ZTNA21846"
+        APPLIESTOTEST
             "EIDSCAAT01"
             "EIDSCAAT02"
+            "ZTNA21845"
+            "ZTNA21846"
         EXECUTIVETEXT
-            Enables temporary access passwords that IT administrators can generate for employees who are locked out or need emergency access to systems. These time-limited passwords provide a secure way to restore access without compromising long-term security policies.
+            Enables temporary access passes that IT administrators can generate for employees who are locked out or need emergency access to systems. These time-limited passes provide a secure way to restore access without compromising long-term security policies.
         ADDEDCOMPONENT
-            {"type":"autoComplete","multiple":false,"creatable":false,"label":"Select TAP Lifetime","name":"standards.TAP.config","options":[{"label":"Only Once","value":"true"},{"label":"Multiple Logons","value":"false"}]}
+            {"type":"number","name":"standards.TAP.MinimumLifetime","label":"Minimum Lifetime (minutes)","defaultValue":60}
+            {"type":"number","name":"standards.TAP.MaximumLifetime","label":"Maximum Lifetime (minutes)","defaultValue":480}
+            {"type":"number","name":"standards.TAP.DefaultLifetime","label":"Default Lifetime (minutes)","defaultValue":60}
+            {"type":"number","name":"standards.TAP.TAPLength","label":"Length (characters)","defaultValue":8}
+            {"type":"autoComplete","multiple":false,"creatable":false,"label":"Number of Times Usable","name":"standards.TAP.config","options":[{"label":"Only Once","value":"true"},{"label":"Multiple Logons","value":"false"}]}
         IMPACT
             Low Impact
         ADDEDDATE
@@ -30,12 +35,30 @@ function Invoke-CIPPStandardTAP {
         RECOMMENDEDBY
             "CIPP"
         UPDATECOMMENTBLOCK
-            Run the Tools\Update-StandardsComments.ps1 script to update this comment block
+            Run the tools\Update-StandardsComments.ps1 script to update this comment block
     .LINK
         https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
     #>
 
     param($Tenant, $Settings)
+    
+    # Get config values using null-coalescing operator
+    $MinimumLifetime  = [int]($Settings.MinimumLifetime ?? 60)
+    $MaximumLifetime  = [int]($Settings.MaximumLifetime ?? 480)
+    $DefaultLifetime  = [int]($Settings.DefaultLifetime ?? 60)
+    $TAPLength        = [int]($Settings.TAPLength ?? 8)
+    $OneTimeUse       = $Settings.config.value ?? $Settings.config ?? 'true'
+    $OneTimeUseBool   = [System.Convert]::ToBoolean($OneTimeUse)
+
+    if ($MinimumLifetime -gt $MaximumLifetime) {
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "TAP: minimum lifetime ($MinimumLifetime) exceeds maximum lifetime ($MaximumLifetime). Skipping run, correct the standard configuration." -Sev Error
+        return
+    }
+    
+    if ($DefaultLifetime -lt $MinimumLifetime -or $DefaultLifetime -gt $MaximumLifetime) {
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "TAP: default lifetime ($DefaultLifetime) must fall between the minimum ($MinimumLifetime) and maximum ($MaximumLifetime). Skipping run, correct the standard configuration." -Sev Error
+        return
+    }
 
     try {
         $CurrentState = New-GraphGetRequest -Uri 'https://graph.microsoft.com/beta/policies/authenticationmethodspolicy/authenticationMethodConfigurations/TemporaryAccessPass' -tenantid $Tenant
@@ -45,33 +68,45 @@ function Invoke-CIPPStandardTAP {
         return
     }
 
-    # Get config value using null-coalescing operator
-    $config = $Settings.config.value ?? $Settings.config
-    if ($null -eq $config) { $config = $True }
-
-    $StateIsCorrect = ($CurrentState.state -eq 'enabled') -and
-    ([System.Convert]::ToBoolean($CurrentState.isUsableOnce) -eq [System.Convert]::ToBoolean($config))
+    $StateIsCorrect = $CurrentState.state -eq 'enabled' -and
+    [int]$CurrentState.minimumLifetimeInMinutes -eq $MinimumLifetime -and
+    [int]$CurrentState.maximumLifetimeInMinutes -eq $MaximumLifetime -and
+    [int]$CurrentState.defaultLifetimeInMinutes -eq $DefaultLifetime -and
+    [int]$CurrentState.defaultLength -eq $TAPLength -and
+    [System.Convert]::ToBoolean($CurrentState.isUsableOnce) -eq $OneTimeUseBool
 
     if ($Settings.remediate -eq $true) {
         if ($StateIsCorrect -eq $true) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Temporary Access Passwords is already enabled.' -sev Info
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Temporary Access Pass policy already matches the desired state.' -sev Info
         } else {
             try {
-                Set-CIPPAuthenticationPolicy -Tenant $Tenant -APIName 'Standards' -AuthenticationMethodId 'TemporaryAccessPass' -Enabled $true -TAPisUsableOnce $config
+                $PolicyConfig = @{
+                  Tenant                 = $Tenant
+                  APIName                = 'Standards'
+                  AuthenticationMethodId = 'TemporaryAccessPass'
+                  Enabled                = $true
+                  TapMinimumLifetime     = $MinimumLifetime
+                  TAPMaximumLifetime     = $MaximumLifetime
+                  TAPDefaultLifeTime     = $DefaultLifetime
+                  TAPDefaultLength       = $TAPLength
+                  TAPisUsableOnce        = $OneTimeUseBool
+                }
+
+                Set-CIPPAuthenticationPolicy @PolicyConfig
             } catch {
                 $ErrorMessage = Get-CippException -Exception $_
-                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to enable Temporary Access Passwords. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to configure Temporary Access Pass policy. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
             }
         }
     }
 
     if ($Settings.alert -eq $true) {
         if ($StateIsCorrect -eq $true) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Temporary Access Passwords is enabled.' -sev Info
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Temporary Access Pass policy is enabled and configured.' -sev Info
         } else {
-            $Object = $CurrentState | Select-Object -Property state, isUsableOnce, defaultLifetimeInMinutes, defaultLength, maximumLifetimeInMinutes
-            Write-StandardsAlert -message 'Temporary Access Passwords is not enabled.' -object $Object -tenant $Tenant -standardName 'TAP' -standardId $Settings.standardId
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Temporary Access Passwords is not enabled.' -sev Info
+            $Object = $CurrentState | Select-Object -Property state, isUsableOnce, defaultLifetimeInMinutes, defaultLength, maximumLifetimeInMinutes, minimumLifetimeInMinutes
+            Write-StandardsAlert -message 'Temporary Access Pass policy is not enabled.' -object $Object -tenant $Tenant -standardName 'TAP' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Temporary Access Pass policy is not enabled.' -sev Info
         }
     }
 
@@ -79,13 +114,23 @@ function Invoke-CIPPStandardTAP {
         Add-CIPPBPAField -FieldName 'TemporaryAccessPass' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $Tenant
 
         $CurrentValue = @{
-            state        = $CurrentState.state
-            isUsableOnce = $CurrentState.isUsableOnce
+            state                    = $CurrentState.state
+            minimumLifetimeInMinutes = [int]$CurrentState.minimumLifetimeInMinutes
+            maximumLifetimeInMinutes = [int]$CurrentState.maximumLifetimeInMinutes
+            defaultLifetimeInMinutes = [int]$CurrentState.defaultLifetimeInMinutes
+            defaultLength            = [int]$CurrentState.defaultLength
+            isUsableOnce             = [System.Convert]::ToBoolean($CurrentState.isUsableOnce)
         }
+
         $ExpectedValue = @{
-            state        = 'enabled'
-            isUsableOnce = [System.Convert]::ToBoolean($config)
+            state                    = 'enabled'
+            minimumLifetimeInMinutes = $MinimumLifetime
+            maximumLifetimeInMinutes = $MaximumLifetime
+            defaultLifetimeInMinutes = $DefaultLifetime
+            defaultLength            = $TAPLength
+            isUsableOnce             = $OneTimeUseBool
         }
+
         Set-CIPPStandardsCompareField -FieldName 'standards.TAP' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -Tenant $Tenant
     }
 }

--- a/frontend/src/data/standards.json
+++ b/frontend/src/data/standards.json
@@ -1212,15 +1212,55 @@
     "cat": "Entra (AAD) Standards",
     "tag": [],
     "appliesToTest": ["EIDSCAAT01", "EIDSCAAT02", "ZTNA21845", "ZTNA21846"],
-    "helpText": "Enables TAP and sets the default TAP lifetime to 1 hour. This configuration also allows you to select if a TAP is single use or multi-logon.",
+    "helpText": "Enable TAP with the specified configuration settings.",
     "docsDescription": "Enables Temporary Access Pass generation for the tenant.",
-    "executiveText": "Enables temporary access passes that IT administrators can generate for employees who are locked out or need emergency access to systems. These time-limited passs provide a secure way to restore access without compromising long-term security policies.",
+    "executiveText": "Enables temporary access passes that IT administrators can generate for employees who are locked out or need emergency access to systems. These time-limited passes provide a secure way to restore access without compromising long-term security policies.",
     "addedComponent": [
+      {
+        "type": "number",
+        "name": "standards.TAP.MinimumLifetime",
+        "label": "Minimum Lifetime (minutes)",
+        "defaultValue": 60,
+        "validators": {
+          "min": { "value": 10, "message": "Minimum value is 10" },
+          "max": { "value": 43200, "message": "Maximum value is 43200" }
+        }
+      },
+      {
+        "type": "number",
+        "name": "standards.TAP.MaximumLifetime",
+        "label": "Maximum Lifetime (minutes)",
+        "defaultValue": 480,
+        "validators": {
+          "min": { "value": 10, "message": "Minimum value is 10" },
+          "max": { "value": 43200, "message": "Maximum value is 43200" }
+        }
+      },
+      {
+        "type": "number",
+        "name": "standards.TAP.DefaultLifetime",
+        "label": "Default Lifetime (minutes)",
+        "defaultValue": 60,
+        "validators": {
+          "min": { "value": 10, "message": "Minimum value is 10" },
+          "max": { "value": 43200, "message": "Maximum value is 43200" }
+        }
+      },
+      {
+        "type": "number",
+        "name": "standards.TAP.TAPLength",
+        "label": "Length (characters)",
+        "defaultValue": 8,
+        "validators": {
+          "min": { "value": 8, "message": "Minimum value is 8" },
+          "max": { "value": 48, "message": "Maximum value is 48" }
+        }
+      },
       {
         "type": "autoComplete",
         "multiple": false,
         "creatable": false,
-        "label": "Select TAP Lifetime",
+        "label": "Number of Times Usable",
         "name": "standards.TAP.config",
         "options": [
           { "label": "Only Once", "value": "true" },


### PR DESCRIPTION
add TAP lifetime and length configuration

Expose minimum, maximum, and default TAP lifetime along with TAP length as configurable options on the Enable Temporary Access Passes standard.

Previously only the single-use/multi-logon toggle was exposed, and the lifetime and length values silently fell back to the Set-CIPPAuthenticationPolicy parameter defaults.

Validate the configuration before contacting Graph: the run is skipped with an error when the minimum lifetime exceeds the maximum, or when the default lifetime falls outside that range, rather than issuing a PATCH that Graph would reject. Absolute bounds are surfaced in the form via field validators.

Drift detection, remediation, and the standards comparison report now cover all five settings.