### PR TITLE
fix(frontend): saved graph preset changes don't propagate until reload

### DIFF
--- a/frontend/src/components/CippComponents/CippAutocomplete.jsx
+++ b/frontend/src/components/CippComponents/CippAutocomplete.jsx
@@ -320,17 +320,31 @@ export const CippAutoComplete = React.forwardRef((props, ref) => {
     api?.autoSelectFirstItem,
   ])
 
+  // single mode: live options win over the form-held copy, a stored label goes stale
+  // when its option refetches under it (e.g. renamed preset), resolve by value id
+  const resolvedDefaultValue = useMemo(() => {
+    if (
+      multiple ||
+      Array.isArray(defaultValue) ||
+      typeof defaultValue !== 'object' ||
+      defaultValue === null
+    ) {
+      return defaultValue
+    }
+    return memoizedOptions.find((option) => option.value === defaultValue.value) ?? defaultValue
+  }, [defaultValue, multiple, memoizedOptions])
+
   // Create a stable key that only changes when necessary inputs change
   const stableKey = useMemo(() => {
     // Only regenerate the key when these values change
     const keyParts = [
-      JSON.stringify(defaultValue),
+      JSON.stringify(resolvedDefaultValue),
       JSON.stringify(preselectedValue),
       api?.url,
       currentTenant,
     ]
     return keyParts.join('-')
-  }, [defaultValue, preselectedValue, api?.url, currentTenant])
+  }, [resolvedDefaultValue, preselectedValue, api?.url, currentTenant])
 
   // keyed remount orphans an open single-mode popup (input unfocused, no close path), multiple refocuses in onChange
   useEffect(() => {
@@ -346,6 +360,22 @@ export const CippAutoComplete = React.forwardRef((props, ref) => {
     },
     [memoizedOptions]
   )
+
+  // shape the seed for MUI: option arrays stay arrays, single objects wrap in multiple mode, strings resolve to options
+  const normalizedDefaultValue = useMemo(() => {
+    if (Array.isArray(resolvedDefaultValue)) {
+      return resolvedDefaultValue.map((item) =>
+        typeof item === 'string' ? lookupOptionByValue(item) : item
+      )
+    }
+    if (typeof resolvedDefaultValue === 'object' && multiple) {
+      return [resolvedDefaultValue]
+    }
+    if (typeof resolvedDefaultValue === 'string') {
+      return lookupOptionByValue(resolvedDefaultValue)
+    }
+    return resolvedDefaultValue
+  }, [resolvedDefaultValue, multiple, lookupOptionByValue])
 
   return (
     <>
@@ -398,17 +428,7 @@ export const CippAutoComplete = React.forwardRef((props, ref) => {
           return filtered
         }}
         size="small"
-        defaultValue={
-          Array.isArray(defaultValue)
-            ? defaultValue.map((item) =>
-                typeof item === 'string' ? lookupOptionByValue(item) : item
-              )
-            : typeof defaultValue === 'object' && multiple
-              ? [defaultValue]
-              : typeof defaultValue === 'string'
-                ? lookupOptionByValue(defaultValue)
-                : defaultValue
-        }
+        defaultValue={normalizedDefaultValue}
         name={name}
         onChange={(event, newValue) => {
           // Store scroll position before processing the change

--- a/frontend/src/components/CippTable/CIPPTableToptoolbar.js
+++ b/frontend/src/components/CippTable/CIPPTableToptoolbar.js
@@ -677,7 +677,7 @@ export const CIPPTableToptoolbar = React.memo(
         // update filters to include graph explorer presets
         setFilterList([...filters, ...graphPresetList])
       }
-    }, [presetList?.isSuccess, simpleColumns])
+    }, [presetList?.isSuccess, presetList?.data, simpleColumns])
 
     return (
       <>


### PR DESCRIPTION
Issue:
two stale spots after saving a graph explorer preset:

- a newly saved preset doesn't appear in the table's Filters dropdown until page reload. the save invalidates and refetches `ListGraphExplorerPresets`, but the toolbar effect that folds presets into the dropdown deps on `presetList.isSuccess` only; a background refetch never transitions it, so the list never rebuilds
- renaming a preset and saving keeps the old name in "Select a preset" until the selection is cleared with 'x'. the form holds the picked option object, and its stored label goes stale when the options refetch under it

Fix:
- `CIPPTableToptoolbar`: add `presetList?.data` to the effect deps so the refetch rebuilds the dropdown
- `CippAutocomplete` single mode: resolve the held value against live options by value id before the remount key and the MUI seed. display-only, form state untouched, covers any single-mode autocomplete whose options refresh under a held value. the `defaultValue` nested ternary moved into an if/else memo with the same branches

Repro:
1. any graph-backed list page -> Filters -> Edit filters -> build a query -> Save Preset -> preset now appears in the dropdown immediately (was: reload required)
2. select a preset in the drawer, change Preset Name, Save Preset -> selector picks up the new name when the refetch lands (was: old name until cleared)