### PR TITLE
ci: add preview container workflows and guard :latest against prerele…

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,146 @@
+name: "Cleanup: Preview Containers"
+
+# Deletes the throwaway container versions built by preview-container.yml (tags prefixed with a
+# branch type: preview-, fix-, feat-, chore- ...):
+#   - when the branch that produced them is deleted
+#   - weekly, for anything older than RETENTION_DAYS (covers one-off workflow_dispatch builds
+#     from branches that were never deleted)
+#
+# NOTE: `on: delete` only fires for workflow files present on the DEFAULT branch, so this has
+# to reach main before branch-deletion cleanup starts working. The scheduled sweep is the
+# backstop either way.
+
+on:
+  delete:
+  schedule:
+    - cron: '0 4 * * 0' # Sundays 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List what would be deleted without deleting it
+        type: boolean
+        default: true
+
+env:
+  PACKAGE_NAME: cipp
+  RETENTION_DAYS: 30
+  # Recognises a throwaway build image by its branch-type prefix. Must match the type list in
+  # preview-container.yml and $PreviewChannelPattern in Invoke-ExecContainerManagement.ps1.
+  # Nothing in this set can match latest / dev / nightly / a bare semver, which is what makes
+  # the sweep safe to run unattended.
+  BUILD_TAG_PATTERN: '^(preview|feat|fix|refactor|perf|chore|build|revert)-'
+
+jobs:
+  cleanup:
+    # Any branch delete is worth a look now that fix/**, feat/** etc. also produce images via
+    # workflow_dispatch - a branch that never had one simply matches nothing. Tag deletions are
+    # skipped: they never produce build images.
+    if: ${{ github.event_name != 'delete' || github.event.ref_type == 'branch' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Delete preview image versions
+        env:
+          # GITHUB_TOKEN can delete versions of a package that inherits access from this repo.
+          # If ghcr.io/cyberdrain/cipp is org-owned without that link, set a GHCR_CLEANUP_TOKEN
+          # repo secret (PAT with delete:packages) and it will be preferred automatically.
+          GH_TOKEN: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          DELETED_REF: ${{ github.event.ref }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          # Dry run defaults to false for automatic triggers, true for manual dispatch.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$DRY_RUN" != "false" ]; then
+            DRY=1
+          else
+            DRY=0
+          fi
+
+          if [ "$EVENT_NAME" = "delete" ]; then
+            # Must reproduce the slug rule in preview-container.yml exactly, including the
+            # branch-type prefix list - a mismatch here silently orphans images.
+            RAW=$(echo "$DELETED_REF" | tr '[:upper:]' '[:lower:]')
+            RAW="${RAW#refs/heads/}"
+            TYPE="${RAW%%/*}"
+            case "$TYPE" in
+              preview|feat|fix|refactor|perf|chore|build|revert)
+                if [ "$TYPE" = "$RAW" ]; then PREFIX="preview"; NAME="$RAW"; else PREFIX="$TYPE"; NAME="${RAW#*/}"; fi
+                ;;
+              *)
+                PREFIX="preview"; NAME="$RAW"
+                ;;
+            esac
+            NAME=$(echo "$NAME" \
+              | sed -E 's/[^a-z0-9._-]+/-/g; s/-{2,}/-/g; s/^[-.]+//; s/[-.]+$//' \
+              | cut -c1-45)
+            NAME="${NAME%-}"
+            if [ -z "$NAME" ]; then
+              echo "Could not derive a slug from '$DELETED_REF' - nothing to do."
+              exit 0
+            fi
+            SLUG="${PREFIX}-${NAME}"
+            echo "Branch '$DELETED_REF' deleted - removing $SLUG and its pinned builds."
+            # Exact moving tag, or that tag plus a -<shortsha> suffix.
+            MATCH="^${SLUG}(-[0-9a-f]{7})?$"
+            CUTOFF=""
+          else
+            echo "Sweeping build images older than ${RETENTION_DAYS} days."
+            MATCH="$BUILD_TAG_PATTERN"
+            CUTOFF=$(date -u -d "${RETENTION_DAYS} days ago" +%s)
+          fi
+
+          # Org-owned package. Falls back to the user endpoint if the org one 404s.
+          LIST_PATH="/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
+          if ! gh api "$LIST_PATH?per_page=1" >/dev/null 2>&1; then
+            LIST_PATH="/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
+            echo "Org package endpoint unavailable, using $LIST_PATH"
+          fi
+
+          gh api --paginate "$LIST_PATH" > versions.json
+
+          # Safety: a version can carry several tags. Delete only when EVERY tag on it matches
+          # both the requested match AND the build-tag pattern, so a version that also carries
+          # latest / dev / nightly / a bare semver can never be caught here even if $MATCH were
+          # wrong. Untagged versions are left alone (GHCR prunes those itself).
+          jq -r --arg match "$MATCH" --arg guard "$BUILD_TAG_PATTERN" --arg cutoff "${CUTOFF:-0}" '
+            .[]
+            | . as $v
+            | ($v.metadata.container.tags // []) as $tags
+            | select(($tags | length) > 0)
+            | select($tags | all(test($match)))
+            | select($tags | all(test($guard)))
+            | select(($cutoff | tonumber) == 0 or (($v.created_at | fromdateiso8601) < ($cutoff | tonumber)))
+            | "\($v.id)\t\($tags | join(","))"
+          ' versions.json > targets.tsv
+
+          if [ ! -s targets.tsv ]; then
+            echo "Nothing to delete."
+            echo "Nothing to delete." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          {
+            echo "### Preview images ${DRY:+(dry run) }removed"
+            echo
+            echo '| Version | Tags |'
+            echo '|---|---|'
+          } >> $GITHUB_STEP_SUMMARY
+
+          while IFS=$'\t' read -r ID TAGS; do
+            echo "| \`$ID\` | $TAGS |" >> $GITHUB_STEP_SUMMARY
+            if [ "$DRY" = "1" ]; then
+              echo "[dry run] would delete $ID ($TAGS)"
+              continue
+            fi
+            echo "Deleting $ID ($TAGS)"
+            # Non-fatal: a version can vanish between listing and delete, and one failure
+            # should not abandon the rest of the sweep.
+            gh api -X DELETE "${LIST_PATH}/${ID}" \
+              || echo "::warning::Could not delete package version $ID ($TAGS)"
+          done < targets.tsv

--- a/.github/workflows/preview-container.yml
+++ b/.github/workflows/preview-container.yml
@@ -1,0 +1,207 @@
+name: "Build: Preview Container"
+
+# Builds a throwaway image from an unmerged branch so it can be tested on a real instance
+# without merging to dev first. Two ways in:
+#   - push to a preview/** branch (opt-in by naming, rebuilds on every push)
+#   - workflow_dispatch against ANY ref, for one-off fix/** and feat/** branches
+# Unlike dev-container.yml / nightly-container.yml this does NOT hardcode `ref: dev`, which is
+# what made those unusable for testing a feature branch.
+#
+# Images are cleaned up by preview-cleanup.yml when the branch is deleted (and by its weekly
+# age sweep), so preview tags are not expected to be long-lived.
+
+on:
+  push:
+    branches: ['preview/**']
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'build/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag or SHA to build
+        required: true
+      config:
+        description: Runtime appsettings baked into the image
+        type: choice
+        options:
+          - development
+          - production
+        default: development
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# Cancel an in-flight build when a newer commit is pushed to the same branch. Keyed per-ref so
+# two different preview branches can build concurrently.
+concurrency:
+  group: preview-container-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Docker tags allow [a-zA-Z0-9_][a-zA-Z0-9._-]* — a branch name generally does not, so
+      # slugify. The part before the first / becomes the tag prefix when it is a known branch
+      # type, so the tag says what kind of change it is: fix/sso-thing -> fix-sso-thing,
+      # feat/foo -> feat-foo, preview/sso-multi-domain -> preview-sso-multi-domain.
+      #
+      # The type list is the subset of conventional-commit types (Conventional_Commits.yml) that
+      # actually change what runs in the container, plus `preview` for branches named purely to
+      # trigger a build. docs/style/test/ci are deliberately absent - they do not alter the
+      # image, so they fall through to the preview- fallback rather than earning their own tag.
+      # This list doubles as the allowlist that Invoke-ExecContainerManagement.ps1 and
+      # preview-cleanup.yml use to recognise a throwaway image, so KEEP THE THREE IN SYNC.
+      # Anything else (no slash, or an unknown prefix) falls back to preview-<whole-ref>, which
+      # guarantees a build image can never collide with latest/dev/nightly or a bare semver.
+      - name: Derive slug and version
+        id: version
+        run: |
+          REF_NAME="${{ github.event.inputs.ref || github.ref_name }}"
+          RAW=$(echo "$REF_NAME" | tr '[:upper:]' '[:lower:]')
+          RAW="${RAW#refs/heads/}"
+
+          TYPE="${RAW%%/*}"
+          case "$TYPE" in
+            preview|feat|fix|refactor|perf|chore|build|revert)
+              # A branch literally named e.g. "fix" with no / has TYPE == RAW; treat as unknown.
+              if [ "$TYPE" = "$RAW" ]; then PREFIX="preview"; NAME="$RAW"; else PREFIX="$TYPE"; NAME="${RAW#*/}"; fi
+              ;;
+            *)
+              PREFIX="preview"; NAME="$RAW"
+              ;;
+          esac
+
+          NAME=$(echo "$NAME" \
+            | sed -E 's/[^a-z0-9._-]+/-/g; s/-{2,}/-/g; s/^[-.]+//; s/[-.]+$//' \
+            | cut -c1-45)
+          NAME="${NAME%-}"
+          if [ -z "$NAME" ]; then
+            echo "::error::Could not derive a usable tag slug from ref '$REF_NAME'"
+            exit 1
+          fi
+          SLUG="${PREFIX}-${NAME}"
+
+          # Same tag-derived scheme as dev/nightly so the version format stays consistent.
+          TAG=$(git tag --sort=-v:refname | head -1)
+          TAG=${TAG:-v0.0.0}
+          BASE="${TAG#v}"
+          FULL_SHA=$(git rev-parse HEAD)
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+
+          echo "slug=${SLUG}" >> $GITHUB_OUTPUT
+          echo "image_tag=${SLUG}" >> $GITHUB_OUTPUT
+          # Keep the "preview." marker in the version regardless of tag prefix, so a build image
+          # is identifiable as one at runtime the same way +dev./+nightly. builds are.
+          echo "app_version=${BASE}+preview.${SLUG}.${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "full_sha=${FULL_SHA}" >> $GITHUB_OUTPUT
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+          # build/Dockerfile ships the Development appsettings (what the dev channel uses and
+          # what runs on real instances today); Dockerfile.release ships Production.
+          if [ "${{ github.event.inputs.config }}" = "production" ]; then
+            echo "dockerfile=build/Dockerfile.release" >> $GITHUB_OUTPUT
+          else
+            echo "dockerfile=build/Dockerfile" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set lower case image name
+        run: echo "IMAGE_NAME_LC=${REPO,,}" >> $GITHUB_ENV
+        env:
+          REPO: ${{ github.repository }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Own key prefix so preview builds do not churn the dev/release frontend caches.
+      - name: Restore frontend build caches
+        id: build-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            yarn-cache
+            next-cache
+          key: cipp-frontend-cache-preview-${{ github.run_id }}
+          restore-keys: |
+            cipp-frontend-cache-preview-
+            cipp-frontend-cache-dev-
+
+      - name: Inject build caches into BuildKit
+        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              "yarn-cache": "/usr/local/share/.cache/yarn",
+              "next-cache": "/build/.next/cache"
+            }
+          skip-extraction: ${{ steps.build-cache.outputs.cache-hit }}
+
+      # The Actions cache is 10 GB per REPOSITORY, shared across scopes and evicted LRU. A
+      # per-branch scope would evict the dev/release caches those builds depend on, so every
+      # preview shares ONE scope and writes mode=min (final-stage layers only) rather than the
+      # mode=max dev/release use. scope=dev is read-only here, for a warm start on a new branch.
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ steps.version.outputs.dockerfile }}
+          push: true
+          cache-from: |
+            type=gha,scope=preview
+            type=gha,scope=dev
+          cache-to: type=gha,mode=min,scope=preview
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.app_version }}
+            COMMIT_SHA=${{ steps.version.outputs.full_sha }}
+            IMAGE_TAG=${{ steps.version.outputs.image_tag }}
+            BUILD_DATE=${{ steps.version.outputs.build_date }}
+            DOTNET_REGISTRY=${{ vars.DOTNET_REGISTRY || 'ghcr.io/cyberdrain' }}
+          # Moving tag is what the Release Channel points at; the -<sha> tag is immutable so a
+          # specific build can be pinned or rolled back to.
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.image_tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.image_tag }}-${{ steps.version.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.description=CIPP - Preview Build (${{ steps.version.outputs.slug }})
+            org.opencontainers.image.revision=${{ steps.version.outputs.full_sha }}
+            org.opencontainers.image.version=${{ steps.version.outputs.app_version }}
+            org.opencontainers.image.created=${{ steps.version.outputs.build_date }}
+
+      - name: Summary
+        run: |
+          {
+            echo "### Preview image built"
+            echo
+            echo '```'
+            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.image_tag }}"
+            echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.image_tag }}-${{ steps.version.outputs.short_sha }}"
+            echo '```'
+            echo
+            echo "Select **${{ steps.version.outputs.image_tag }}** under Settings → Container Management → Release Channel to run it."
+            echo
+            echo "> Preview images are unsupported and are deleted when the branch is deleted."
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -11,6 +11,16 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # `release: [published]` also fires for PRE-releases, and this job moves :latest — the tag
+    # every stable customer follows. Without this guard, ticking "set as a pre-release" in the
+    # GitHub UI would ship that build to the entire estate. Negation form (not `== false`) so a
+    # missing or blank value cannot evaluate truthy.
+    #
+    # Consequence: publishing a pre-release now produces NO image at all. The run still shows in
+    # the Actions tab as *skipped* - that is the signal that nothing shipped. If a release
+    # candidate channel is ever wanted, this is the hook point: build on prerelease, push
+    # :<version> plus a moving :prerelease, and keep :latest behind this same condition.
+    if: ${{ !github.event.release.prerelease }}
     permissions:
       contents: read
       packages: write
