### PR TITLE
fix(frontend): numeric chart height to silence recharts first-render warning

### DIFF
--- a/frontend/src/components/CippComponents/SecureScoreCard.jsx
+++ b/frontend/src/components/CippComponents/SecureScoreCard.jsx
@@ -70,7 +70,8 @@ export const SecureScoreCard = ({ data, isLoading }) => {
         ) : (
           <>
             <Box sx={{ height: 250 }}>
-              <ResponsiveContainer width="100%" height="100%">
+              {/* numeric height, recharts warns before its first measure when both sizes are percentages */}
+              <ResponsiveContainer width="100%" height="250">
                 {(() => {
                   const sortedData = [...data].sort(
                     (a, b) => new Date(a.createdDateTime) - new Date(b.createdDateTime)

--- a/frontend/src/pages/cipp/advanced/worker-health.js
+++ b/frontend/src/pages/cipp/advanced/worker-health.js
@@ -443,7 +443,8 @@ const HistoryChart = ({ data, rangeMinutes, title, icon, children }) => {
       <CardHeader title={title} titleTypographyProps={{ variant: "h6" }} avatar={icon} />
       <CardContent sx={{ pt: 0 }}>
         <Box sx={{ height: 250 }}>
-          <ResponsiveContainer width="100%" height="100%">
+          {/* numeric height, recharts warns before its first measure when both sizes are percentages */}
+          <ResponsiveContainer width="100%" height={250}>
             {children(data, theme)}
           </ResponsiveContainer>
         </Box>


### PR DESCRIPTION
Issue
On prod and dev any page with a recharts responsive container logs a zero-size warning:
> The width(-1) and height(-1) of chart should be greater than 0,
>    please check the style of container, or the props width(100%) and height(100%),
>    or add a minWidth(0) or minHeight(undefined) or use aspect(undefined) to control the
>    height and width.

This is caused by the recharts dimension check because its initial size is -1x-1 and passing in "100%" is meaningless if its size is measured before there's an actual DOM element to measure, so it always triggers the warning if both sizes are percentages. 

Tested changes on Dashboard and Worker Health measuring mount time, render time and ResizeObserver triggers all identical between height={250} and height="100%"