### PR TITLE
fix(build-tools): fix invalid paths to frontend/backend dirs

### DIFF
--- a/build/tools/Update-StandardsComments.ps1
+++ b/build/tools/Update-StandardsComments.ps1
@@ -181,7 +181,7 @@ function Get-LicenseCheckCapabilities {
 }
 
 # Find the paths to the standards.json file based on the current script path
-$RepoRoot = Split-Path $PSScriptRoot
+$RepoRoot = Split-Path (Split-Path $PSScriptRoot)
 $BackendRoot = Join-Path $RepoRoot 'backend'
 $CapabilityPresets = Get-CIPPCapabilityPresets -Path (Join-Path $BackendRoot 'Modules\CIPPCore\Public\Functions\Test-CIPPStandardLicense.ps1')
 

--- a/build/tools/Update-StandardsJson.ps1
+++ b/build/tools/Update-StandardsJson.ps1
@@ -14,8 +14,8 @@ Version: 1.2 - Only overwrites if SHA values differ
 #>
 
 # Source and destination paths, relative to this script in the monorepo's tools folder
-$source = Join-Path $PSScriptRoot '..\frontend\src\data\standards.json'
-$destination = Join-Path $PSScriptRoot '..\backend\Config\standards.json'
+$source = Join-Path $PSScriptRoot '..\..\frontend\src\data\standards.json'
+$destination = Join-Path $PSScriptRoot '..\..\backend\Config\standards.json'
 
 function Get-FileSHA256 {
     param (


### PR DESCRIPTION
Fix invalid paths to the `frontend` and `backend` dirs in `Update-StandardsJson.ps1` and `Update-StandardsComments.ps1`