### PR TITLE
feat(standards): add bulk Set Schedule action for standards templates

### DIFF
--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecStandardTemplateSchedule.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecStandardTemplateSchedule.ps1
@@ -1,0 +1,57 @@
+function Invoke-ExecStandardTemplateSchedule {
+  <#
+  .FUNCTIONALITY
+      Entrypoint
+  .ROLE
+      Tenant.Standards.ReadWrite
+  #>
+  [CmdletBinding()]
+  param($Request, $TriggerMetadata)
+
+  $APIName = $Request.Params.CIPPEndpoint
+  $Headers = $Request.Headers
+  $ID = $Request.Body.TemplateId ?? $Request.Query.TemplateId
+  # The stored field is runManually: $true means "do not run on schedule".
+  $RunManually = $Request.Body.runManually -eq $true -or $Request.Body.runManually -eq 'true'
+  $StatusCode = [HttpStatusCode]::InternalServerError
+
+  try {
+    $Table = Get-CippTable -tablename 'templates'
+    $SafeID = ConvertTo-CIPPODataFilterValue -Value $ID -Type Guid
+    $Entity = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'StandardsTemplateV2' and RowKey eq '$SafeID'"
+    if (-not $Entity) {
+      $StatusCode = [HttpStatusCode]::BadRequest
+      throw "Standards template '$ID' was not found."
+    }
+
+    $Data = $Entity.JSON | ConvertFrom-Json -Depth 100
+    if ($Data.type -eq 'drift') {
+      $StatusCode = [HttpStatusCode]::BadRequest
+      throw "Template '$($Data.templateName)' is a drift template and does not run on a schedule."
+    }
+
+    $Data | Add-Member -NotePropertyName 'runManually' -NotePropertyValue $RunManually -Force
+    $Data | Add-Member -NotePropertyName 'updatedBy' -NotePropertyValue ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Headers.'x-ms-client-principal')) | ConvertFrom-Json).userDetails -Force
+    $Data | Add-Member -NotePropertyName 'updatedAt' -NotePropertyValue (Get-Date).ToUniversalTime() -Force
+
+    $Entity.JSON = (ConvertTo-Json -Compress -Depth 100 -InputObject $Data)
+    $null = Add-CIPPAzDataTableEntity @Table -Entity $Entity -Force
+
+    $Result = $RunManually ?
+        "Disabled the schedule for template '$($Data.templateName)'. It will only run when triggered manually." :
+        "Enabled the schedule for template '$($Data.templateName)'."
+    Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Info
+    $StatusCode = [HttpStatusCode]::OK
+  } catch {
+    if ($StatusCode -eq [HttpStatusCode]::BadRequest) {
+      $Result = $_.Exception.Message
+      Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Warning
+    } else {
+      $ErrorMessage = Get-CippException -Exception $_
+      $Result = "Failed to update the schedule for template id $($ID). Error: $($ErrorMessage.NormalizedError)"
+      Write-LogMessage -Headers $Headers -API $APIName -message $Result -Sev Error -LogData $ErrorMessage
+    }
+  }
+
+  return ([HttpResponseContext]@{ StatusCode = $StatusCode; Body = @{ 'Results' = $Result } })
+}

--- a/frontend/src/pages/tenant/standards/templates/index.js
+++ b/frontend/src/pages/tenant/standards/templates/index.js
@@ -3,7 +3,7 @@ import { CippTablePage } from '../../../../components/CippComponents/CippTablePa
 import { Layout as DashboardLayout } from '../../../../layouts/index.js' // had to add an extra path here because I added an extra folder structure. We should switch to absolute pathing so we dont have to deal with relative.
 import { TabbedLayout } from '../../../../layouts/TabbedLayout'
 import Link from 'next/link'
-import { CopyAll, Delete, PlayArrow, AddBox, Edit, GitHub, ContentCopy } from '@mui/icons-material'
+import { CopyAll, Delete, PlayArrow, AddBox, Edit, GitHub, ContentCopy, Schedule } from '@mui/icons-material'
 import { ApiGetCall, ApiPostCall } from '../../../../api/ApiCall'
 import { Grid } from '@mui/system'
 import { CippApiResults } from '../../../../components/CippComponents/CippApiResults'
@@ -81,6 +81,34 @@ const Page = () => {
         />
       ),
       confirmText: 'Are you sure you want to force a run of this template?',
+      multiPost: false,
+    },
+    {
+      label: 'Set Schedule',
+      title: 'Set Schedule',
+      type: 'POST',
+      url: '/api/ExecStandardTemplateSchedule',
+      icon: <Schedule />,
+      data: {
+        TemplateId: 'GUID',
+      },
+      fields: [
+        {
+          label: 'Schedule',
+          name: 'runManually',
+          type: 'select',
+          multiple: false,
+          creatable: false,
+          options: [
+            { label: 'Disable schedule (run manually only)', value: 'true' },
+            { label: 'Enable schedule', value: 'false' },
+          ],
+          required: true,
+          validators: { required: { value: true, message: 'This field is required' } },
+        },
+      ],
+      confirmText: 'Set the schedule for [templateName]?',
+      condition: (row) => row.type !== 'drift',
       multiPost: false,
     },
     {


### PR DESCRIPTION
Adds a "Set Schedule" action to the standards templates table so the "Do not run on schedule" (`runManually`) flag can be changed for one or many templates at once, instead of opening each template in the editor.

`AddStandardsTemplate` replaces the entire template row, so it cannot be reused for a single-field update. This adds an `ExecStandardTemplateSchedule` entrypoint that does a targeted read-modify-write: load the entity, set `runManually` along with `updatedBy`/`updatedAt`, and write the entity back so the `SHA`/`Source` columns behind the `isSynced` flag are preserved.

Drift templates are rejected in both the UI action condition and the endpoint, since they do not run on a schedule.