### PR TITLE
fix(frontend): add filter type column to worker-health and EnrollmentProfileTabs

### DIFF
--- a/frontend/src/components/CippComponents/EnrollmentProfileTabs.jsx
+++ b/frontend/src/components/CippComponents/EnrollmentProfileTabs.jsx
@@ -261,11 +261,12 @@ export const AppleADEEnrollmentProfiles = () => {
 
   const appleFilters = useMemo(
     () => [
-      { filterName: 'All', value: [] },
-      { filterName: 'macOS', value: [{ id: 'platform', value: 'macOS' }] },
+      { filterName: 'All', value: [], type: 'column' },
+      { filterName: 'macOS', value: [{ id: 'platform', value: 'macOS' }], type: 'column' },
       {
         filterName: 'iOS/iPadOS',
         value: [{ id: 'platform', value: 'iOS/iPadOS' }],
+        type: 'column',
       },
     ],
     []

--- a/frontend/src/pages/cipp/advanced/worker-health.js
+++ b/frontend/src/pages/cipp/advanced/worker-health.js
@@ -699,9 +699,9 @@ const Page = () => {
 
   const jobFilters = useMemo(
     () => [
-      { filterName: "Queued", value: [{ id: "Status", value: "Queued" }] },
-      { filterName: "Running", value: [{ id: "Status", value: "Running" }] },
-      { filterName: "Failed", value: [{ id: "Status", value: "Failed" }] },
+      { filterName: "Queued", value: [{ id: "Status", value: "Queued" }], type: "column" },
+      { filterName: "Running", value: [{ id: "Status", value: "Running" }], type: "column" },
+      { filterName: "Failed", value: [{ id: "Status", value: "Failed" }], type: "column" },
     ],
     []
   );


### PR DESCRIPTION
Issue:
`type: 'column'` missing from the filter definition which causes the prebuilt filters to not work.

Fix: 
add type

Repro:
<img width="800" height="226" alt="fix-table-toolbar-filters" src="https://github.com/user-attachments/assets/03eef75d-0426-42e1-9a42-0e69268a56c6" />
