### PR TITLE
fix(frontend): readable hover state on remove photo button

### DIFF
--- a/frontend/src/components/CippCards/CippUserInfoCard.jsx
+++ b/frontend/src/components/CippCards/CippUserInfoCard.jsx
@@ -193,7 +193,7 @@ export const CippUserInfoCard = (props) => {
                           sx={{
                             backgroundColor: "action.hover",
                             "&:hover": {
-                              backgroundColor: "error.light",
+                              backgroundColor: "error.main",
                               color: "error.contrastText",
                             },
                           }}


### PR DESCRIPTION
High contrast on hover makes the icon illegible. 
<img width="282" height="258" alt="image" src="https://github.com/user-attachments/assets/2003870b-4c0b-482b-9442-1d3925f0438a" />

Fixed, swap theme color:
<img width="236" height="285" alt="image" src="https://github.com/user-attachments/assets/b4ed3be3-6068-46d3-bd82-064d3d9d1171" />

