### PR TITLE
fix(frontend): graph explorer ux fixes/crash handling

### DIFF
--- a/frontend/src/components/CippTable/CippGraphExplorerFilter.js
+++ b/frontend/src/components/CippTable/CippGraphExplorerFilter.js
@@ -32,7 +32,6 @@ const CippGraphExplorerFilter = ({
   selectedPreset = null,
   onPresetSelect,
   hideButtons = false,
-  initialValues = null,
 }) => {
   const [offCanvasOpen, setOffCanvasOpen] = useState(false)
   const [cardExpanded, setCardExpanded] = useState(true)
@@ -67,12 +66,6 @@ const CippGraphExplorerFilter = ({
       reportTemplate: null,
     },
   })
-
-  useEffect(() => {
-    if (initialValues && !selectedPreset) {
-      formControl.reset({ ...formControl.getValues(), ...initialValues }, { keepDefaultValues: true })
-    }
-  }, [])
 
   const defaultGraphExplorerTitle = 'Graph Explorer'
 
@@ -226,60 +219,48 @@ const CippGraphExplorerFilter = ({
     if (option.value !== selectedPresets?.value) {
       presetControl.setValue('reportTemplate', option)
     }
-  }, [selectedPreset?.id, selectedPreset?.filterName, presetOptions])
+    // selectedPreset?.value covers the autocomplete option shape (no id/filterName keys)
+  }, [selectedPreset?.id, selectedPreset?.filterName, selectedPreset?.value, presetOptions])
 
   useEffect(() => {
     if (selectedPresets?.addedFields?.params) {
       setPresetOwner(selectedPresets?.addedFields?.IsMyPreset ?? false)
-      Object.keys(selectedPresets.addedFields.params).forEach(
-        (key) =>
-          selectedPresets.addedFields.params[key] == null &&
-          delete selectedPresets.addedFields.params[key]
-      )
-      //if $select is a blank array, set it to a string.
-      if (
-        selectedPresets.addedFields.params.$select &&
-        selectedPresets.addedFields.params.$select.length === 0
-      ) {
-        selectedPresets.addedFields.params.$select = ''
-      }
 
-      // if $select is an array, extract the values and comma separate
-      if (
-        Array.isArray(selectedPresets.addedFields.params.$select) &&
-        selectedPresets.addedFields.params.$select.length > 0
-      ) {
-        selectedPresets.addedFields.params.$select = selectedPresets.addedFields.params.$select
-          .map((item) => item.value)
-          .join(',')
+      // normalize on a copy, addedFields.params is shared state (defaultPresets module / react-query cache)
+      const params = { ...selectedPresets.addedFields.params }
+      Object.keys(params).forEach((key) => {
+        if (params[key] == null) {
+          delete params[key]
+        }
+      })
+
+      // $select arrives as comma string (built-in presets) or array (saved presets), form needs [{label,value}]
+      if (Array.isArray(params.$select)) {
+        params.$select = params.$select.map((item) =>
+          typeof item === 'string' ? { label: item, value: item } : item
+        )
+      } else if (typeof params.$select === 'string' && params.$select !== '') {
+        params.$select = params.$select.split(',').map((item) => ({ label: item, value: item }))
+      } else {
+        params.$select = []
       }
-      selectedPresets.addedFields.params.$select !== ''
-        ? (selectedPresets.addedFields.params.$select = selectedPresets.addedFields.params?.$select
-            ?.split(',')
-            .map((item) => ({ label: item, value: item })))
-        : (selectedPresets.addedFields.params.$select = [])
 
       // Convert version string to autocomplete object format, default to beta if not present
-      if (selectedPresets.addedFields.params.version) {
+      if (params.version) {
         const versionValue =
-          typeof selectedPresets.addedFields.params.version === 'string'
-            ? selectedPresets.addedFields.params.version
-            : selectedPresets.addedFields.params.version.value
-        selectedPresets.addedFields.params.version = {
-          label: versionValue,
-          value: versionValue,
-        }
+          typeof params.version === 'string' ? params.version : params.version.value
+        params.version = { label: versionValue, value: versionValue }
       } else {
-        selectedPresets.addedFields.params.version = { label: 'beta', value: 'beta' }
+        params.version = { label: 'beta', value: 'beta' }
       }
 
-      selectedPresets.addedFields.params.id = selectedPresets.value
+      params.id = selectedPresets.value
       setSelectedPreset(selectedPresets.value)
-      selectedPresets.addedFields.params.name = selectedPresets.label
+      params.name = selectedPresets.label
 
       // save last preset title
       setLastPresetTitle(selectedPresets.label)
-      formControl.reset(selectedPresets?.addedFields?.params, { keepDefaultValues: true })
+      formControl.reset(params, { keepDefaultValues: true })
 
       // Notify parent when preset changes in this component
       if (onPresetSelect) {
@@ -507,8 +488,9 @@ const CippGraphExplorerFilter = ({
   }
   // Handle filter form submission
   const onSubmit = (values) => {
-    if (values.$select && Array.isArray(values.$select) && values.$select.length > 0) {
-      values.$select = values?.$select?.map((item) => item.value)?.join(',')
+    if (Array.isArray(values.$select)) {
+      // empty array joins to '', removed by the null/empty cleanup below
+      values.$select = values.$select.map((item) => item.value).join(',')
     }
     if (values.version && values.version.value) {
       values.version = values.version.value
@@ -533,7 +515,11 @@ const CippGraphExplorerFilter = ({
     delete values.id
     delete values.IsShared
     delete values.reportTemplate
-    delete values.ReverseTenantLookupProperty
+    delete values.manualPagination
+    if (!values.ReverseTenantLookup) {
+      // property only means something with the lookup enabled
+      delete values.ReverseTenantLookupProperty
+    }
 
     Object.keys(values).forEach((key) => {
       if (values[key] === null || values[key] === '') {

--- a/frontend/src/components/CippTable/CippGraphExplorerSimpleFilter.js
+++ b/frontend/src/components/CippTable/CippGraphExplorerSimpleFilter.js
@@ -59,6 +59,11 @@ const CippGraphExplorerSimpleFilter = ({
   }, [defaultPresets, presetList.isSuccess, presetList.data]);
 
   const handleRunPreset = () => {
+    // re-run the last applied query from the edit drawer, preset change clears it
+    if (currentFilterValues) {
+      onSubmitFilter(currentFilterValues);
+      return;
+    }
     if (selectedPreset?.addedFields?.params) {
       const params = selectedPreset.addedFields.params;
       const values = { ...params };
@@ -68,7 +73,7 @@ const CippGraphExplorerSimpleFilter = ({
         values.$select = values.$select
           .map((item) => (typeof item === "string" ? item : item.value))
           .join(",");
-      } else if (values.$select === "") {
+      } else if (!values.$select || values.$select.length === 0) {
         delete values.$select;
       }
 
@@ -93,7 +98,10 @@ const CippGraphExplorerSimpleFilter = ({
         delete values.AsApp;
       }
 
-      // Remove null/empty values
+      // Remove non-API fields and null/empty values (presets saved from the form carry id/name/IsShared in params)
+      delete values.id;
+      delete values.name;
+      delete values.IsShared;
       Object.keys(values).forEach((key) => {
         if (values[key] === null || values[key] === "") {
           delete values[key];
@@ -117,8 +125,14 @@ const CippGraphExplorerSimpleFilter = ({
   };
 
   const handlePresetChange = (preset) => {
+    setCurrentFilterValues(null);
     presetControl.setValue("reportTemplate", preset);
   };
+
+  // preset picked directly in the bar, discard drawer edits so Run uses the pristine preset
+  useEffect(() => {
+    setCurrentFilterValues(null);
+  }, [selectedPreset?.value]);
 
   return (
     <>
@@ -148,7 +162,7 @@ const CippGraphExplorerSimpleFilter = ({
             color="primary"
             startIcon={<PlayCircle />}
             onClick={handleRunPreset}
-            disabled={!selectedPreset}
+            disabled={!selectedPreset && !currentFilterValues}
             sx={{ minWidth: "100px" }}
           >
             Run
@@ -180,6 +194,7 @@ const CippGraphExplorerSimpleFilter = ({
         visible={offCanvasVisible}
         onClose={() => setOffCanvasVisible(false)}
         contentPadding={1}
+        keepMounted={true}
       >
         <CippGraphExplorerFilter
           onSubmitFilter={handleFilterSubmit}
@@ -188,7 +203,6 @@ const CippGraphExplorerSimpleFilter = ({
           relatedQueryKeys={relatedQueryKeys}
           selectedPreset={selectedPreset}
           onPresetSelect={handlePresetChange}
-          initialValues={currentFilterValues}
         />
       </CippOffCanvas>
     </>

--- a/frontend/src/pages/tenant/tools/graph-explorer/index.js
+++ b/frontend/src/pages/tenant/tools/graph-explorer/index.js
@@ -1,12 +1,12 @@
 import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
 import CippGraphExplorerSimpleFilter from "../../../../components/CippTable/CippGraphExplorerSimpleFilter";
+import { CippDataTable } from "../../../../components/CippTable/CippDataTable";
 import { useState } from "react";
 import { Grid, Stack, Box, Container } from "@mui/system";
 import { useSettings } from "../../../../hooks/use-settings";
 import { CippCodeBlock } from "../../../../components/CippComponents/CippCodeBlock";
 import { ApiGetCallWithPagination } from "../../../../api/ApiCall";
-import { CircularProgress, Typography, Card } from "@mui/material";
+import { Alert, CircularProgress, Divider, Typography, Card } from "@mui/material";
 import { CippHead } from "../../../../components/CippComponents/CippHead";
 
 const Page = () => {
@@ -15,9 +15,10 @@ const Page = () => {
   const [viewMode, setViewMode] = useState("table");
   const tenantFilter = useSettings().currentTenant;
   const queryKey = JSON.stringify({ apiFilter, tenantFilter });
+  const apiUrl = apiFilter.endpoint ? "/api/ListGraphRequest" : "/api/ListEmptyResults";
 
   const apiData = ApiGetCallWithPagination({
-    url: apiFilter.endpoint ? "/api/ListGraphRequest" : "/api/ListEmptyResults",
+    url: apiUrl,
     data: { tenantFilter, ...apiFilter },
     queryKey: queryKey,
     waiting: !!apiFilter.endpoint && viewMode === "json",
@@ -25,89 +26,93 @@ const Page = () => {
 
   const jsonData = apiData?.data?.pages?.[0]?.Results || apiData?.data || {};
 
-  if (viewMode === "json") {
-    return (
-      <>
-        <CippHead title={pageTitle} />
-        <Box>
-          <Container maxWidth={false} sx={{ height: "100%" }}>
-            <Stack spacing={2} sx={{ height: "calc(100vh - 200px)" }}>
-              <Grid container spacing={2}>
-                <Grid size={{ xs: 12 }}>
-                  <CippGraphExplorerSimpleFilter
-                    onSubmitFilter={setApiFilter}
-                    onPresetChange={setPageTitle}
-                    viewMode={viewMode}
-                    onViewModeChange={setViewMode}
-                  />
-                </Grid>
-              </Grid>
-              <Typography variant="h6" component="h1">
-                {pageTitle}
-              </Typography>
-              <Card sx={{ flex: 1, minHeight: 0, overflow: "hidden", position: "relative" }}>
-                {apiData.isLoading || apiData.isFetching ? (
-                  <Box
-                    sx={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      backgroundColor: "rgba(0, 0, 0, 0.3)",
-                      zIndex: 10,
-                      gap: 2,
-                    }}
-                  >
-                    <CircularProgress size={60} />
-                    <Typography variant="body1" color="text.secondary">
-                      Loading data...
-                    </Typography>
-                  </Box>
-                ) : null}
-                <CippCodeBlock
-                  type="editor"
-                  key={queryKey}
-                  code={JSON.stringify(jsonData, null, 2)}
-                  editorHeight="calc(100vh - 260px)"
-                  showLineNumbers={true}
-                  readOnly={true}
-                />
-              </Card>
-            </Stack>
-          </Container>
-        </Box>
-      </>
-    );
-  }
-
+  // the filter bar (and its edit drawer) mounts once, view toggles only swap the content below
   return (
-    <CippTablePage
-      tableFilter={
-        <Grid container spacing={2}>
-          <Grid size={{ xs: 12 }}>
-            <CippGraphExplorerSimpleFilter
-              onSubmitFilter={setApiFilter}
-              onPresetChange={setPageTitle}
-              viewMode={viewMode}
-              onViewModeChange={setViewMode}
-            />
-          </Grid>
-        </Grid>
-      }
-      title={pageTitle}
-      apiDataKey="Results"
-      apiUrl={apiFilter.endpoint ? "/api/ListGraphRequest" : "/api/ListEmptyResults"}
-      apiData={apiFilter}
-      queryKey={queryKey}
-      /*Key={`${apiFilter.endpoint}-${apiFilter.$select}`}*/
-      simpleColumns={apiFilter?.$select != "" ? apiFilter?.$select?.split(",") : []}
-      clearOnError={true}
-    />
+    <>
+      <CippHead title={pageTitle} />
+      <Box>
+        <Container maxWidth={false} sx={{ height: "100%" }}>
+          <Stack
+            spacing={2}
+            sx={{ height: viewMode === "json" ? "calc(100vh - 200px)" : "100%" }}
+          >
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12 }}>
+                <CippGraphExplorerSimpleFilter
+                  onSubmitFilter={setApiFilter}
+                  onPresetChange={setPageTitle}
+                  viewMode={viewMode}
+                  onViewModeChange={setViewMode}
+                />
+              </Grid>
+            </Grid>
+            {viewMode === "json" ? (
+              <>
+                <Typography variant="h6" component="h1">
+                  {pageTitle}
+                </Typography>
+                <Card sx={{ flex: 1, minHeight: 0, overflow: "hidden", position: "relative" }}>
+                  {apiData.isLoading || apiData.isFetching ? (
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        backgroundColor: "rgba(0, 0, 0, 0.3)",
+                        zIndex: 10,
+                        gap: 2,
+                      }}
+                    >
+                      <CircularProgress size={60} />
+                      <Typography variant="body1" color="text.secondary">
+                        Loading data...
+                      </Typography>
+                    </Box>
+                  ) : null}
+                  <CippCodeBlock
+                    type="editor"
+                    key={queryKey}
+                    code={JSON.stringify(jsonData, null, 2)}
+                    editorHeight="calc(100vh - 260px)"
+                    showLineNumbers={true}
+                    readOnly={true}
+                  />
+                </Card>
+              </>
+            ) : (
+              <>
+                {!tenantFilter && (
+                  <Alert severity="warning">
+                    No tenant selected. Please select a tenant from the dropdown above.
+                  </Alert>
+                )}
+                <Card sx={{ display: "flex" }}>
+                  <Divider />
+                  <CippDataTable
+                    queryKey={queryKey}
+                    title={tenantFilter ? `${pageTitle} - ${tenantFilter}` : pageTitle}
+                    simple={false}
+                    api={{
+                      url: apiUrl,
+                      data: { tenantFilter, ...apiFilter },
+                      dataKey: "Results",
+                    }}
+                    simpleColumns={apiFilter?.$select != "" ? apiFilter?.$select?.split(",") : []}
+                    clearOnError={true}
+                  />
+                </Card>
+              </>
+            )}
+          </Stack>
+        </Container>
+      </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
Issues:
- toggling between table/json view rebuilds the filter bar and resets any selected preset, or query settings in the drawer
- edits made in the query drawer are lost on close
- saved presets storing $select as an array populate the form incorrectly, so switching between the two types sometimes doesn't apply the second one
- preset normalization rewrote objects in-place, corrupting built-in presets until a reload
- submitting with reverse tenant lookup enabled dropped the property and manualPagination leaked into api params

Fixes:
pages/tenant/tools/graph-explorer/index.js
- one layout for both views; the filter bar (and its drawer) mounts once, the view toggle only swaps the content below it
- table mode renders CippDataTable directly (was CippTablePage in a separate return branch, which forced the bar remount)
- warning alert when no tenant is selected

CippGraphExplorerSimpleFilter.js
- drawer is keepMounted, so drawer form state survives close/reopen
- last applied drawer query is kept: Run re-runs it; picking a preset (bar or drawer) discards it so Run uses the pristine preset again
- Run enabled when a preset is selected or drawer edits exist
removed the initialValues remount workaround (unneeded with keepMounted)
- Run conversion strips id/name/IsShared that saved-from-form presets carry in params

CippGraphExplorerFilter.js
- preset params are normalized on a copy; the source objects (GraphExplorerPresets module, react-query cache) are never mutated
- $select accepts a comma string, a string array, or a {label, value} array
- preset-sync effect also keys on selectedPreset.value, so option-shape presets (no id/filterName) re-apply on change
- submit keeps ReverseTenantLookupProperty when the lookup is enabled, drops manualPagination, omits empty $select
- removed the now-unused initialValues prop

Repros:
Run button state disabled after manual edits in drawer:
<img width="800" height="404" alt="graph-explorer-run-button" src="https://github.com/user-attachments/assets/31680742-0165-461b-9d7e-07f20d59d8fa" />

Swapping between table/json view resets state:
<img width="800" height="404" alt="graph-explorer-json-swap" src="https://github.com/user-attachments/assets/5be99c37-63b5-44e5-b8bf-c57ed0847319" />

Drawer resetting values on close:
<img width="800" height="404" alt="graph-explorer-swallow-values" src="https://github.com/user-attachments/assets/fd60d44e-c978-4939-879f-e6b20c2a0383" />

Page crash on $select
<img width="800" height="404" alt="graph-explorer-crash" src="https://github.com/user-attachments/assets/db0ec518-fd12-4968-80c5-43db31eca39f" />