@@ -81,6 +91,8 @@ jobs:
             IMAGE_TAG=latest
             BUILD_DATE=${{ steps.version.outputs.build_date }}
             DOTNET_REGISTRY=${{ vars.DOTNET_REGISTRY || 'ghcr.io/cyberdrain' }}
+          # :latest is the stable channel every customer follows. Nothing conditional or
+          # experimental should ever be added here - gate it at the job `if` instead.
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.app_version }}


### PR DESCRIPTION
Workflow-only cherry of 116fef2 from dev. These two triggers only fire from the DEFAULT branch, so they stay dormant until the files are on main:

  - preview-cleanup.yml `schedule:` (weekly sweep) and `on: delete` (cleanup when a preview branch is deleted)
  - release-container.yml `release: [published]`, which is what the prerelease guard has to intercept

That guard is the urgent part. release-container.yml fires on any published release INCLUDING prereleases, and unconditionally pushes :latest - so ticking "set as a pre-release" in the GitHub UI ships that build to every instance on the stable channel. Guarded now; a prerelease publish shows as a skipped run instead.

preview-container.yml is included so the set stays together and main is not carrying half a feature; its own `push: branches: ['preview/**']` trigger already works from dev.

The product-side half of 116fef2 (the Container Management channel picker that lists and validates these tags, plus its docs) is deliberately NOT here
- that is product code and reaches main through the normal dev promotion. Until then a branch build can be selected by pointing linuxFxVersion at the tag directly.

.github/workflows/ differs between main and dev by exactly these three changes, so this is purely additive and the next dev->main merge is a no-op for these files.