### PR TITLE
feat(sso): support multiple custom domains per instance

### DIFF
--- a/backend/Modules/CIPPCore/Public/Authentication/Get-CIPPSiteHostname.ps1
+++ b/backend/Modules/CIPPCore/Public/Authentication/Get-CIPPSiteHostname.ps1
@@ -1,0 +1,114 @@
+function Get-CIPPSiteHostname {
+    <#
+    .SYNOPSIS
+        Returns every hostname bound to the App Service running this instance.
+    .DESCRIPTION
+        Queries ARM for the site's properties.hostNames, which covers the default
+        *.azurewebsites.net hostname plus every custom domain bound to it.
+
+        A container can carry many custom domains, and EasyAuth builds its redirect_uri from
+        the incoming Host header — so every bound hostname needs its own callback on the SSO
+        app registration. Anything that writes redirectUris should source them from here
+        rather than from a single "current" URL.
+
+        When ARM cannot be reached (no managed identity, missing WEBSITE_* variables, a 403
+        or a transient failure) the list falls back to WEBSITE_HOSTNAME plus the last known
+        instance URL from Get-CIPPHostname. That fallback is NOT complete — a custom domain
+        nobody has browsed yet will be absent — so callers must not treat "nothing missing"
+        as proof that every domain can sign in. Use -IncludeStatus to tell the two apart.
+
+        In local development the fallback is skipped entirely and the list comes back empty,
+        so callers no-op rather than writing a localhost callback to a real app registration.
+    .PARAMETER AsRedirectUri
+        Return the EasyAuth callback URI for each hostname instead of the bare hostname.
+    .PARAMETER IncludeStatus
+        Return an object with Hostnames, RedirectUris, Discovered and Error instead of a bare
+        list, so the caller can distinguish an authoritative list from a best-effort fallback.
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [switch]$AsRedirectUri,
+        [switch]$IncludeStatus
+    )
+
+    $Discovered = $false
+    $DiscoveryError = $null
+    $Hostnames = [System.Collections.Generic.List[string]]::new()
+    $IsLocalDev = $env:AzureWebJobsStorage -eq 'UseDevelopmentStorage=true' -or $env:NonLocalHostAzurite -eq 'true'
+
+    try {
+        $SiteName = $env:WEBSITE_SITE_NAME
+        $ResourceGroup = $env:WEBSITE_RESOURCE_GROUP
+        $SubscriptionId = if ($env:WEBSITE_OWNER_NAME) { ($env:WEBSITE_OWNER_NAME -split '\+')[0] } else { $null }
+
+        if (-not ($SiteName -and $ResourceGroup -and $SubscriptionId)) {
+            throw 'Not running in App Service (WEBSITE_SITE_NAME/WEBSITE_RESOURCE_GROUP/WEBSITE_OWNER_NAME not set).'
+        }
+        if (-not ($env:IDENTITY_ENDPOINT -and $env:IDENTITY_HEADER)) {
+            throw 'No managed identity is available to query ARM.'
+        }
+
+        $SiteUri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Web/sites/$SiteName`?api-version=2024-11-01"
+        $SiteResponse = New-CIPPAzRestRequest -Uri $SiteUri -Method GET -ErrorAction Stop
+
+        if (-not $SiteResponse.properties.hostNames) {
+            throw 'ARM returned no hostNames for this site.'
+        }
+
+        $SiteResponse.properties.hostNames | ForEach-Object { $Hostnames.Add($_) }
+        $Discovered = $true
+        Write-Information "[SiteHostname] Discovered hostnames from ARM: $($Hostnames -join ', ')"
+    } catch {
+        $DiscoveryError = $_.Exception.Message
+        Write-Information "[SiteHostname] ARM hostname discovery failed — falling back to known hostnames: $DiscoveryError"
+    }
+
+    if (-not $Discovered) {
+        # Best effort: the platform hostname, plus the last URL the instance was actually
+        # served from (Config/InstanceProperties/CIPPURL), which is usually the custom domain.
+        if ($env:WEBSITE_HOSTNAME) { $Hostnames.Add($env:WEBSITE_HOSTNAME) }
+
+        # ...but NOT in local dev. There is no App Service there, so discovery always fails and
+        # we would fall through to the stored CIPPURL - which Invoke-ExecPartnerWebhook -Save
+        # writes from the request host, i.e. 'localhost'. The dev SSO AppId in DevSecrets points
+        # at a REAL app registration, so that would permanently graft a localhost callback onto
+        # it. Returning nothing here makes the callers no-op, which is what dev should do.
+        if ($IsLocalDev) {
+            Write-Information '[SiteHostname] Local development - skipping stored instance URL fallback'
+        } else {
+            try {
+                $KnownHost = Get-CIPPHostname
+                if (-not [string]::IsNullOrWhiteSpace($KnownHost) -and $KnownHost -notin $Hostnames) {
+                    $Hostnames.Add($KnownHost)
+                }
+            } catch {
+                Write-Information "[SiteHostname] Stored instance URL lookup failed: $($_.Exception.Message)"
+            }
+        }
+
+        # Belt and braces: a loopback or unqualified name is never a hostname EasyAuth serves,
+        # and registering one on the app registration would be junk that nothing cleans up.
+        $Local = @($Hostnames | Where-Object { $_ -in @('localhost', '127.0.0.1', '::1') -or $_ -notlike '*.*' })
+        foreach ($Bad in $Local) {
+            Write-Information "[SiteHostname] Ignoring non-routable hostname '$Bad'"
+            $null = $Hostnames.Remove($Bad)
+        }
+    }
+
+    $RedirectUris = @($Hostnames | ForEach-Object { "https://$_/.auth/login/aad/callback" })
+
+    if ($IncludeStatus) {
+        return [PSCustomObject]@{
+            Hostnames    = @($Hostnames)
+            RedirectUris = $RedirectUris
+            Discovered   = $Discovered
+            Error        = $DiscoveryError
+        }
+    }
+    if ($AsRedirectUri) {
+        return $RedirectUris
+    }
+    return @($Hostnames)
+}

--- a/backend/Modules/CIPPCore/Public/Authentication/New-CIPPSSOApp.ps1
+++ b/backend/Modules/CIPPCore/Public/Authentication/New-CIPPSSOApp.ps1
@@ -26,6 +26,16 @@ function New-CIPPSSOApp {
     $CallbackUri = $RedirectUri.TrimEnd('/') + '/.auth/login/aad/callback'
     $SignInAudience = if ($MultiTenant) { 'AzureADMultipleOrgs' } else { 'AzureADMyOrg' }
 
+    # A container can carry several custom domains and EasyAuth derives redirect_uri from the
+    # incoming Host header, so every bound hostname needs its own callback - not just the URL
+    # the admin happened to run setup from. Writing only $CallbackUri here would strip sign-in
+    # from every other domain until the next warmup re-added it.
+    $DesiredUris = [System.Collections.Generic.List[string]]::new()
+    $DesiredUris.Add($CallbackUri)
+    foreach ($Uri in @(Get-CIPPSiteHostname -AsRedirectUri)) {
+        if ($Uri -notin $DesiredUris) { $DesiredUris.Add($Uri) }
+    }
+
     # Microsoft Graph resource ID and delegated permission GUIDs
     $GraphResourceId = '00000003-0000-0000-c000-000000000000'
     $Permissions = @(
@@ -56,9 +66,17 @@ function New-CIPPSSOApp {
         $State = 'updated'
         Write-Information "[SSO-App] Updating existing app: $AppClientId"
 
+        # Union with what is already registered - never send a shorter array than the app
+        # already has, or re-running setup silently breaks sign-in on the other domains.
+        $MergedUris = [System.Collections.Generic.List[string]]::new()
+        foreach ($Uri in @($ExistingApp.web.redirectUris)) { $MergedUris.Add($Uri) }
+        foreach ($Uri in $DesiredUris) {
+            if ($Uri -notin $MergedUris) { $MergedUris.Add($Uri) }
+        }
+
         $PatchBody = @{
             web                    = @{
-                redirectUris          = @($CallbackUri)
+                redirectUris          = $MergedUris
                 implicitGrantSettings = @{ enableIdTokenIssuance = $true }
             }
             signInAudience         = $SignInAudience
@@ -70,7 +88,7 @@ function New-CIPPSSOApp {
             )
         } | ConvertTo-Json -Depth 10 -Compress
 
-        New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$AppObjectId" -body $PatchBody -type PATCH -NoAuthCheck $true -AsApp $true
+        $null = New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$AppObjectId" -body $PatchBody -type PATCH -NoAuthCheck $true -AsApp $true
     } else {
         # Create new app registration
         $State = 'created'
@@ -80,7 +98,7 @@ function New-CIPPSSOApp {
             displayName            = $AppDisplayName
             signInAudience         = $SignInAudience
             web                    = @{
-                redirectUris          = @($CallbackUri)
+                redirectUris          = $DesiredUris
                 implicitGrantSettings = @{ enableIdTokenIssuance = $true }
             }
             requiredResourceAccess = @(

--- a/backend/Modules/CIPPCore/Public/Authentication/Update-CIPPSSORedirectUri.ps1
+++ b/backend/Modules/CIPPCore/Public/Authentication/Update-CIPPSSORedirectUri.ps1
@@ -11,13 +11,36 @@ function Update-CIPPSSORedirectUri {
     2. Ensures the SSO app's web.redirectUris includes a callback URI for each hostname.
     3. Verifies and patches signInAudience on the app reg if it doesn't match the stored
        multi-tenant flag (AzureADMyOrg for single-tenant, AzureADMultipleOrgs for multi).
+
+    Additive only — it never removes a URI, so a domain bound out-of-band keeps working.
+
+    .PARAMETER PassThru
+    Emit a result object describing what happened. Off by default so warmup callers
+    (Initialize-CIPPAuth) don't pick up stray pipeline output.
     #>
     [CmdletBinding()]
-    param()
+    param(
+        [switch]$PassThru
+    )
+
+    $EmitResult = $PassThru.IsPresent
+
+    # Local helper so every exit point returns the same shape (or nothing, without -PassThru)
+    $Result = {
+        param([string]$Status, [string[]]$RedirectUris, [string[]]$AddedUris, [string]$Message)
+        if (-not $EmitResult) { return }
+        [PSCustomObject]@{
+            Status       = $Status
+            RedirectUris = @($RedirectUris)
+            AddedUris    = @($AddedUris)
+            Message      = $Message
+        }
+    }
 
     $CurrentHost = $env:WEBSITE_HOSTNAME
     if (-not $CurrentHost) {
         Write-Information '[SSO-Redirect] WEBSITE_HOSTNAME not set, skipping redirect URI update'
+        & $Result 'skipped' @() @() 'WEBSITE_HOSTNAME is not set — cannot determine this instance''s hostnames.'
         return
     }
 
@@ -46,36 +69,17 @@ function Update-CIPPSSORedirectUri {
 
     if (-not $SSOAppId) {
         Write-Information '[SSO-Redirect] No SSO AppId found, skipping redirect URI update'
+        & $Result 'skipped' @() @() 'No SSO app registration is configured for this instance.'
         return
     }
 
-    # Discover all bound hostnames via ARM (custom domains + default)
-    $AllHostnames = @($CurrentHost)
-    try {
-        $SiteName = $env:WEBSITE_SITE_NAME
-        $ResourceGroup = $env:WEBSITE_RESOURCE_GROUP
-        $SubscriptionId = if ($env:WEBSITE_OWNER_NAME) { ($env:WEBSITE_OWNER_NAME -split '\+')[0] } else { $null }
-
-        if ($SiteName -and $ResourceGroup -and $SubscriptionId -and $env:IDENTITY_ENDPOINT -and $env:IDENTITY_HEADER) {
-            $TokenUri = "$($env:IDENTITY_ENDPOINT)?resource=https://management.azure.com/&api-version=2019-08-01"
-            $TokenResponse = Invoke-RestMethod -Uri $TokenUri -Headers @{ 'X-IDENTITY-HEADER' = $env:IDENTITY_HEADER } -Method Get
-            $ArmToken = $TokenResponse.access_token
-
-            $SiteUri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Web/sites/$SiteName`?api-version=2024-11-01"
-            $SiteResponse = Invoke-RestMethod -Uri $SiteUri -Headers @{ Authorization = "Bearer $ArmToken" } -Method Get
-
-            if ($SiteResponse.properties.hostNames) {
-                $AllHostnames = @($SiteResponse.properties.hostNames)
-                Write-Information "[SSO-Redirect] Discovered hostnames from ARM: $($AllHostnames -join ', ')"
-            }
-        }
-    } catch {
-        Write-Information "[SSO-Redirect] ARM hostname discovery failed (using WEBSITE_HOSTNAME only): $($_.Exception.Message)"
-    }
-
-    # Build required redirect URIs from all hostnames
-    $RequiredUris = foreach ($Hostname in $AllHostnames) {
-        "https://$Hostname/.auth/login/aad/callback"
+    # Every bound hostname (custom domains + default) needs its own callback. When ARM can't be
+    # reached this list is a best-effort fallback, not the full set of bound domains - the patch
+    # below is still safe (it only adds), but we must not report "nothing missing" as an all-clear.
+    $HostnameState = Get-CIPPSiteHostname -IncludeStatus
+    $RequiredUris = @($HostnameState.RedirectUris)
+    if (-not $HostnameState.Discovered) {
+        Write-Information "[SSO-Redirect] Could not enumerate bound domains — working from known hostnames only: $($HostnameState.Error)"
     }
 
     try {
@@ -83,7 +87,7 @@ function Update-CIPPSSORedirectUri {
         $ExistingUris = @($AppResponse.web.redirectUris)
 
         # Determine which URIs are missing
-        $MissingUris = $RequiredUris | Where-Object { $_ -notin $ExistingUris }
+        $MissingUris = @($RequiredUris | Where-Object { $_ -notin $ExistingUris })
 
         # Determine the expected signInAudience
         $ExpectedAudience = if ($SSOMultiTenant) { 'AzureADMultipleOrgs' } else { 'AzureADMyOrg' }
@@ -91,6 +95,11 @@ function Update-CIPPSSORedirectUri {
 
         if ($MissingUris.Count -eq 0 -and -not $AudienceMismatch) {
             Write-Information '[SSO-Redirect] All redirect URIs present and signInAudience correct'
+            if ($HostnameState.Discovered) {
+                & $Result 'nochange' $ExistingUris @() 'All sign-in URLs are already registered.'
+            } else {
+                & $Result 'partial' $ExistingUris @() "The sign-in URLs we could identify are already registered, but the list of custom domains bound to this instance could not be read, so some may be missing: $($HostnameState.Error)"
+            }
             return
         }
 
@@ -99,12 +108,12 @@ function Update-CIPPSSORedirectUri {
         # single-tenant fails with "SigninAudienceRestrictions with restricted mode can be
         # configured only on multi-tenants apps"). Sending them together would let that
         # rejection also drop the redirect URI additions, which are needed for sign-in.
+        $UpdatedUris = [System.Collections.Generic.List[string]]::new()
+        $ExistingUris | ForEach-Object { $UpdatedUris.Add($_) }
         if ($MissingUris.Count -gt 0) {
-            $UpdatedUris = [System.Collections.Generic.List[string]]::new()
-            $ExistingUris | ForEach-Object { $UpdatedUris.Add($_) }
             $MissingUris | ForEach-Object { $UpdatedUris.Add($_) }
             $UriBody = @{ web = @{ redirectUris = $UpdatedUris } } | ConvertTo-Json -Depth 5
-            New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$($AppResponse.id)" -body $UriBody -type PATCH -NoAuthCheck $true -AsApp $true
+            $null = New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$($AppResponse.id)" -body $UriBody -type PATCH -NoAuthCheck $true -AsApp $true
             Write-Information "[SSO-Redirect] Added redirect URIs: $($MissingUris -join ', ')"
             Write-LogMessage -API 'SSO-Redirect' -message "Added redirect URIs: $($MissingUris -join ', ')" -sev Info
         }
@@ -113,7 +122,7 @@ function Update-CIPPSSORedirectUri {
             Write-Information "[SSO-Redirect] Correcting signInAudience: $($AppResponse.signInAudience) -> $ExpectedAudience"
             try {
                 $AudienceBody = @{ signInAudience = $ExpectedAudience } | ConvertTo-Json -Compress
-                New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$($AppResponse.id)" -body $AudienceBody -type PATCH -NoAuthCheck $true -AsApp $true
+                $null = New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$($AppResponse.id)" -body $AudienceBody -type PATCH -NoAuthCheck $true -AsApp $true
                 Write-LogMessage -API 'SSO-Redirect' -message "Updated signInAudience to $ExpectedAudience (multiTenant=$SSOMultiTenant)" -sev Info
             } catch {
                 # Non-fatal: a tenant app-management policy is blocking the audience change.
@@ -122,7 +131,18 @@ function Update-CIPPSSORedirectUri {
                 Write-Information "[SSO-Redirect] signInAudience change to $ExpectedAudience was rejected by tenant policy (leaving app reg as $($AppResponse.signInAudience)): $($_.Exception.Message)"
             }
         }
+
+        $Summary = if ($MissingUris.Count -gt 0) { "Registered $($MissingUris.Count) new sign-in URL(s)." } else { 'Sign-in URLs were already up to date.' }
+        if ($HostnameState.Discovered) {
+            & $Result 'updated' $UpdatedUris $MissingUris $Summary
+        } else {
+            & $Result 'partial' $UpdatedUris $MissingUris "$Summary The full list of custom domains bound to this instance could not be read, so others may still be missing: $($HostnameState.Error)"
+        }
+        return
     } catch {
-        Write-LogMessage -API 'SSO-Redirect' -message "Failed to update SSO app registration: $_" -LogData (Get-CippException -Exception $_) -sev Warning
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -API 'SSO-Redirect' -message "Failed to update SSO app registration: $_" -LogData $ErrorMessage -sev Warning
+        & $Result 'error' @() @() $ErrorMessage.NormalizedError
+        return
     }
 }

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Setup/Invoke-ExecSSOSetup.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Setup/Invoke-ExecSSOSetup.ps1
@@ -23,6 +23,35 @@ function Invoke-ExecSSOSetup {
         return "https://$($env:WEBSITE_HOSTNAME)"
     }
 
+    # Compare the callbacks registered on the SSO app against every hostname bound to this
+    # container. A container can have several custom domains and each needs its own callback,
+    # so "missing" here means those domains cannot sign in yet.
+    $GetRedirectUriState = {
+        param([string]$AppId)
+        $HostnameState = Get-CIPPSiteHostname -IncludeStatus
+        $Required = @($HostnameState.RedirectUris)
+        $Registered = @()
+        if ($AppId) {
+            try {
+                $App = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/applications(appId='$AppId')?`$select=web" -NoAuthCheck $true -AsApp $true
+                $Registered = @($App.web.redirectUris)
+            } catch {
+                Write-Information "[SSO-Setup] Could not read redirect URIs for $AppId : $($_.Exception.Message)"
+            }
+        }
+        [PSCustomObject]@{
+            # Fall back to the required set when the app can't be read, so the UI still shows
+            # which URLs this instance expects rather than an empty list.
+            RedirectUris    = if ($Registered.Count -gt 0) { $Registered } else { $Required }
+            MissingUris     = @($Required | Where-Object { $_ -notin $Registered })
+            Known           = $Registered.Count -gt 0
+            # False means the bound-domain list is a best-effort guess, so an empty MissingUris
+            # is NOT proof that every domain can sign in. The UI has to say so.
+            DomainsVerified = $HostnameState.Discovered
+            DomainsError    = $HostnameState.Error
+        }
+    }
+
     # Save a row to the migration table while preserving fields that aren't being updated
     $SaveMigrationRow = {
         param([hashtable]$Updates)
@@ -149,6 +178,74 @@ function Invoke-ExecSSOSetup {
                     Write-LogMessage -API $APIName -message "Failed to get SSO status: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
                     $Body = @{ Results = @{ configured = $false; status = 'error'; lastError = $ErrorMessage.NormalizedError } }
                 }
+            }
+
+            # Report which hostnames can actually sign in, and self-heal a domain that was
+            # bound after the app was provisioned (e.g. a custom domain added from the
+            # management portal). Only patches when something is genuinely missing, so
+            # polling this endpoint doesn't hammer Graph with writes.
+            try {
+                if ($Body.Results -is [hashtable] -and $Body.Results.appId) {
+                    $UriState = & $GetRedirectUriState $Body.Results.appId
+                    if ($UriState.Known -and $UriState.MissingUris.Count -gt 0) {
+                        Write-Information "[SSO-Setup] $($UriState.MissingUris.Count) bound hostname(s) missing a callback — patching"
+                        $Refreshed = Update-CIPPSSORedirectUri -PassThru
+                        if ($Refreshed.Status -eq 'updated') { $UriState = & $GetRedirectUriState $Body.Results.appId }
+                    }
+                    $Body.Results.redirectUris = @($UriState.RedirectUris)
+                    $Body.Results.missingRedirectUris = @($UriState.MissingUris)
+                    $Body.Results.domainsVerified = [bool]$UriState.DomainsVerified
+                    $Body.Results.domainsError = $UriState.DomainsError
+                }
+            } catch {
+                Write-Information "[SSO-Setup] Redirect URI status check failed (non-fatal): $($_.Exception.Message)"
+            }
+        }
+
+        'RefreshRedirectUris' {
+            # Register a callback for every hostname bound to this container. Warmup does this
+            # too, but a domain added through the management portal would otherwise have no
+            # callback until the next restart - and sign-in on it fails with AADSTS50011.
+            try {
+                $Refreshed = Update-CIPPSSORedirectUri -PassThru
+
+                if ($Refreshed.Status -eq 'skipped') {
+                    $StatusCode = [HttpStatusCode]::BadRequest
+                    $Body = @{ Results = $Refreshed.Message }
+                    break
+                }
+                if ($Refreshed.Status -eq 'error') {
+                    $StatusCode = [HttpStatusCode]::InternalServerError
+                    $Body = @{ Results = "Failed to refresh sign-in URLs: $($Refreshed.Message)" }
+                    break
+                }
+
+                if ($Refreshed.AddedUris.Count -gt 0) {
+                    Write-LogMessage -API $APIName -headers $Headers -message "Refreshed SSO sign-in URLs, added: $($Refreshed.AddedUris -join ', ')" -sev Info
+                }
+
+                # 'partial' means the additive patch ran but we could not read the full list of
+                # domains bound to this container, so we cannot promise every domain can sign in.
+                # Reporting that as a success is how a broken custom domain stays invisible.
+                $IsPartial = $Refreshed.Status -eq 'partial'
+                if ($IsPartial) {
+                    Write-LogMessage -API $APIName -headers $Headers -message "SSO sign-in URL refresh could not enumerate bound domains: $($Refreshed.Message)" -sev Warning
+                }
+
+                $Body = @{
+                    Results = @{
+                        message         = $Refreshed.Message
+                        redirectUris    = @($Refreshed.RedirectUris)
+                        addedUris       = @($Refreshed.AddedUris)
+                        domainsVerified = -not $IsPartial
+                        severity        = if ($IsPartial) { 'warning' } else { 'success' }
+                    }
+                }
+            } catch {
+                $ErrorMessage = Get-CippException -Exception $_
+                Write-LogMessage -API $APIName -headers $Headers -message "SSO sign-in URL refresh failed: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+                $StatusCode = [HttpStatusCode]::InternalServerError
+                $Body = @{ Results = "Failed to refresh sign-in URLs: $($ErrorMessage.NormalizedError)" }
             }
         }
 
@@ -407,15 +504,25 @@ function Invoke-ExecSSOSetup {
                 # Look up the existing app and patch it
                 $AppResponse = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/applications(appId='$($Existing.AppId)')?`$select=id,appId,web,signInAudience" -NoAuthCheck $true -AsApp $true
 
+                # Merge, never replace. $TargetUrl is only whichever domain the admin is
+                # browsing from - an instance can have several custom domains bound, and each
+                # needs its own callback. Replacing the array here used to strip sign-in from
+                # every other domain until the next container restart re-ran warmup.
+                $MergedUris = [System.Collections.Generic.List[string]]::new()
+                foreach ($Uri in @($AppResponse.web.redirectUris)) { $MergedUris.Add($Uri) }
+                foreach ($Uri in @($CallbackUri) + @(Get-CIPPSiteHostname -AsRedirectUri)) {
+                    if ($Uri -notin $MergedUris) { $MergedUris.Add($Uri) }
+                }
+
                 $PatchBody = @{
                     signInAudience = $SignInAudience
                     web            = @{
-                        redirectUris          = @($CallbackUri)
+                        redirectUris          = $MergedUris
                         implicitGrantSettings = @{ enableIdTokenIssuance = $true }
                     }
                 } | ConvertTo-Json -Depth 10 -Compress
 
-                New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$($AppResponse.id)" -body $PatchBody -type PATCH -NoAuthCheck $true -AsApp $true
+                $null = New-GraphPOSTRequest -uri "https://graph.microsoft.com/v1.0/applications/$($AppResponse.id)" -body $PatchBody -type PATCH -NoAuthCheck $true -AsApp $true
 
                 # Update migration table
                 & $SaveMigrationRow @{
@@ -681,7 +788,7 @@ function Invoke-ExecSSOSetup {
 
         default {
             $StatusCode = [HttpStatusCode]::BadRequest
-            $Body = @{ Results = "Unknown action: $Action. Use 'Status', 'Create', 'Repair', 'Recreate', 'Update', 'RotateSecret', 'ManualConfigure', or 'Migrate'." }
+            $Body = @{ Results = "Unknown action: $Action. Use 'Status', 'Create', 'Repair', 'Recreate', 'Update', 'RefreshRedirectUris', 'RotateSecret', 'ManualConfigure', or 'Migrate'." }
         }
     }
 

--- a/backend/Tests/Private/Get-CIPPSiteHostname.Tests.ps1
+++ b/backend/Tests/Private/Get-CIPPSiteHostname.Tests.ps1
@@ -1,0 +1,236 @@
+# Pester tests for Get-CIPPSiteHostname
+# A container can carry several custom domains and each needs its own EasyAuth callback, so this
+# function is the single source of truth for "which hostnames are bound". The important property
+# is not just that the happy path enumerates them - it's that a FAILED lookup is distinguishable
+# from a successful one, because callers use an empty "missing" set to tell customers everything
+# can sign in. A silent fallback that looks like success is the bug these tests guard.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Authentication/Get-CIPPSiteHostname.ps1'
+
+    # Minimal stubs so Mock has commands to replace during tests
+    function New-CIPPAzRestRequest { param($Uri, $Method) }
+    function Get-CIPPHostname { param($Headers, [switch]$Save) }
+
+    . $FunctionPath
+}
+
+Describe 'Get-CIPPSiteHostname' {
+    BeforeEach {
+        $script:DefaultHost = 'cippxyz.azurewebsites.net'
+        $script:CustomHostA = 'cipp.contoso.com'
+        $script:CustomHostB = 'portal.fabrikam.com'
+        $script:SubId = '11111111-1111-1111-1111-111111111111'
+
+        $script:OriginalEnv = @{
+            WEBSITE_SITE_NAME      = $env:WEBSITE_SITE_NAME
+            WEBSITE_RESOURCE_GROUP = $env:WEBSITE_RESOURCE_GROUP
+            WEBSITE_OWNER_NAME     = $env:WEBSITE_OWNER_NAME
+            WEBSITE_HOSTNAME       = $env:WEBSITE_HOSTNAME
+            IDENTITY_ENDPOINT      = $env:IDENTITY_ENDPOINT
+            IDENTITY_HEADER        = $env:IDENTITY_HEADER
+            AzureWebJobsStorage    = $env:AzureWebJobsStorage
+            NonLocalHostAzurite    = $env:NonLocalHostAzurite
+        }
+
+        # Fully-configured App Service with a managed identity by default
+        $env:WEBSITE_SITE_NAME = 'cippxyz'
+        $env:WEBSITE_RESOURCE_GROUP = 'cipp-rg'
+        $env:WEBSITE_OWNER_NAME = "$script:SubId+cipp-rg-CentralUSwebspace-Linux"
+        $env:WEBSITE_HOSTNAME = $script:DefaultHost
+        $env:IDENTITY_ENDPOINT = 'http://localhost:8081/msi/token'
+        $env:IDENTITY_HEADER = 'stub-identity-header'
+        $env:AzureWebJobsStorage = 'DefaultEndpointsProtocol=https;AccountName=stub'
+        $env:NonLocalHostAzurite = ''
+
+        Mock -CommandName Get-CIPPHostname -MockWith { $script:CustomHostA }
+        Mock -CommandName New-CIPPAzRestRequest -MockWith {
+            [PSCustomObject]@{
+                properties = [PSCustomObject]@{
+                    hostNames = @($script:DefaultHost, $script:CustomHostA, $script:CustomHostB)
+                }
+            }
+        }
+    }
+
+    AfterEach {
+        foreach ($Key in $script:OriginalEnv.Keys) {
+            Set-Item -Path "env:$Key" -Value $script:OriginalEnv[$Key]
+        }
+    }
+
+    Context 'When ARM can be queried' {
+        It 'returns every hostname bound to the site' {
+            $Result = Get-CIPPSiteHostname
+
+            $Result | Should -HaveCount 3
+            $Result | Should -Contain $script:DefaultHost
+            $Result | Should -Contain $script:CustomHostA
+            $Result | Should -Contain $script:CustomHostB
+        }
+
+        It 'builds the ARM URI from the WEBSITE_* variables, splitting the subscription out of WEBSITE_OWNER_NAME' {
+            Get-CIPPSiteHostname | Out-Null
+
+            Should -Invoke New-CIPPAzRestRequest -Times 1 -Exactly -ParameterFilter {
+                $Uri -like "https://management.azure.com/subscriptions/$script:SubId/resourceGroups/cipp-rg/providers/Microsoft.Web/sites/cippxyz?api-version=*"
+            }
+        }
+
+        It 'returns an EasyAuth callback for each hostname with -AsRedirectUri' {
+            $Result = Get-CIPPSiteHostname -AsRedirectUri
+
+            $Result | Should -HaveCount 3
+            $Result | Should -Contain "https://$script:CustomHostA/.auth/login/aad/callback"
+            $Result | Should -Contain "https://$script:CustomHostB/.auth/login/aad/callback"
+        }
+
+        It 'reports Discovered = true with no error under -IncludeStatus' {
+            $Result = Get-CIPPSiteHostname -IncludeStatus
+
+            $Result.Discovered | Should -BeTrue
+            $Result.Error | Should -BeNullOrEmpty
+            $Result.Hostnames | Should -HaveCount 3
+            $Result.RedirectUris | Should -HaveCount 3
+        }
+
+        It 'does not fall back to the stored instance URL' {
+            Get-CIPPSiteHostname | Out-Null
+
+            Should -Invoke Get-CIPPHostname -Times 0 -Exactly
+        }
+    }
+
+    Context 'When the domains cannot be queried' {
+        It 'flags Discovered = false when ARM throws, and surfaces the reason' {
+            Mock -CommandName New-CIPPAzRestRequest -MockWith { throw 'Azure REST API call failed: AuthorizationFailed' }
+
+            $Result = Get-CIPPSiteHostname -IncludeStatus
+
+            $Result.Discovered | Should -BeFalse
+            $Result.Error | Should -Match 'AuthorizationFailed'
+        }
+
+        It 'flags Discovered = false when ARM answers without any hostNames' {
+            Mock -CommandName New-CIPPAzRestRequest -MockWith { [PSCustomObject]@{ properties = [PSCustomObject]@{} } }
+
+            $Result = Get-CIPPSiteHostname -IncludeStatus
+
+            $Result.Discovered | Should -BeFalse
+            $Result.Error | Should -Match 'no hostNames'
+        }
+
+        It 'does not call ARM at all when there is no managed identity' {
+            $env:IDENTITY_ENDPOINT = ''
+            $env:IDENTITY_HEADER = ''
+
+            $Result = Get-CIPPSiteHostname -IncludeStatus
+
+            Should -Invoke New-CIPPAzRestRequest -Times 0 -Exactly
+            $Result.Discovered | Should -BeFalse
+            $Result.Error | Should -Match 'managed identity'
+        }
+
+        It 'does not call ARM at all when not running in App Service' {
+            $env:WEBSITE_SITE_NAME = ''
+
+            $Result = Get-CIPPSiteHostname -IncludeStatus
+
+            Should -Invoke New-CIPPAzRestRequest -Times 0 -Exactly
+            $Result.Discovered | Should -BeFalse
+            $Result.Error | Should -Match 'App Service'
+        }
+
+        It 'falls back to the platform hostname plus the last known instance URL' {
+            Mock -CommandName New-CIPPAzRestRequest -MockWith { throw 'boom' }
+
+            $Result = Get-CIPPSiteHostname
+
+            # The custom domain from Config/InstanceProperties/CIPPURL is the whole point of the
+            # fallback - without it a customer on a custom domain gets only the azurewebsites name.
+            $Result | Should -HaveCount 2
+            $Result | Should -Contain $script:DefaultHost
+            $Result | Should -Contain $script:CustomHostA
+        }
+
+        It 'does not duplicate the hostname when the stored URL is the platform hostname' {
+            Mock -CommandName New-CIPPAzRestRequest -MockWith { throw 'boom' }
+            Mock -CommandName Get-CIPPHostname -MockWith { $script:DefaultHost }
+
+            $Result = Get-CIPPSiteHostname
+
+            $Result | Should -HaveCount 1
+            $Result | Should -Be $script:DefaultHost
+        }
+
+        It 'still returns the platform hostname when the stored URL lookup itself fails' {
+            Mock -CommandName New-CIPPAzRestRequest -MockWith { throw 'boom' }
+            Mock -CommandName Get-CIPPHostname -MockWith { throw 'table storage unavailable' }
+
+            { Get-CIPPSiteHostname } | Should -Not -Throw
+
+            $Result = Get-CIPPSiteHostname
+            $Result | Should -HaveCount 1
+            $Result | Should -Be $script:DefaultHost
+        }
+
+        It 'drops a non-routable hostname rather than registering it' {
+            Mock -CommandName New-CIPPAzRestRequest -MockWith { throw 'boom' }
+            Mock -CommandName Get-CIPPHostname -MockWith { 'localhost' }
+
+            $Result = Get-CIPPSiteHostname
+
+            $Result | Should -Not -Contain 'localhost'
+            $Result | Should -Be $script:DefaultHost
+        }
+
+        It 'returns an empty list rather than throwing when nothing at all is known' {
+            $env:WEBSITE_SITE_NAME = ''
+            $env:WEBSITE_HOSTNAME = ''
+            Mock -CommandName Get-CIPPHostname -MockWith { $null }
+
+            $Result = Get-CIPPSiteHostname -IncludeStatus
+
+            $Result.Discovered | Should -BeFalse
+            $Result.Hostnames | Should -HaveCount 0
+            $Result.RedirectUris | Should -HaveCount 0
+        }
+    }
+
+    Context 'When running in local development' {
+        # There is no App Service locally, so discovery always fails and we would fall through to
+        # the stored CIPPURL - which Invoke-ExecPartnerWebhook -Save writes from the request host,
+        # i.e. 'localhost'. The dev SSO AppId in DevSecrets is a REAL app registration, so that
+        # would permanently graft a localhost callback onto it. Returning nothing is the point.
+        BeforeEach {
+            $env:WEBSITE_SITE_NAME = ''
+            $env:WEBSITE_RESOURCE_GROUP = ''
+            $env:WEBSITE_OWNER_NAME = ''
+            $env:WEBSITE_HOSTNAME = ''
+            $env:IDENTITY_ENDPOINT = ''
+            $env:IDENTITY_HEADER = ''
+            Mock -CommandName Get-CIPPHostname -MockWith { 'localhost' }
+        }
+
+        It 'returns nothing under Azurite so callers no-op' {
+            $env:AzureWebJobsStorage = 'UseDevelopmentStorage=true'
+
+            $Result = Get-CIPPSiteHostname -IncludeStatus
+
+            $Result.Discovered | Should -BeFalse
+            $Result.RedirectUris | Should -HaveCount 0
+            Should -Invoke Get-CIPPHostname -Times 0 -Exactly
+            Should -Invoke New-CIPPAzRestRequest -Times 0 -Exactly
+        }
+
+        It 'returns nothing under NonLocalHostAzurite so callers no-op' {
+            $env:NonLocalHostAzurite = 'true'
+
+            $Result = Get-CIPPSiteHostname -AsRedirectUri
+
+            $Result | Should -HaveCount 0
+            Should -Invoke Get-CIPPHostname -Times 0 -Exactly
+        }
+    }
+}

--- a/frontend/src/components/CippSettings/CippSSOSettings.jsx
+++ b/frontend/src/components/CippSettings/CippSSOSettings.jsx
@@ -87,6 +87,24 @@ export const CippSSOSettings = () => {
   // Three states on purpose: warmup may not have attempted the grant yet, which is not the
   // same as the tenant refusing it. Failure is a soft one — sign-in still works, users just
   // see the consent prompt they see today.
+  // A container can have several custom domains bound, and EasyAuth derives its redirect_uri
+  // from the incoming Host header — so each one needs its own callback on the app registration.
+  // Show the hostname rather than the full /.auth/login/aad/callback URL; that's what an admin
+  // actually recognises.
+  const hostFromUri = (uri) => {
+    try {
+      return new URL(uri).host;
+    } catch {
+      return uri;
+    }
+  };
+  const signInHosts = (data?.redirectUris ?? []).map(hostFromUri);
+  const missingSignInHosts = (data?.missingRedirectUris ?? []).map(hostFromUri);
+  // When the backend couldn't read the domains bound to this container, an empty
+  // missingRedirectUris means "we don't know", not "everything is fine" — say so rather than
+  // showing a clean list a customer would read as confirmation.
+  const domainsUnverified = hasAppId && data?.domainsVerified === false;
+
   const preconsentInfo =
     data?.preconsented === true
       ? { label: "Granted", color: "success" }
@@ -153,6 +171,13 @@ export const CippSSOSettings = () => {
         Action: "Update",
         multiTenant: formControl.getValues("multiTenant"),
       },
+    });
+  };
+
+  const handleRefreshSignInUrls = () => {
+    ssoAction.mutate({
+      url: "/api/ExecSSOSetup",
+      data: { Action: "RefreshRedirectUris" },
     });
   };
 
@@ -252,6 +277,53 @@ export const CippSSOSettings = () => {
                     <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
                       {data.appId}
                     </Typography>
+                  </Grid>
+                </>
+              )}
+
+              {signInHosts.length > 0 && (
+                <>
+                  <Grid size={{ xs: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      Sign-in URLs
+                    </Typography>
+                  </Grid>
+                  <Grid size={{ xs: 8 }}>
+                    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                      {signInHosts.map((host) => (
+                        <Chip
+                          key={host}
+                          label={host}
+                          size="small"
+                          color={missingSignInHosts.includes(host) ? "warning" : "default"}
+                        />
+                      ))}
+                    </Stack>
+                    {missingSignInHosts.length > 0 && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: "block", mt: 0.5 }}
+                      >
+                        {missingSignInHosts.join(", ")}{" "}
+                        {missingSignInHosts.length === 1 ? "is" : "are"} bound to this
+                        instance but not registered on the app. Click{" "}
+                        <strong>Refresh Sign-in URLs</strong> to add{" "}
+                        {missingSignInHosts.length === 1 ? "it" : "them"}.
+                      </Typography>
+                    )}
+                    {domainsUnverified && (
+                      <Typography
+                        variant="caption"
+                        color="warning.main"
+                        sx={{ display: "block", mt: 0.5 }}
+                      >
+                        This list may be incomplete — the custom domains bound to this
+                        instance could not be read, so a domain that cannot sign in would not
+                        show up here.
+                        {data?.domainsError ? ` (${data.domainsError})` : ""}
+                      </Typography>
+                    )}
                   </Grid>
                 </>
               )}
@@ -416,6 +488,14 @@ export const CippSSOSettings = () => {
 
             {isProvisioned && (
               <>
+                <Button
+                  variant="outlined"
+                  color={missingSignInHosts.length > 0 ? "warning" : "inherit"}
+                  onClick={handleRefreshSignInUrls}
+                  disabled={ssoAction.isPending}
+                >
+                  Refresh Sign-in URLs
+                </Button>
                 <Button
                   variant="outlined"
                   color="warning"


### PR DESCRIPTION
New-CIPPSSOApp and the Update action replaced web.redirectUris with a single-element array, so running SSO Create or Update stripped the callback for every other custom domain bound to the container. Sign-in on those domains then failed with AADSTS50011 until a restart re-ran warmup.

All redirect URI writes are now additive over every bound hostname, sourced from a new Get-CIPPSiteHostname helper (extracted from the ARM lookup that was inlined in Update-CIPPSSORedirectUri).

A domain added from the management portal also had no callback until the container restarted, with nothing in the UI explaining the failure. Status now reports which hostnames can sign in and self-heals when one is missing, and a RefreshRedirectUris action backs a "Refresh Sign-in URLs" button.

When the bound domains cannot be read that is now reported, rather than being silently treated as "nothing missing" - previously a failed lookup was indistinguishable from a clean result. The fallback is skipped entirely in local development, where the stored CIPPURL is localhost while the dev SSO AppId points at a real app registration.

Adds 16 Pester tests for Get-CIPPSiteHostname.