### PR TITLE
feat(tenant-selector): keep current tenant visible in the nav dropdown list

### DIFF
--- a/frontend/src/components/CippComponents/CippTenantSelector.jsx
+++ b/frontend/src/components/CippComponents/CippTenantSelector.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { CippAutoComplete } from "../CippComponents/CippAutocomplete";
 import { ApiGetCall } from "../../api/ApiCall";
-import { IconButton, Tooltip, Box } from "@mui/material";
+import { IconButton, Tooltip, Box, Chip, Typography } from "@mui/material";
 import { Refresh } from "@mui/icons-material";
 import React, { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
@@ -383,6 +383,41 @@ export const CippTenantSelector = React.forwardRef((props, ref) => {
           isOptionEqualToValue={
             (option, value) => option.value === value.value // Custom equality test to compare the tenant by value
           }
+          // Keep the selected tenant in the list so it stays in its alphabetical position
+          filterSelectedOptions={false}
+          renderOption={(props, option, { selected, index }) => {
+            const { key, ...optionProps } = props;
+            return (
+              <Box component="li" key={`${option.value}-${index}`} {...optionProps}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    width: "100%",
+                    minWidth: 0,
+                  }}
+                >
+                  <Typography variant="body1" noWrap>
+                    {option.label}
+                  </Typography>
+                  {selected && (
+                    <Chip
+                      label="Current"
+                      size="small"
+                      variant="outlined"
+                      sx={{
+                        ml: "auto",
+                        flexShrink: 0,
+                        height: 20,
+                        color: "text.secondary",
+                      }}
+                    />
+                  )}
+                </Box>
+              </Box>
+            );
+          }}
         />
         {refreshButton && (
           <IconButton


### PR DESCRIPTION
The global tenant selector hid the active tenant from its own dropdown, so scrolling the list left a gap where the selected tenant should have been and the only way to see it was the closed input. This makes it difficult to locate one's place in the tenant list when systematically working through the tenants from top-to-bottom (or vice versa), checking pages that do not support the "All Tenants" view.

Override `filterSelectedOptions` on the `CippAutoComplete` call site so the current tenant stays in its alphabetical position, and mark that row with a "Current" chip. MUI supplies the selected flag to `renderOption` via the existing `isOptionEqualToValue`, and highlights + scrolls to the row on open now that it is no longer filtered out.

<img width="426" height="580" alt="image" src="https://github.com/user-attachments/assets/540ca1a6-93e7-433a-8292-33975d9a3789" />

Both props are passed from `CippTenantSelector` rather than changed in `CippAutocomplete`: they land in the trailing `{...other}` spread, which overrides the shared defaults without affecting the other autocompletes that rely on selected options being filtered out.

_NOTE: This does not affect `CippFormTenantSelector`, the in-form tenant picker used by the wizards, drawers, and form pages. That component reaches `CippAutoComplete` through `CippFormComponent` and passes neither `filterSelectedOptions` nor `renderOption`, so it keeps the shared defaults. That matters most for its default `multiple=true` mode, where filtering already-chosen tenants out of the list is the wanted behavior: selections are shown as chips in the input, and repeating them in the dropdown would let the same tenant be picked twice._