### PR TITLE
feat(domains): CNAME alone proves ownership for subdomains

### DIFF
--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecAppServiceDomains.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecAppServiceDomains.ps1
@@ -15,8 +15,10 @@ function Invoke-ExecAppServiceDomains {
         Actions (passed as Query.Action or Body.Action):
             List           - Site metadata (default hostname, inbound IP, verification id) plus every
                              hostname binding and any App Service Managed Certificate that matches.
-            CheckDns       - Live DoH lookup of the two records a custom domain needs (ownership TXT
-                             at asuid.<host> and the CNAME/A alias). Powers wizard step 1 + resume.
+            CheckDns       - Live DoH lookup of the records a custom domain needs. A matching CNAME
+                             alias verifies on its own; the ownership TXT at asuid.<host> is only
+                             required for apex/A, wildcard or proxied aliases — and a stale TXT
+                             (wrong value) is flagged for removal. Powers wizard step 1 + resume.
             AddBinding     - Create the hostname binding (wizard step 2). Azure re-validates ownership.
             AddCertificate - Create an App Service Managed Certificate and enable the SNI SSL binding
                              (wizard step 3). Safe to re-run — reuses an existing cert if present.
@@ -52,8 +54,9 @@ function Invoke-ExecAppServiceDomains {
     }
 
     # Work out which DNS records a given custom hostname needs. Azure accepts either a CNAME (to the
-    # app's default hostname) or an A record (to the inbound IP) for the alias itself, plus a TXT
-    # ownership record at asuid.<host>. Wildcards verify ownership at the parent domain.
+    # app's default hostname) or an A record (to the inbound IP) for the alias itself. A matching
+    # CNAME proves ownership by itself; the TXT record at asuid.<host> is only needed when it can't
+    # (apex/A aliases, proxied CNAMEs, and wildcards — which verify ownership at the parent domain).
     function Get-DomainRecordPlan {
         param(
             [string]$Hostname,
@@ -172,15 +175,21 @@ function Invoke-ExecAppServiceDomains {
                     -InboundIp $SiteObj.properties.inboundIpAddress `
                     -VerificationId $SiteObj.properties.customDomainVerificationId
 
-                # Ownership: TXT at asuid.<host> must contain the verification id.
+                # Ownership TXT at asuid.<host>. A matching CNAME alias proves ownership by itself,
+                # so the TXT record is only REQUIRED when Azure cannot see such a CNAME: apex/A
+                # aliases, wildcards, and proxied records (e.g. Cloudflare orange-cloud). A TXT
+                # record with the WRONG value is worse than none — Azure hard-fails the binding on
+                # a mismatched asuid even when the CNAME is correct, so surface it for removal.
                 $TxtValues = Resolve-DohRecord -Name $Plan.AsuidHost -Type 'TXT'
-                $OwnershipVerified = $TxtValues -contains $Plan.VerificationId
+                $AsuidState = if ($TxtValues.Count -eq 0) { 'Absent' } elseif ($TxtValues -contains $Plan.VerificationId) { 'Match' } else { 'Mismatch' }
+                $StaleAsuid = ($AsuidState -eq 'Mismatch')
 
                 # Alias: accept a CNAME to the default hostname OR an A record to the inbound IP.
                 # Wildcards can't be resolved directly, so ownership alone gates them here — Azure
                 # validates the wildcard alias when the binding is created.
                 $AliasVerified = $false
                 $AliasDetail = $null
+                $CnameMatch = $null
                 if ($Plan.IsWildcard) {
                     $AliasVerified = $true
                     $AliasDetail = 'Wildcard alias is validated by Azure when the binding is created.'
@@ -201,31 +210,47 @@ function Invoke-ExecAppServiceDomains {
                     }
                 }
 
+                # TXT required whenever a matching CNAME can't vouch for the hostname.
+                $OwnershipRequired = [bool]($Plan.IsWildcard -or -not $CnameMatch)
+                $OwnershipVerified = $OwnershipRequired ? ($AsuidState -eq 'Match') : (-not $StaleAsuid)
+                # Proceed when a clean CNAME verified the domain, or the TXT record proves
+                # ownership (covers apex/A, wildcard and proxied aliases — Azure then makes the
+                # final call at binding time, matching the previous wizard behavior).
+                $CanProceed = ($CnameMatch -and -not $StaleAsuid) -or ($AsuidState -eq 'Match')
+
+                $Records = [System.Collections.Generic.List[object]]::new()
+                if ($OwnershipRequired -or $StaleAsuid) {
+                    $Records.Add([pscustomobject]@{
+                            Purpose  = 'Ownership'
+                            Type     = 'TXT'
+                            Host     = $Plan.AsuidHost
+                            Value    = $Plan.VerificationId
+                            Verified = ($AsuidState -eq 'Match')
+                        })
+                }
+                $Records.Add([pscustomobject]@{
+                        Purpose  = 'Alias'
+                        Type     = $Plan.RecommendedType
+                        Host     = $Plan.IsApex ? '@' : $HostName
+                        Value    = $Plan.IsApex ? $Plan.ARecordTarget : $Plan.CnameTarget
+                        Verified = $AliasVerified
+                    })
+
                 $Body = @{
                     Results = @{
                         Hostname          = $HostName
                         RecommendedType   = $Plan.RecommendedType
                         IsWildcard        = $Plan.IsWildcard
                         OwnershipVerified = $OwnershipVerified
+                        OwnershipRequired = $OwnershipRequired
+                        AsuidState        = $AsuidState
+                        StaleAsuid        = $StaleAsuid
+                        AsuidHost         = $Plan.AsuidHost
                         AliasVerified     = $AliasVerified
                         AllVerified       = ($OwnershipVerified -and $AliasVerified)
+                        CanProceed        = [bool]$CanProceed
                         AliasDetail       = $AliasDetail
-                        Records           = @(
-                            [pscustomobject]@{
-                                Purpose  = 'Ownership'
-                                Type     = 'TXT'
-                                Host     = $Plan.AsuidHost
-                                Value    = $Plan.VerificationId
-                                Verified = $OwnershipVerified
-                            }
-                            [pscustomobject]@{
-                                Purpose  = 'Alias'
-                                Type     = $Plan.RecommendedType
-                                Host     = $Plan.IsApex ? '@' : $HostName
-                                Value    = $Plan.IsApex ? $Plan.ARecordTarget : $Plan.CnameTarget
-                                Verified = $AliasVerified
-                            }
-                        )
+                        Records           = @($Records)
                     }
                 }
             }
@@ -239,8 +264,10 @@ function Invoke-ExecAppServiceDomains {
                 $Site = Get-AppServiceSiteInfo
                 $ArmBase = Get-SiteArmBase -Site $Site
 
-                # Azure enforces domain-ownership validation (asuid TXT + alias) during this PUT and
-                # returns a descriptive error if the records aren't in place yet.
+                # Azure enforces domain-ownership validation during this PUT: a matching CNAME
+                # suffices on its own; the asuid TXT is the fallback for apex/A, wildcard and
+                # proxied aliases. A TXT record with the WRONG value hard-fails validation even
+                # when the CNAME is correct, so append removal guidance to that error.
                 $BindingUri = "$($ArmBase)/hostNameBindings/$HostName`?api-version=$ApiVersion"
                 $BindingBody = @{
                     properties = @{
@@ -248,7 +275,16 @@ function Invoke-ExecAppServiceDomains {
                         hostNameType = 'Verified'
                     }
                 }
-                New-CIPPAzRestRequest -Uri $BindingUri -Method PUT -Body $BindingBody -ContentType 'application/json' | Out-Null
+                try {
+                    New-CIPPAzRestRequest -Uri $BindingUri -Method PUT -Body $BindingBody -ContentType 'application/json' | Out-Null
+                } catch {
+                    $BindingError = $_.Exception.Message
+                    if ($BindingError -match 'TXT record|asuid|CanonicalName') {
+                        $AsuidHint = $HostName.StartsWith('*.') ? "asuid.$($HostName.Substring(2))" : "asuid.$HostName"
+                        throw "$BindingError — If a TXT record named '$AsuidHint' already exists with a different value, remove or update it: a stale domain-verification record blocks validation even when the CNAME/A alias is correct."
+                    }
+                    throw
+                }
 
                 Write-LogMessage -API $APIName -headers $Headers -message "Added custom domain binding '$HostName' to $($Site.SiteName)" -sev Info
                 $Body = @{ Results = "Custom domain '$HostName' bound to the App Service. You can now enable a managed certificate." }

--- a/deployment/Invoke-CippMigration.ps1
+++ b/deployment/Invoke-CippMigration.ps1
@@ -573,13 +573,24 @@ if ($domainsToPoint.Count -gt 0) {
     foreach ($domain in $domainsToPoint) {
         $source = if ($swaCustomDomains.DomainName -contains $domain) { ' (was on SWA)' } else { '' }
         Write-Information "Domain: $domain$source"
-        Write-Information '  A record'
-        Write-Information "    Name  : $domain"
-        Write-Information "    Value : $NewInboundIp"
-        if ($NewDomainVerificationId) {
-            Write-Information '  TXT record (domain verification)'
-            Write-Information "    Name  : asuid.$domain"
-            Write-Information "    Value : $NewDomainVerificationId"
+        # Subdomains verify via the CNAME alone — no asuid TXT needed (and a stale one from a
+        # previous setup blocks validation; it should be removed). Apex domains map via an A
+        # record, which can't prove ownership, so those still need the verification TXT.
+        $isApex = @($domain.Split('.')).Count -le 2
+        if ($isApex) {
+            Write-Information '  A record'
+            Write-Information "    Name  : $domain"
+            Write-Information "    Value : $NewInboundIp"
+            if ($NewDomainVerificationId) {
+                Write-Information '  TXT record (domain verification — required for apex/A records)'
+                Write-Information "    Name  : asuid.$domain"
+                Write-Information "    Value : $NewDomainVerificationId"
+            }
+        } else {
+            Write-Information '  CNAME record'
+            Write-Information "    Name  : $domain"
+            Write-Information "    Value : $NewHostname"
+            Write-Information "  NOTE: if a TXT record named 'asuid.$domain' exists from a previous setup, REMOVE it — a stale verification record blocks validation. (Only proxied/orange-cloud aliases need it, set to: $NewDomainVerificationId)"
         }
         Write-Information ''
     }

--- a/docs/setup/maintaining-cipp/migrating-to-the-latest-version-of-cipp.md
+++ b/docs/setup/maintaining-cipp/migrating-to-the-latest-version-of-cipp.md
@@ -42,7 +42,7 @@ If you haven't already completed the SSO set up steps you will be prompted to co
 {% step %}
 ### Custom Domain
 
-If you had a custom domain on your old version of CIPP, you'll need to migrate it too. To migrate a domain to the new generation of CIPP, point its existing CNAME record at CIPPXXXX.azurewebsites.net, create the asuid TXT record shown under Add Domain, then add the domain here. It will move over automatically. This step must be performed in the [management portal](https://management.cipp.app/).
+If you had a custom domain on your old version of CIPP, you'll need to migrate it too. To migrate a domain to the new generation of CIPP, point its existing CNAME record at CIPPXXXX.azurewebsites.net, then add the domain here. It will move over automatically. If a TXT record named `asuid.<your domain>` exists from your previous setup, remove it — a stale domain-verification record blocks validation. This step must be performed in the [management portal](https://management.cipp.app/).
 
 {% hint style="warning" %}
 Users who load your pre-existing custom domain prior to the certificate being provisioned will be redirected to the new Azure URL. After the certificate is provisioned they may still experience this behavior as their local DNS cache will remember the redirect. Please direct those users to clear their cache.

--- a/docs/setup/setting-up-cipp/customdomain.md
+++ b/docs/setup/setting-up-cipp/customdomain.md
@@ -34,10 +34,10 @@ Go to [management.cipp.app](https://management.cipp.app/)
 {% step %}
 ### Add DNS Records
 
-The screen will give you an A and TXT record that you need to add to your DNS provider.
+The screen will give you the DNS record you need to add at your DNS provider: a CNAME for a subdomain, or an A record for an apex (root) domain.
 
-{% hint style="info" %}
-Adding a subdomain? Create the records on the subdomain instead: an A record named and a TXT record named asuid.
+{% hint style="warning" %}
+If a TXT record named `asuid.<your domain>` exists from a previous setup, remove it — a stale domain-verification record blocks validation. These records are no longer used.
 {% endhint %}
 {% endstep %}
 

--- a/docs/user-documentation/cipp/advanced/super-admin/custom-domains.md
+++ b/docs/user-documentation/cipp/advanced/super-admin/custom-domains.md
@@ -17,7 +17,7 @@ The App Service card shows the read-only details you need when creating DNS reco
 | Site name              | The name of the App Service hosting this CIPP instance.                                                 |
 | Default hostname       | The App Service's default hostname. Use this as the CNAME target when adding a subdomain.               |
 | Inbound IP (A record)  | The App Service's inbound IP address. Use this as the A record value when adding an apex (root) domain. |
-| Domain verification ID | The value used in the ownership TXT record (at `asuid.<domain>`) to prove you control the domain.       |
+| Domain verification ID | The value for the ownership TXT record (at `asuid.<domain>`). Only needed for apex, wildcard, or proxied domains — a subdomain CNAME proves ownership on its own. |
 
 ## Table Details
 
@@ -42,10 +42,14 @@ Select **Add Custom Domain** to start the wizard, or use **Manage / Fix** on an 
 
 Enter the fully qualified domain CIPP should answer on. This can be a subdomain (for example `portal.contoso.com`), an apex domain (`contoso.com`), or a wildcard (`*.contoso.com`). The wizard then lists the DNS records to create at your DNS provider:
 
-* An **Ownership** TXT record at `asuid.<domain>`, set to the domain verification ID.
 * An **Alias** record: a CNAME pointing to the App Service default hostname for a subdomain, or an A record pointing to the inbound IP for an apex domain.
+* For apex and wildcard domains only, an **Ownership** TXT record at `asuid.<domain>`, set to the domain verification ID. A subdomain's CNAME proves ownership on its own, so no TXT record is needed there.
 
-Create the records, then select **Check DNS** to verify them. Once ownership is confirmed you can continue. Two situations are handled gracefully: a wildcard domain is verified by ownership alone (its alias is validated by Azure when the binding is created), and a proxied alias — such as a Cloudflare "orange-cloud" record — may not be visible to the check, in which case you can still continue and Azure makes the final check at binding time.
+Create the records, then select **Check DNS** to verify them. Once verified you can continue. Two situations are handled gracefully: a wildcard domain is verified by ownership alone (its alias is validated by Azure when the binding is created), and a proxied alias — such as a Cloudflare "orange-cloud" record — is not visible to the check, in which case the wizard asks for the ownership TXT record instead and Azure makes the final check at binding time.
+
+{% hint style="warning" %}
+If an `asuid.<domain>` TXT record exists from a previous setup with a different value, **remove it**. A stale verification record blocks Azure's validation even when the CNAME is correct.
+{% endhint %}
 {% endstep %}
 
 {% step %}

--- a/frontend/src/components/CippSettings/CippAppServiceDomains.jsx
+++ b/frontend/src/components/CippSettings/CippAppServiceDomains.jsx
@@ -27,14 +27,7 @@ import {
   Typography,
 } from "@mui/material";
 import { Grid } from "@mui/system";
-import {
-  CheckCircle,
-  Cancel,
-  HelpOutline,
-  Lock,
-  LockOpen,
-  Refresh,
-} from "@mui/icons-material";
+import { CheckCircle, Cancel, HelpOutline, Lock, LockOpen, Refresh } from "@mui/icons-material";
 import { PlusIcon, TrashIcon, WrenchScrewdriverIcon } from "@heroicons/react/24/outline";
 import { CippDataTable } from "../CippTable/CippDataTable";
 import CippButtonCard from "../CippCards/CippButtonCard";
@@ -65,21 +58,39 @@ const computeRecordPlan = (hostname, siteInfo) => {
   const isApex = !isWildcard && labels.length <= 2;
   const asuidHost = isWildcard ? `asuid.${base}` : `asuid.${host}`;
 
+  // A CNAME alias proves ownership on its own, so subdomains don't get a TXT row up front —
+  // the ownership TXT is only needed for apex/A and wildcard domains (and proxied CNAMEs,
+  // which CheckDns detects and surfaces after the fact).
   return {
     host,
     isWildcard,
     isApex,
     recommendedType: isApex ? "A" : "CNAME",
+    asuidHost,
     records: [
-      {
-        purpose: "Ownership",
-        type: "TXT",
-        host: asuidHost,
-        value: siteInfo?.CustomDomainVerificationId ?? "",
-      },
+      ...(isApex || isWildcard
+        ? [
+            {
+              purpose: "Ownership",
+              type: "TXT",
+              host: asuidHost,
+              value: siteInfo?.CustomDomainVerificationId ?? "",
+            },
+          ]
+        : []),
       isApex
-        ? { purpose: "Alias", type: "A", host, value: siteInfo?.InboundIpAddress ?? "" }
-        : { purpose: "Alias", type: "CNAME", host, value: siteInfo?.DefaultHostName ?? "" },
+        ? {
+            purpose: "Alias",
+            type: "A",
+            host,
+            value: siteInfo?.InboundIpAddress ?? "",
+          }
+        : {
+            purpose: "Alias",
+            type: "CNAME",
+            host,
+            value: siteInfo?.DefaultHostName ?? "",
+          },
     ],
   };
 };
@@ -137,7 +148,9 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
   const [certDone, setCertDone] = useState(false);
   const [dnsResult, setDnsResult] = useState(null);
 
-  const dnsCheck = ApiPostCall({ onResult: (body) => setDnsResult(body?.Results ?? null) });
+  const dnsCheck = ApiPostCall({
+    onResult: (body) => setDnsResult(body?.Results ?? null),
+  });
   const bindingAction = ApiPostCall({
     relatedQueryKeys: [LIST_QUERY_KEY],
     onResult: () => {
@@ -186,6 +199,24 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
 
   const ownershipVerified = dnsResult?.OwnershipVerified ?? false;
   const aliasVerified = dnsResult?.AliasVerified ?? false;
+  const staleAsuid = dnsResult?.StaleAsuid ?? false;
+  const canProceed = dnsResult?.CanProceed ?? false;
+
+  // CheckDns can promote the ownership TXT to required after the fact (proxied CNAME) —
+  // splice it in ahead of the alias row when the client-side plan didn't include it.
+  const visibleRecords = useMemo(() => {
+    const rows = [...plan.records];
+    const hasOwnershipRow = rows.some((r) => r.purpose === "Ownership");
+    if (!hasOwnershipRow && (dnsResult?.OwnershipRequired || staleAsuid)) {
+      rows.unshift({
+        purpose: "Ownership",
+        type: "TXT",
+        host: dnsResult?.AsuidHost ?? plan.asuidHost,
+        value: siteInfo?.CustomDomainVerificationId ?? "",
+      });
+    }
+    return rows;
+  }, [plan, dnsResult, staleAsuid, siteInfo]);
 
   const runDnsCheck = () => {
     dnsCheck.mutate({
@@ -220,7 +251,7 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
           {steps.map((label, idx) => (
             <Step
               key={label}
-              completed={idx === 0 ? ownershipVerified || bindingDone : idx === 1 ? bindingDone : certDone}
+              completed={idx === 0 ? canProceed || bindingDone : idx === 1 ? bindingDone : certDone}
             >
               <StepLabel>{label}</StepLabel>
             </Step>
@@ -251,8 +282,9 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
               <>
                 <Alert severity="info">
                   Create the following records at your DNS provider, then click{" "}
-                  <strong>Check DNS</strong>. The <strong>{plan.recommendedType}</strong> alias record
-                  is recommended for this domain type; Azure also accepts the other alias type.
+                  <strong>Check DNS</strong>. The <strong>{plan.recommendedType}</strong> alias
+                  record is recommended for this domain type; Azure also accepts the other alias
+                  type.
                 </Alert>
                 <Table size="small">
                   <TableHead>
@@ -265,7 +297,7 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {plan.records.map((r) => (
+                    {visibleRecords.map((r) => (
                       <TableRow key={r.purpose}>
                         <TableCell>{r.purpose}</TableCell>
                         <TableCell>
@@ -275,7 +307,12 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
                           {r.host}
                           <CippCopyToClipBoard text={r.host} />
                         </TableCell>
-                        <TableCell sx={{ fontFamily: "monospace", wordBreak: "break-all" }}>
+                        <TableCell
+                          sx={{
+                            fontFamily: "monospace",
+                            wordBreak: "break-all",
+                          }}
+                        >
                           {r.value}
                           {r.value ? <CippCopyToClipBoard text={r.value} /> : null}
                         </TableCell>
@@ -288,22 +325,32 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
                 </Table>
                 {isWildcard && (
                   <Alert severity="warning">
-                    Wildcard domains verify by ownership only; the alias is validated by Azure when the
-                    binding is created. Note: App Service Managed Certificates do not support wildcard
-                    domains — you will need to upload your own certificate for HTTPS.
+                    Wildcard domains verify by ownership only; the alias is validated by Azure when
+                    the binding is created. Note: App Service Managed Certificates do not support
+                    wildcard domains — you will need to upload your own certificate for HTTPS.
                   </Alert>
                 )}
-                {dnsResult && !ownershipVerified && (
+                {staleAsuid && (
+                  <Alert severity="error">
+                    A TXT record at <code>{dnsResult?.AsuidHost}</code> exists with an outdated
+                    verification ID. <strong>Remove it</strong> (or update it to the value shown
+                    above) — a stale domain-verification record blocks Azure's validation even when
+                    the alias record is correct.
+                  </Alert>
+                )}
+                {dnsResult && !staleAsuid && !canProceed && (
                   <Alert severity="warning">
-                    The ownership TXT record hasn't propagated yet. DNS changes can take a few minutes.{" "}
+                    {dnsResult.OwnershipRequired
+                      ? "The required DNS records haven't propagated yet — DNS changes can take a few minutes. If your alias record is proxied (e.g. Cloudflare orange-cloud), Azure can't see it: either set it to DNS-only, or create the ownership TXT record shown above. "
+                      : "The alias record hasn't propagated yet. DNS changes can take a few minutes. "}
                     {dnsResult.AliasDetail}
                   </Alert>
                 )}
-                {dnsResult && ownershipVerified && !aliasVerified && !isWildcard && (
+                {dnsResult && canProceed && !aliasVerified && !isWildcard && (
                   <Alert severity="info">
-                    Ownership is verified. The alias record isn't visible yet — this is expected if the
-                    record is proxied (e.g. Cloudflare orange-cloud). You can continue; Azure will make
-                    the final check when the binding is created.
+                    Ownership is verified. The alias record isn't visible yet — this is expected if
+                    the record is proxied (e.g. Cloudflare orange-cloud). You can continue; Azure
+                    will make the final check when the binding is created.
                   </Alert>
                 )}
                 {dnsCheck.isError && (
@@ -338,7 +385,8 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
           <Stack spacing={2}>
             {certDone ? (
               <Alert severity="success" icon={<Lock fontSize="inherit" />}>
-                <strong>{hostname}</strong> is fully configured and secured with a managed certificate.
+                <strong>{hostname}</strong> is fully configured and secured with a managed
+                certificate.
               </Alert>
             ) : isWildcard ? (
               <Alert severity="warning">
@@ -348,8 +396,8 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
             ) : (
               <>
                 <Alert severity="info">
-                  Provision a free App Service Managed Certificate for <strong>{hostname}</strong> and
-                  enable the SNI SSL binding. This can take a minute or two.
+                  Provision a free App Service Managed Certificate for <strong>{hostname}</strong>{" "}
+                  and enable the SNI SSL binding. This can take a minute or two.
                 </Alert>
                 <Alert severity="warning">
                   If the domain's alias is proxied through a CDN (e.g. Cloudflare orange-cloud),
@@ -366,7 +414,10 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
       <DialogActions sx={{ px: 3, pb: 2, justifyContent: "space-between" }}>
         <Box>
           {activeStep > 0 && !managing && (
-            <Button onClick={() => setActiveStep((s) => s - 1)} disabled={anyPending([dnsCheck, bindingAction, certAction])}>
+            <Button
+              onClick={() => setActiveStep((s) => s - 1)}
+              disabled={anyPending([dnsCheck, bindingAction, certAction])}
+            >
               Back
             </Button>
           )}
@@ -384,11 +435,7 @@ const DomainWizard = ({ open, onClose, siteInfo, initialDomain }) => {
               >
                 {dnsCheck.isPending ? "Checking..." : "Check DNS"}
               </Button>
-              <Button
-                variant="contained"
-                onClick={() => setActiveStep(1)}
-                disabled={!ownershipVerified}
-              >
+              <Button variant="contained" onClick={() => setActiveStep(1)} disabled={!canProceed}>
                 Next
               </Button>
             </>
@@ -499,7 +546,11 @@ export const CippAppServiceDomains = () => {
         </Box>
         <Divider />
         <Stack direction="row" spacing={1} alignItems="center">
-          {row.Secured ? <Lock color="success" fontSize="small" /> : <LockOpen color="disabled" fontSize="small" />}
+          {row.Secured ? (
+            <Lock color="success" fontSize="small" />
+          ) : (
+            <LockOpen color="disabled" fontSize="small" />
+          )}
           <Typography variant="body2">{sslStateLabel(row.SslState)}</Typography>
         </Stack>
         {row.HostNameType && (
@@ -533,11 +584,11 @@ export const CippAppServiceDomains = () => {
     <Grid container spacing={3}>
       <Grid size={{ xs: 12 }}>
         <Alert severity="info">
-          Map custom domains to the App Service that hosts this CIPP instance. Each domain needs a DNS
-          ownership record and an alias record, a hostname binding, and (optionally) a free managed
-          TLS certificate — the wizard walks through all three and can be reopened at any time to
-          finish or fix a domain. The default <code>*.azurewebsites.net</code> hostname always remains
-          available.
+          Map custom domains to the App Service that hosts this CIPP instance. Each domain needs a
+          DNS ownership record and an alias record, a hostname binding, and (optionally) a free
+          managed TLS certificate — the wizard walks through all three and can be reopened at any
+          time to finish or fix a domain. The default <code>*.azurewebsites.net</code> hostname
+          always remains available.
         </Alert>
       </Grid>
 
@@ -565,8 +616,11 @@ export const CippAppServiceDomains = () => {
                   value={siteInfo?.CustomDomainVerificationId}
                 />
                 <Typography variant="caption" color="text.secondary">
-                  Use the default hostname as the CNAME target for subdomains, the inbound IP as the A
-                  record for apex domains, and the verification ID as the <code>asuid</code> TXT value.
+                  Use the default hostname as the CNAME target for subdomains, and the inbound IP as
+                  the A record for apex domains. The verification ID is only needed as an{" "}
+                  <code>asuid</code> TXT value for apex, wildcard or proxied domains — a subdomain
+                  CNAME verifies on its own, and a stale <code>asuid</code> record should be
+                  removed.
                 </Typography>
               </Stack>
             )}


### PR DESCRIPTION
Azure accepts a matching CNAME as sufficient proof of domain ownership, so the asuid TXT record is not required for subdomain aliases. This change:

- Removes the TXT row from the wizard for subdomains (apex/wildcard still require it)
- Detects stale/mismatched asuid TXT records and surfaces an error with removal guidance — a wrong TXT blocks validation even when the CNAME is correct
- Introduces CanProceed/AsuidState/StaleAsuid fields from CheckDns so the frontend can gate the Next button correctly
- Updates migration script to recommend CNAME for subdomains and warn about stale TXT records
- Updates all docs to reflect the new requirements