### PR TITLE
Feat: Add bulk action assignment feature

### DIFF
--- a/docs/user-documentation/tenant/standards/template.md
+++ b/docs/user-documentation/tenant/standards/template.md
@@ -52,7 +52,7 @@ Toggle on the "Add this standard to the template" for each desired template. Onc
 
 For each standard:
 
-* Set the desired Action(s). For assistance on selecting which action, review [#actions](./#actions "mention"). Drift configuration standards will instead have an optional toggle to allow you to automatically remediate when drift is detected.
+* Set the desired Action(s). For assistance on selecting which action, review [#actions](./#actions "mention"). Drift configuration standards will instead have an optional toggle to allow you to automatically remediate when drift is detected. To set the same action(s) on every standard in the template at once, use the "Set All Actions" button in the toolbar above the standards list: tick the desired action(s) and choose "Apply to all standards". This replaces each standard's current action selection; actions a standard does not support are skipped for that standard.
 * Each standard will then have the potential for additional fields that need to be set. Please review those fields and configure as desired.
 
 {% hint style="info" %}

--- a/frontend/src/components/CippStandards/CippStandardAccordion.jsx
+++ b/frontend/src/components/CippStandards/CippStandardAccordion.jsx
@@ -16,6 +16,10 @@ import {
   InputAdornment,
   ButtonGroup,
   Button,
+  Menu,
+  MenuItem,
+  Checkbox,
+  ListItemText,
 } from "@mui/material";
 import {
   ExpandMore as ExpandMoreIcon,
@@ -121,6 +125,8 @@ const CippStandardAccordion = ({
   const [searchQuery, setSearchQuery] = useState("");
   const [savedValues, setSavedValues] = useState({});
   const [originalValues, setOriginalValues] = useState({});
+  const [bulkAnchorEl, setBulkAnchorEl] = useState(null);
+  const [bulkActions, setBulkActions] = useState([]);
 
   const watchedValues = useWatch({
     control: formControl.control,
@@ -367,6 +373,44 @@ const CippStandardAccordion = ({
     formControl.setValue(`${standardName}.action`, action);
   };
 
+  // Apply the selected action set to every standard in the template
+  const handleBulkSetActions = () => {
+    // Collapse any expanded accordion so the action change isn't edited underneath the user
+    if (expanded) {
+      handleAccordionToggle(null);
+    }
+
+    const newSaved = {};
+    const newConfigured = {};
+
+    Object.keys(selectedStandards).forEach((standardName) => {
+      const baseStandardName = standardName.split("[")[0];
+      const standard = providedStandards.find((s) => s.name === baseStandardName);
+      if (!standard) return; // unknown/removed standard — skip
+      if (standard.deprecated) return; // deprecated standards can't be configured
+
+      // Replace the action selection, keeping only actions this standard supports
+      const nextActions = getAvailableActions(standard.disabledFeatures).filter((action) =>
+        bulkActions.includes(action.value),
+      );
+      if (nextActions.length === 0) return;
+
+      formControl.setValue(`${standardName}.action`, nextActions, { shouldDirty: true });
+
+      // Only the action is saved — any other unsaved edits stay unsaved so Cancel still reverts them
+      const previous = get(savedValues, standardName);
+      const merged = previous
+        ? { ...cloneDeep(previous), action: nextActions }
+        : { action: nextActions };
+      newSaved[standardName] = merged;
+      newConfigured[standardName] = isStandardConfigured(standardName, standard, merged);
+    });
+
+    setSavedValues((prev) => ({ ...prev, ...newSaved }));
+    setConfiguredState((prev) => ({ ...prev, ...newConfigured }));
+    setBulkAnchorEl(null);
+  };
+
   // Cancel changes for a standard
   const handleCancel = (standardName) => {
     // Get the last saved values
@@ -517,6 +561,8 @@ const CippStandardAccordion = ({
           <Stack
             direction={{ xs: "column", sm: "row" }}
             spacing={2}
+            flexWrap="wrap"
+            useFlexGap
             sx={{
               mt: 2,
               mb: 3,
@@ -611,6 +657,52 @@ const CippStandardAccordion = ({
                 Unconfigured ({standardCounts.unconfiguredCount})
               </Button>
             </ButtonGroup>
+            {!isDriftMode && (
+              <>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  size="small"
+                  onClick={(e) => setBulkAnchorEl(e.currentTarget)}
+                >
+                  Set All Actions
+                </Button>
+                <Menu
+                  anchorEl={bulkAnchorEl}
+                  open={Boolean(bulkAnchorEl)}
+                  onClose={() => setBulkAnchorEl(null)}
+                >
+                  {getAvailableActions({}).map((action) => (
+                    <MenuItem
+                      key={action.value}
+                      dense
+                      onClick={() =>
+                        setBulkActions((prev) =>
+                          prev.includes(action.value)
+                            ? prev.filter((v) => v !== action.value)
+                            : [...prev, action.value],
+                        )
+                      }
+                    >
+                      <Checkbox
+                        size="small"
+                        checked={bulkActions.includes(action.value)}
+                        disableRipple
+                        sx={{ p: 0.5, mr: 1 }}
+                      />
+                      <ListItemText primary={action.label} />
+                    </MenuItem>
+                  ))}
+                  <Divider />
+                  <MenuItem dense disabled={bulkActions.length === 0} onClick={handleBulkSetActions}>
+                    <ListItemText
+                      primary="Apply to all standards"
+                      slotProps={{ primary: { color: "primary" } }}
+                    />
+                  </MenuItem>
+                </Menu>
+              </>
+            )}
           </Stack>
 
           {!hasFilteredStandards && (


### PR DESCRIPTION
Introduce a toolbar menu that allows users to apply selected actions across all supported standards.
This makes it very easy to deploy a "Report only" standard based on applied templates if customers wants to know what changes, before its applied.