### PR TITLE
fix(frontend): wrap disableable tooltip children in span

### DIFF
--- a/frontend/src/components/CippComponents/CippReportToolbar.jsx
+++ b/frontend/src/components/CippComponents/CippReportToolbar.jsx
@@ -128,12 +128,14 @@ export const CippReportToolbar = () => {
           }
           arrow
         >
-          <CippAddTestReportDrawer
-            buttonText="Edit"
-            mode="edit"
-            reportToEdit={selectedCustomReport}
-            disabled={!selectedCustomReport}
-          />
+          <Box component="span">
+            <CippAddTestReportDrawer
+              buttonText="Edit"
+              mode="edit"
+              reportToEdit={selectedCustomReport}
+              disabled={!selectedCustomReport}
+            />
+          </Box>
         </Tooltip>
         <Tooltip
           title={

--- a/frontend/src/components/CippComponents/CippUserPhotoManager.jsx
+++ b/frontend/src/components/CippComponents/CippUserPhotoManager.jsx
@@ -299,23 +299,25 @@ export const CippUserPhotoManager = ({
           {/* Camera overlay button when not in upload mode */}
           {!selectedFile && (
             <Tooltip title="Change Photo">
-              <IconButton
-                sx={{
-                  position: "absolute",
-                  bottom: 0,
-                  right: 0,
-                  backgroundColor: "primary.main",
-                  color: "white",
-                  "&:hover": {
-                    backgroundColor: "primary.dark",
-                  },
-                }}
-                size="small"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={isLoading}
-              >
-                <PhotoCamera fontSize="small" />
-              </IconButton>
+              <span>
+                <IconButton
+                  sx={{
+                    position: "absolute",
+                    bottom: 0,
+                    right: 0,
+                    backgroundColor: "primary.main",
+                    color: "white",
+                    "&:hover": {
+                      backgroundColor: "primary.dark",
+                    },
+                  }}
+                  size="small"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isLoading}
+                >
+                  <PhotoCamera fontSize="small" />
+                </IconButton>
+              </span>
             </Tooltip>
           )}
         </Box>

--- a/frontend/src/components/CippWizard/CippTenantModeDeploy.jsx
+++ b/frontend/src/components/CippWizard/CippTenantModeDeploy.jsx
@@ -63,13 +63,15 @@ export const CippTenantModeDeploy = (props) => {
             Partner Tenant
           </Typography>
           <Tooltip title="Refresh partner tenant information">
-            <IconButton
-              size="small"
-              onClick={() => partnerTenantInfo.refetch()}
-              disabled={partnerTenantInfo.isLoading}
-            >
-              <Sync fontSize="small" />
-            </IconButton>
+            <span>
+              <IconButton
+                size="small"
+                onClick={() => partnerTenantInfo.refetch()}
+                disabled={partnerTenantInfo.isLoading}
+              >
+                <Sync fontSize="small" />
+              </IconButton>
+            </span>
           </Tooltip>
         </Stack>
         <Typography variant="body2" sx={{ mt: 2, mb: 2 }}>

--- a/frontend/src/components/ExecutiveReportButton.js
+++ b/frontend/src/components/ExecutiveReportButton.js
@@ -3051,46 +3051,48 @@ export const ExecutiveReportButton = (props) => {
         </MenuItem>
       ) : (
         <Tooltip title="Generate Executive Report with preview and configuration">
-          <Button
-            variant="contained"
-            startIcon={<PictureAsPdf />}
-            onClick={() => setPreviewOpen(true)}
-            sx={{
-              minWidth: 0,
-              width: '100%',
-              pl: 1,
-              pr: 1,
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-              justifyContent: 'center',
-              '& .MuiButton-startIcon': {
-                marginLeft: 0,
-                marginRight: 0.75,
-                flexShrink: 0,
-              },
-              fontWeight: 'bold',
-              textTransform: 'none',
-              borderRadius: 2,
-              boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-              transition: 'all 0.2s ease-in-out',
-            }}
-            {...other}
-          >
-            <Box
-              component="span"
+          <Box component="span" sx={{ display: 'inline-flex', width: '100%', minWidth: 0 }}>
+            <Button
+              variant="contained"
+              startIcon={<PictureAsPdf />}
+              onClick={() => setPreviewOpen(true)}
               sx={{
                 minWidth: 0,
-                maxWidth: '100%',
+                width: '100%',
+                pl: 1,
+                pr: 1,
                 overflow: 'hidden',
                 whiteSpace: 'nowrap',
                 textOverflow: 'ellipsis',
-                textAlign: 'center',
+                justifyContent: 'center',
+                '& .MuiButton-startIcon': {
+                  marginLeft: 0,
+                  marginRight: 0.75,
+                  flexShrink: 0,
+                },
+                fontWeight: 'bold',
+                textTransform: 'none',
+                borderRadius: 2,
+                boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+                transition: 'all 0.2s ease-in-out',
               }}
+              {...other}
             >
-              Executive Summary
-            </Box>
-          </Button>
+              <Box
+                component="span"
+                sx={{
+                  minWidth: 0,
+                  maxWidth: '100%',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                  textAlign: 'center',
+                }}
+              >
+                Executive Summary
+              </Box>
+            </Button>
+          </Box>
         </Tooltip>
       )}
 

--- a/frontend/src/pages/cipp/advanced/worker-health.js
+++ b/frontend/src/pages/cipp/advanced/worker-health.js
@@ -734,14 +734,20 @@ const Page = () => {
                   </Typography>
                 )}
                 <Tooltip title={effectivePaused ? "Resume auto-refresh" : "Pause auto-refresh"}>
-                  <IconButton
-                    size="small"
-                    onClick={() => setPaused((p) => !p)}
-                    color={effectivePaused ? "warning" : "default"}
-                    disabled={isImported}
-                  >
-                    {effectivePaused ? <PlayArrow fontSize="small" /> : <Pause fontSize="small" />}
-                  </IconButton>
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={() => setPaused((p) => !p)}
+                      color={effectivePaused ? "warning" : "default"}
+                      disabled={isImported}
+                    >
+                      {effectivePaused ? (
+                        <PlayArrow fontSize="small" />
+                      ) : (
+                        <Pause fontSize="small" />
+                      )}
+                    </IconButton>
+                  </span>
                 </Tooltip>
                 <Tooltip title="Export page data as JSON">
                   <IconButton size="small" onClick={handleExport}>

--- a/frontend/src/pages/email/spamfilter/list-quarantine-policies/index.js
+++ b/frontend/src/pages/email/spamfilter/list-quarantine-policies/index.js
@@ -89,26 +89,28 @@ const Page = () => {
         Edit Settings
       </Button>
       <Tooltip title="Refresh Data">
-        <IconButton
-          className="MuiIconButton"
-          disabled={GlobalQuarantinePolicy?.isLoading || GlobalQuarantinePolicy?.isFetching}
-          onClick={() => {
-            GlobalQuarantinePolicy.refetch();
-          }}
-        >
-          <SvgIcon
-            fontSize="small"
-            sx={{
-              animation: GlobalQuarantinePolicy?.isFetching ? "spin 1s linear infinite" : "none",
-              "@keyframes spin": {
-                "0%": { transform: "rotate(0deg)" },
-                "100%": { transform: "rotate(360deg)" },
-              },
+        <span>
+          <IconButton
+            className="MuiIconButton"
+            disabled={GlobalQuarantinePolicy?.isLoading || GlobalQuarantinePolicy?.isFetching}
+            onClick={() => {
+              GlobalQuarantinePolicy.refetch();
             }}
           >
-            <Sync />
-          </SvgIcon>
-        </IconButton>
+            <SvgIcon
+              fontSize="small"
+              sx={{
+                animation: GlobalQuarantinePolicy?.isFetching ? "spin 1s linear infinite" : "none",
+                "@keyframes spin": {
+                  "0%": { transform: "rotate(0deg)" },
+                  "100%": { transform: "rotate(360deg)" },
+                },
+              }}
+            >
+              <Sync />
+            </SvgIcon>
+          </IconButton>
+        </span>
       </Tooltip>
     </>,
   ];

--- a/frontend/src/pages/tenant/manage/edit.js
+++ b/frontend/src/pages/tenant/manage/edit.js
@@ -254,16 +254,18 @@ const Page = () => {
               title="Tenant Details"
               actionButton={
                 <Tooltip title="Refresh">
-                  <IconButton
-                    onClick={() => tenantDetails.refetch()}
-                    disabled={tenantDetails.isFetching}
-                    size="small"
-                    sx={{ mt: 0.25 }}
-                  >
-                    <SvgIcon fontSize="small">
-                      <Sync />
-                    </SvgIcon>
-                  </IconButton>
+                  <span>
+                    <IconButton
+                      onClick={() => tenantDetails.refetch()}
+                      disabled={tenantDetails.isFetching}
+                      size="small"
+                      sx={{ mt: 0.25 }}
+                    >
+                      <SvgIcon fontSize="small">
+                        <Sync />
+                      </SvgIcon>
+                    </IconButton>
+                  </span>
                 </Tooltip>
               }
               propertyItems={[

--- a/frontend/src/pages/tools/report-builder/builder/index.js
+++ b/frontend/src/pages/tools/report-builder/builder/index.js
@@ -495,17 +495,19 @@ const DatabaseBlock = ({
       cardActions={
         <Stack direction="row" spacing={0.5} alignItems="center">
           <Tooltip title="Refresh data">
-            <IconButton
-              size="small"
-              onClick={handleRefresh}
-              disabled={dbCacheApi.isFetching || !currentTenant}
-            >
-              {dbCacheApi.isFetching ? (
-                <CircularProgress size={16} />
-              ) : (
-                <Refresh fontSize="small" />
-              )}
-            </IconButton>
+            <span>
+              <IconButton
+                size="small"
+                onClick={handleRefresh}
+                disabled={dbCacheApi.isFetching || !currentTenant}
+              >
+                {dbCacheApi.isFetching ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <Refresh fontSize="small" />
+                )}
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title="Move up">
             <span>


### PR DESCRIPTION
Issue
Loading the app (/=dashboard) logs this on every cold load:

> [browser] MUI: You are providing a disabled `button` child to the Tooltip component.
> A disabled element does not fire events.
> Tooltip needs to listen to the child element's events to display the title.
>
> Add a simple wrapper element, such as a `span`.

 the initial cause on loadup is from ExecutiveReportButton: `disabled` (true while org data fetches) rides the props spread onto the Button that Tooltip wraps directly. in addition to the console error, tooltips on disabled buttons never display, and Tooltip cloning props onto the button replaces its accessible name with the tooltip text which is against MUI a11y convention

Fixes
wrap in a span (this same pattern is in pdfExportButton, csvExportButton, and the report-builder move buttons), and in the 7 other components with the same construction:

- ExecutiveReportButton (layout-preserving inline-flex span, the button keeps filling its flex cell on both dashboards)
- CippReportToolbar edit button (matches the existing wrapper on its delete sibling)
- CippUserPhotoManager change-photo button
- CippTenantModeDeploy partner refresh
- worker-health pause/resume
- list-quarantine-policies refresh
- tenant/manage/edit refresh
- report-builder block refresh