### PR TITLE
fix(frontend): guard formatter null check cell branches, fix client crash

### DIFF
--- a/frontend/src/utils/get-cipp-formatting.js
+++ b/frontend/src/utils/get-cipp-formatting.js
@@ -106,6 +106,9 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
   }
 
   if (cellName === 'Severity' || cellName === 'logsToInclude') {
+    if (data == null) {
+      return isText ? 'No data' : <Chip variant="outlined" label="No data" size="small" color="info" />
+    }
     if (Array.isArray(data)) {
       return isText ? data.join(', ') : renderChipList(data)
     } else {
@@ -703,6 +706,9 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
   }
 
   if (cellName === 'Parameters.ScheduledBackupValues') {
+    if (!data || typeof data !== 'object') {
+      return isText ? 'No data' : <Chip variant="outlined" label="No data" size="small" color="info" />
+    }
     return isText ? (
       JSON.stringify(data)
     ) : (


### PR DESCRIPTION
Issue
get-cipp-formatting attempts to access objects before the null check later in the file.  Object.keys(undefined) threw in the MRT cell and crashed the page.
 
Fix
add null check guard, so null rows render the standard No data chip.
same class: Severity/logsToInclude read data.label on null. 

Note: we should refactor this file 👀

Repro
Set up hidden system task (/tenant/administration/alert-configuration) with scripted cipp alert option
/cipp/scheduler -> show system jobs -> columns -> add Paramters - Scheduled Backup Values -> scroll so the cell renders
<img width="800" height="350" alt="scheduled-tasks-crash" src="https://github.com/user-attachments/assets/6d5bf525-5a65-445b-82a0-589ef6d0162a" />
