### PR TITLE
fix(frontend): fix CippAutocomplete dropdown orphaning

### DIFF
--- a/frontend/src/components/CippComponents/CippAutocomplete.jsx
+++ b/frontend/src/components/CippComponents/CippAutocomplete.jsx
@@ -332,6 +332,13 @@ export const CippAutoComplete = React.forwardRef((props, ref) => {
     return keyParts.join('-')
   }, [defaultValue, preselectedValue, api?.url, currentTenant])
 
+  // keyed remount orphans an open single-mode popup (input unfocused, no close path), multiple refocuses in onChange
+  useEffect(() => {
+    if (!multiple) {
+      setOpen(false)
+    }
+  }, [stableKey, multiple])
+
   const lookupOptionByValue = useCallback(
     (value) => {
       const foundOption = memoizedOptions.find((option) => option.value === value)


### PR DESCRIPTION
Issue:
CippAutoComplete wraps MUI Autocomplete with `key={stableKey}`. Whenever any of the values in `stableKey` change (defaultValue, preselectedValue, api.url, current tenant), the Autocomplete is remounted and the popup reopens with focus lost, so the normal close paths (blur, escape, click-away) target the unmounted component. The only way to close it is to select a value or click the close chevron.

Most visible on clearable single-selects: clicking the 'x' changes the value, which changes stableKey, which remounts mid-interaction and strands the open popup.

Fix:
Add an effect: whenever `stableKey` changes, close the popup (setOpen(false)).
Multi-select is deliberately excluded, its onChange already refocuses the input and restores scroll, and closing there would break keep-open-while-multi-selecting.

Note: 
this form component currently has a weird interaction with CippFormComponent where the selected value is fed back into stableKey as defaultValue so any time the value changes, the entire autocomplete component is remounted unnecessarily.   changing this behavior is a wider fix and outside the scope of this change.   changing the selected value should not remount the component. 

Repro example:
<img width="600" height="514" alt="fix-autocomplete" src="https://github.com/user-attachments/assets/70e74e8e-2512-4313-9456-a25d9f8a2b9b" />
