### PR TITLE
feat(auth): introduce CippAuthShell for all auth screens 

### DIFF
--- a/.github/workflows/preview-container.yml
+++ b/.github/workflows/preview-container.yml
@@ -105,8 +105,10 @@ jobs:
           echo "slug=${SLUG}" >> $GITHUB_OUTPUT
           echo "image_tag=${SLUG}" >> $GITHUB_OUTPUT
           # Keep the "preview." marker in the version regardless of tag prefix, so a build image
-          # is identifiable as one at runtime the same way +dev./+nightly. builds are.
-          echo "app_version=${BASE}+preview.${SLUG}.${SHORT_SHA}" >> $GITHUB_OUTPUT
+          # is identifiable as one at runtime the same way +dev./+nightly. builds are. The slug
+          # already starts with "preview-" for preview/** branches, so strip that to avoid
+          # "+preview.preview-foo"; other prefixes (fix-, feat-, ...) are kept as-is.
+          echo "app_version=${BASE}+preview.${SLUG#preview-}.${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "full_sha=${FULL_SHA}" >> $GITHUB_OUTPUT
           echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 

--- a/frontend/src/components/CippComponents/CippAuthShell.jsx
+++ b/frontend/src/components/CippComponents/CippAuthShell.jsx
@@ -1,0 +1,222 @@
+import NextLink from 'next/link'
+import PropTypes from 'prop-types'
+import { Box, Button, Card, LinearProgress, Stack, Typography } from '@mui/material'
+import { alpha } from '@mui/material/styles'
+import { Grid } from '@mui/system'
+import { blue } from '../../theme/colors'
+
+// Full-viewport shell for the screens a signed-out user can land on: sign-in,
+// access denied, logging in, api offline. PrivateRoute renders those pages as
+// components, so this never sits inside DashboardLayout and owns its own ground.
+//
+// The left panel is deliberately mode-invariant — brand navy and white in both
+// light and dark — the same trick CippImageCard uses with neutral.900. Only the
+// right half flips, and it does so purely through palette tokens.
+
+// 100vh includes the area under iOS Safari's collapsing url bar, which clips the
+// bottom of the stacked mobile layout. An sx array would mean responsive
+// breakpoints rather than a fallback, so the override goes through @supports.
+const fullHeight = {
+  minHeight: '100vh',
+  '@supports (min-height: 100dvh)': { minHeight: '100dvh' },
+}
+
+// public/logo.png carries its own white keyline, so it reads on the navy panel
+// untouched — no mask, no plate, no light/dark variant. Do not swap this for
+// src/components/logo.js: that file throws if its inlined payload is altered.
+const CippBrandLockup = () => (
+  <Box
+    component="img"
+    src="/logo.png"
+    alt="CIPP"
+    sx={{ display: 'block', width: 'auto', height: { xs: 58, md: 96 } }}
+  />
+)
+
+export const CippAuthShell = ({
+  title,
+  titleIcon,
+  description,
+  actionText,
+  actionHref,
+  onActionClick,
+  actionDisabled = false,
+  secondaryText,
+  secondaryHref,
+  onSecondaryClick,
+  busy = false,
+  children,
+  version,
+  tagline = 'CyberDrain Improved Partner Portal',
+}) => {
+  // href wins over onClick so a caller passing both gets one control, not two
+  const hasPrimary = Boolean(actionText) && Boolean(actionHref || onActionClick)
+  const hasSecondary = Boolean(secondaryText) && Boolean(secondaryHref || onSecondaryClick)
+
+  return (
+    <Box sx={{ ...fullHeight, bgcolor: 'background.default' }}>
+      <Grid container sx={{ ...fullHeight, alignItems: 'stretch' }}>
+        <Grid
+          size={{ xs: 12, md: 6 }}
+          sx={{
+            position: 'relative',
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            gap: { xs: 2.5, md: 4 },
+            bgcolor: blue.main,
+            color: 'common.white',
+            px: { xs: 3, md: 8 },
+            py: { xs: 3.5, md: 8 },
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              inset: 0,
+              pointerEvents: 'none',
+              // one concatenated string: an array here would mean breakpoints
+              background: (theme) =>
+                `radial-gradient(90% 65% at 8% -12%, ${alpha(
+                  theme.palette.primary.main,
+                  0.32
+                )} 0%, transparent 70%),` +
+                `radial-gradient(60% 55% at 105% 108%, ${alpha(
+                  theme.palette.primary.main,
+                  0.14
+                )} 0%, transparent 70%)`,
+            },
+          }}
+        >
+          <Box sx={{ position: 'relative', zIndex: 1 }}>
+            <CippBrandLockup />
+          </Box>
+
+          {/* hidden on the stacked layout, where the panel is just a header strip */}
+          <Box
+            sx={{
+              position: 'relative',
+              zIndex: 1,
+              display: { xs: 'none', sm: 'block' },
+            }}
+          >
+            <Typography variant="h3" sx={{ color: 'common.white', maxWidth: 520 }}>
+              {tagline}
+            </Typography>
+          </Box>
+
+          <Typography
+            variant="caption"
+            sx={{
+              position: 'relative',
+              zIndex: 1,
+              color: alpha('#FFFFFF', 0.72),
+            }}
+          >
+            {version ? `v${version}` : ' '}
+          </Typography>
+        </Grid>
+
+        <Grid
+          size={{ xs: 12, md: 6 }}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: { xs: 'flex-start', md: 'center' },
+            px: { xs: 2, sm: 3, md: 6 },
+            pt: { xs: 4, md: 6 },
+            // _app.js mounts CippSpeedDial outside PrivateRoute, so the help fab
+            // overlays these pages — clear it on the stacked layout
+            pb: { xs: 10, md: 6 },
+          }}
+        >
+          <Box sx={{ width: '100%', maxWidth: 520 }}>
+            <Card aria-busy={busy || undefined} sx={{ overflow: 'hidden' }}>
+              <Box sx={{ height: 4 }}>{busy && <LinearProgress sx={{ height: 4 }} />}</Box>
+              <Box sx={{ p: { xs: 3, md: 4 } }}>
+                {/* icon is a sibling of the title, never nested inside it, so the
+                    heading stays a single unambiguous text node */}
+                <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mb: 2 }}>
+                  {titleIcon}
+                  <Typography variant="h4" component="h1">
+                    {title}
+                  </Typography>
+                </Stack>
+
+                {description &&
+                  (typeof description === 'string' ? (
+                    <Typography variant="body1" sx={{ color: 'text.secondary' }}>
+                      {description}
+                    </Typography>
+                  ) : (
+                    <Box sx={{ color: 'text.secondary' }}>{description}</Box>
+                  ))}
+
+                {(hasPrimary || hasSecondary) && (
+                  <Stack direction="row" spacing={1.5} useFlexGap flexWrap="wrap" sx={{ mt: 4 }}>
+                    {hasPrimary &&
+                      (actionHref ? (
+                        <Button
+                          component={NextLink}
+                          href={actionHref}
+                          variant="contained"
+                          size="large"
+                          disabled={actionDisabled}
+                        >
+                          {actionText}
+                        </Button>
+                      ) : (
+                        <Button
+                          onClick={onActionClick}
+                          variant="contained"
+                          size="large"
+                          disabled={actionDisabled}
+                        >
+                          {actionText}
+                        </Button>
+                      ))}
+
+                    {hasSecondary &&
+                      (secondaryHref ? (
+                        <Button
+                          component={NextLink}
+                          href={secondaryHref}
+                          variant="outlined"
+                          size="large"
+                        >
+                          {secondaryText}
+                        </Button>
+                      ) : (
+                        <Button onClick={onSecondaryClick} variant="outlined" size="large">
+                          {secondaryText}
+                        </Button>
+                      ))}
+                  </Stack>
+                )}
+              </Box>
+            </Card>
+
+            {children && <Box sx={{ mt: 3 }}>{children}</Box>}
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  )
+}
+
+CippAuthShell.propTypes = {
+  title: PropTypes.node.isRequired,
+  titleIcon: PropTypes.node,
+  description: PropTypes.node,
+  actionText: PropTypes.string,
+  actionHref: PropTypes.string,
+  onActionClick: PropTypes.func,
+  actionDisabled: PropTypes.bool,
+  secondaryText: PropTypes.string,
+  secondaryHref: PropTypes.string,
+  onSecondaryClick: PropTypes.func,
+  busy: PropTypes.bool,
+  children: PropTypes.node,
+  version: PropTypes.string,
+  tagline: PropTypes.string,
+}

--- a/frontend/src/components/CippTable/CIPPTableToptoolbar.js
+++ b/frontend/src/components/CippTable/CIPPTableToptoolbar.js
@@ -29,7 +29,6 @@ import {
   Code as CodeIcon,
   PictureAsPdf as PdfIcon,
   TableChart as CsvIcon,
-  SevereCold,
   Sync,
   Check as CheckIcon,
   MoreVert as MoreVertIcon,
@@ -1281,13 +1280,6 @@ export const CIPPTableToptoolbar = React.memo(
               >
                 Bulk Actions
               </Button>
-            )}
-
-            {/* Cold start indicator */}
-            {getRequestData?.data?.pages?.[0]?.Metadata?.ColdStart === true && (
-              <Tooltip title="Function App cold start was detected, data takes a little longer to retrieve on first load.">
-                <SevereCold />
-              </Tooltip>
             )}
 
             {/* Queue tracker */}

--- a/frontend/src/components/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute.js
@@ -3,6 +3,7 @@ import UnauthenticatedPage from "../pages/unauthenticated.js";
 import LoadingPage from "../pages/loading.js";
 import ApiOfflinePage from "../pages/api-offline.js";
 import { useState, useEffect } from "react";
+import { rememberSession } from "../utils/auth-session.js";
 
 // EasyAuth exposes the signed-in identity in two shapes depending on the host:
 //   - Static Web Apps:      { clientPrincipal: { userDetails, userRoles, ... } }
@@ -10,6 +11,13 @@ import { useState, useEffect } from "react";
 // an authenticated session must be detected from either populated shape.
 const hasAuthenticatedSession = (data) =>
   Boolean(data?.clientPrincipal) || (Array.isArray(data) && data.length > 0);
+
+// Being signed out and being signed in without access need different screens and
+// different actions, so the unauthenticated page is told which one it is rather
+// than guessing. SESSION means there is no identity at all; PERMISSIONS means a
+// valid identity that CIPP won't let through.
+export const UNAUTH_SESSION = "session";
+export const UNAUTH_PERMISSIONS = "permissions";
 
 export const PrivateRoute = ({ children, routeType }) => {
   const [unauthLatched, setUnauthLatched] = useState(false);
@@ -43,9 +51,17 @@ export const PrivateRoute = ({ children, routeType }) => {
     waiting: session.isSuccess && hasAuthenticatedSession(session.data),
   });
 
+  // Record that a session existed on this device so the sign-in screen can tell
+  // an expired session from a first visit.
+  useEffect(() => {
+    if (hasAuthenticatedSession(session.data)) {
+      rememberSession();
+    }
+  }, [session.data]);
+
   // If latched as unauthenticated, always show unauthenticated page
   if (unauthLatched) {
-    return <UnauthenticatedPage />;
+    return <UnauthenticatedPage reason={UNAUTH_SESSION} />;
   }
 
   // Check if the session is still loading before determining authentication status
@@ -87,21 +103,23 @@ export const PrivateRoute = ({ children, routeType }) => {
   if (null !== apiRoles?.data?.clientPrincipal && undefined !== apiRoles?.data) {
     roles = apiRoles?.data?.clientPrincipal?.userRoles ?? [];
   } else if (null === apiRoles?.data?.clientPrincipal || undefined === apiRoles?.data) {
-    return <UnauthenticatedPage />;
+    // CIPP has no identity for this caller at all, so there is nothing to deny
+    return <UnauthenticatedPage reason={UNAUTH_SESSION} />;
   }
   if (null === roles) {
-    return <UnauthenticatedPage />;
+    return <UnauthenticatedPage reason={UNAUTH_SESSION} />;
   } else {
     const blockedRoles = ["anonymous", "authenticated"];
     const userRoles = roles?.filter((role) => !blockedRoles.includes(role)) ?? [];
     const isAuthenticated = userRoles.length > 0 && !apiRoles?.error;
     const isAdmin = roles?.includes("admin") || roles?.includes("superadmin");
+    // from here the identity is real, it just isn't allowed through
     if (routeType === "admin" && !isAdmin) {
-      return <UnauthenticatedPage />;
+      return <UnauthenticatedPage reason={UNAUTH_PERMISSIONS} />;
     }
 
     if (!isAuthenticated) {
-      return <UnauthenticatedPage />;
+      return <UnauthenticatedPage reason={UNAUTH_PERMISSIONS} />;
     }
 
     return children;

--- a/frontend/src/pages/api-offline.js
+++ b/frontend/src/pages/api-offline.js
@@ -1,167 +1,110 @@
-import {
-  Box,
-  Button,
-  Container,
-  Stack,
-  Alert,
-  CircularProgress,
-  Typography,
-  SvgIcon,
-} from "@mui/material";
-import { Grid } from "@mui/system";
-import Head from "next/head";
-import { useState, useEffect } from "react";
-import axios from "axios";
-import { CippImageCard } from "../components/CippCards/CippImageCard";
-import { ErrorOutlineOutlined } from "@mui/icons-material";
+import { Alert, Box, Button, SvgIcon, Typography } from '@mui/material'
+import Head from 'next/head'
+import { useState } from 'react'
+import axios from 'axios'
+import { ErrorOutlineOutlined } from '@mui/icons-material'
+import { CippAuthShell } from '../components/CippComponents/CippAuthShell'
+import { ApiGetCall } from '../api/ApiCall'
 
+// Reached almost exclusively from legacy Function App deployments, which are
+// still supported — hence the wording here.
 const ApiOfflinePage = () => {
-  const [testingConnection, setTestingConnection] = useState(false);
-  const [testResult, setTestResult] = useState(null);
-  const [apiVersion, setApiVersion] = useState(null);
+  const [testingConnection, setTestingConnection] = useState(false)
+  const [testResult, setTestResult] = useState(null)
 
-  // Check API version when component mounts
-  useEffect(() => {
-    const checkApiVersion = async () => {
-      try {
-        const response = await axios.get("/version.json", { timeout: 5000 });
-        setApiVersion(response.data?.version || "Unknown");
-      } catch (error) {
-        console.error("Failed to fetch API version:", error);
-      }
-    };
-
-    checkApiVersion();
-  }, []);
+  const version = ApiGetCall({
+    url: '/version.json',
+    queryKey: 'LocalVersion',
+  })
 
   const handleTestConnection = async () => {
-    setTestingConnection(true);
-    setTestResult(null);
+    setTestingConnection(true)
+    setTestResult(null)
 
     try {
       // Try to ping the API
-      const testCall = await axios.get("/api/me", { timeout: 45000 });
-      console.log("API Test Call Response:", testCall);
-      if (!testCall.headers["content-type"]?.includes("application/json")) {
-        throw new Error("API did not return the expected response.");
+      const testCall = await axios.get('/api/me', { timeout: 45000 })
+      console.log('API Test Call Response:', testCall)
+      if (!testCall.headers['content-type']?.includes('application/json')) {
+        throw new Error('API did not return the expected response.')
       }
-      setTestResult({ success: true, message: "Connection successful! Try refreshing the page." });
+      setTestResult({
+        success: true,
+        message: 'Connection successful! Try refreshing the page.',
+      })
     } catch (error) {
-      let errorMessage = "Connection failed.";
+      let errorMessage = 'Connection failed.'
 
       if (error.response) {
         // Request was made and server responded with a status code outside of 2xx range
-        errorMessage = `API responded with status: ${error.response.status}`;
+        errorMessage = `API responded with status: ${error.response.status}`
         if (error.response.status === 404) {
           errorMessage +=
-            " (API endpoint not found, this can be the case if your Function App is on Version 7 or below)";
+            ' (API endpoint not found, this can be the case if your Function App is on Version 7 or below)'
         }
       } else if (error.request) {
         // Request was made but no response received
-        errorMessage = "No response received from API. Check if your Function App is running.";
+        errorMessage = 'No response received from API. Check if your Function App is running.'
       } else {
         // Error in setting up the request
-        errorMessage = `Error: ${error.message}`;
+        errorMessage = `Error: ${error.message}`
       }
 
-      setTestResult({ success: false, message: errorMessage });
+      setTestResult({ success: false, message: errorMessage })
     } finally {
-      setTestingConnection(false);
+      setTestingConnection(false)
     }
-  };
-
-  // We're now using Typography components directly in the JSX
-  // instead of generating a help text string
+  }
 
   return (
     <>
       <Head>
         <title>API Offline</title>
       </Head>
-      <Box
-        sx={{
-          flexGrow: 1,
-          py: 4,
-          height: "100vh", // Full height of the viewport
-          bgcolor: "background.default", // Add background color to match theme
-        }}
+      <CippAuthShell
+        busy={testingConnection}
+        version={version?.data?.version}
+        titleIcon={
+          <SvgIcon sx={{ color: 'error.main' }}>
+            <ErrorOutlineOutlined />
+          </SvgIcon>
+        }
+        title="CIPP API Unreachable"
+        description={
+          <>
+            <Typography variant="body1">
+              The CIPP API appears to be offline or out of date.
+            </Typography>
+            <Typography variant="body1" sx={{ mt: 2 }}>
+              If you are self-hosting CIPP, please ensure your Function App is running and up to
+              date.
+            </Typography>
+          </>
+        }
+        actionText={testingConnection ? 'Testing Connection...' : 'Test API Connection'}
+        onActionClick={handleTestConnection}
+        actionDisabled={testingConnection}
       >
-        <Container maxWidth={false}>
-          <Stack spacing={6} sx={{ height: "100%" }}>
-            <Grid
-              container
-              spacing={3}
-              justifyContent="center" // Center horizontally
-              alignItems="center" // Center vertically
-              sx={{ height: "100%" }} // Ensure the container takes full height
-            >
-              <Grid size={{ md: 6, xs: 12 }}>
-                <CippImageCard
-                  isFetching={false}
-                  imageUrl="/assets/illustrations/undraw_server_status_re_n8ln.svg"
-                  title={
-                    <Typography variant="h4" component="h1" gutterBottom>
-                      <SvgIcon sx={{ verticalAlign: "middle", mr: 1, color: "error.main" }}>
-                        <ErrorOutlineOutlined />
-                      </SvgIcon>
-                      CIPP API Unreachable
-                    </Typography>
-                  }
-                  text={
-                    <Box sx={{ mt: 2 }}>
-                      <Typography variant="body1">
-                        The CIPP API appears to be offline or out of date.
-                        {apiVersion && (
-                          <Typography
-                            component="span"
-                            sx={{ fontWeight: "medium", display: "block", mt: 1 }}
-                          >
-                            Frontend Version: {apiVersion}
-                          </Typography>
-                        )}
-                      </Typography>
-
-                      <Typography variant="body1" sx={{ mt: 2 }}>
-                        If you are self-hosting CIPP, please ensure your Function App is running and
-                        up to date. If you are using the hosted version, please check your
-                        subscription in GitHub.
-                      </Typography>
-                    </Box>
-                  }
-                  linkText={testingConnection ? "Testing Connection..." : "Test API Connection"}
-                  onButtonClick={handleTestConnection}
-                />
-
-                {testResult && (
-                  <Box sx={{ mt: 3, mb: 2 }}>
-                    <Alert severity={testResult.success ? "success" : "error"}>
-                      <Typography variant="body2">{testResult.message}</Typography>
-                      {testResult.success && (
-                        <Button
-                          variant="outlined"
-                          color="primary"
-                          sx={{ mt: 1 }}
-                          onClick={() => window.location.reload()}
-                        >
-                          Refresh Page
-                        </Button>
-                      )}
-                    </Alert>
-                  </Box>
-                )}
-
-                {testingConnection && (
-                  <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
-                    <CircularProgress />
-                  </Box>
-                )}
-              </Grid>
-            </Grid>
-          </Stack>
-        </Container>
-      </Box>
+        {testResult && (
+          <Alert severity={testResult.success ? 'success' : 'error'}>
+            <Typography variant="body2">{testResult.message}</Typography>
+            {testResult.success && (
+              <Box>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  sx={{ mt: 1 }}
+                  onClick={() => window.location.reload()}
+                >
+                  Refresh Page
+                </Button>
+              </Box>
+            )}
+          </Alert>
+        )}
+      </CippAuthShell>
     </>
-  );
-};
+  )
+}
 
-export default ApiOfflinePage;
+export default ApiOfflinePage

--- a/frontend/src/pages/loading.js
+++ b/frontend/src/pages/loading.js
@@ -1,70 +1,28 @@
-import { Box, Container, Stack } from "@mui/material";
-import { Grid } from "@mui/system";
-import Head from "next/head";
-import { CippImageCard } from "../components/CippCards/CippImageCard";
-
-import { ApiGetCall } from "../api/ApiCall";
-import { useState, useEffect } from "react";
+import Head from 'next/head'
+import { ApiGetCall } from '../api/ApiCall'
+import { CippAuthShell } from '../components/CippComponents/CippAuthShell'
 
 const Page = () => {
-  const [loadingText, setLoadingText] = useState("Please wait while we log you in...");
-  const orgData = ApiGetCall({
-    url: "/api/me",
-    queryKey: "authmecipp",
-  });
-
-  const [loadingImage, setLoadingImage] = useState(
-    "/assets/illustrations/undraw_analysis_dq08.svg"
-  );
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (!orgData.isSuccess) {
-        setLoadingText(
-          "The function app may be experiencing a cold start currently, this can take a little longer than usual..."
-        );
-        setLoadingImage("/assets/illustrations/undraw-into-the-night-nd84.svg");
-      }
-    }, 20000); // 20 seconds
-
-    return () => clearTimeout(timer);
-  }, [orgData.isSuccess]);
+  // /version.json is served by the frontend host, so it resolves even when the
+  // API doesn't
+  const version = ApiGetCall({
+    url: '/version.json',
+    queryKey: 'LocalVersion',
+  })
 
   return (
     <>
       <Head>
         <title>Loading</title>
       </Head>
-      <Box
-        sx={{
-          flexGrow: 1,
-          py: 4,
-          height: "100vh", // Full height of the viewport
-        }}
-      >
-        <Container maxWidth={false}>
-          <Stack spacing={6} sx={{ height: "100%" }}>
-            <Grid
-              container
-              spacing={3}
-              justifyContent="center" // Center horizontally
-              alignItems="center" // Center vertically
-              sx={{ height: "100%" }} // Ensure the container takes full height
-            >
-              <Grid size={{ md: 6, xs: 12 }}>
-                <CippImageCard
-                  isFetching={false}
-                  imageUrl={loadingImage}
-                  text={loadingText}
-                  title="Logging into CIPP"
-                />
-              </Grid>
-            </Grid>
-          </Stack>
-        </Container>
-      </Box>
+      <CippAuthShell
+        busy
+        version={version?.data?.version}
+        title="Logging into CIPP"
+        description="Please wait while we log you in..."
+      />
     </>
-  );
-};
+  )
+}
 
-export default Page;
+export default Page

--- a/frontend/src/pages/unauthenticated.js
+++ b/frontend/src/pages/unauthenticated.js
@@ -1,82 +1,124 @@
-import { Box, Container, Stack } from "@mui/material";
-import { Grid } from "@mui/system";
-import Head from "next/head";
-import { CippImageCard } from "../components/CippCards/CippImageCard";
-import { ApiGetCall } from "../api/ApiCall";
-import { useMemo } from "react";
+import Head from 'next/head'
+import { useMemo } from 'react'
+import { Box, Stack, SvgIcon, Typography } from '@mui/material'
+import { PersonOutlineOutlined } from '@mui/icons-material'
+import { CippAuthShell } from '../components/CippComponents/CippAuthShell'
+import { ApiGetCall } from '../api/ApiCall'
+import { hasSeenSession } from '../utils/auth-session'
 
-const Page = () => {
+const LOGIN_BASE = '/.auth/login/aad?prompt=select_account'
+
+// This page prerenders in Node during `next build` (next.config.js sets
+// output: 'export'), so window can't be read unconditionally.
+const loginUrl = () =>
+  typeof window === 'undefined'
+    ? LOGIN_BASE
+    : `${LOGIN_BASE}&post_login_redirect_uri=${encodeURIComponent(window.location.href)}`
+
+// Two different failures wearing one face until now. No identity at all is not a
+// denial — there is nothing to explain and one thing to do. A real identity CIPP
+// won't let through is, and it needs the account named.
+const Page = ({ reason = 'session' }) => {
   const orgData = ApiGetCall({
-    url: "/api/me",
-    queryKey: "authmecipp",
-  });
+    url: '/api/me',
+    queryKey: 'authmecipp',
+  })
 
   const swaStatus = ApiGetCall({
-    url: "/.auth/me",
-    queryKey: "authmeswa",
+    url: '/.auth/me',
+    queryKey: 'authmeswa',
     staleTime: 120000,
     refetchOnWindowFocus: true,
-  });
+  })
 
-  const blockedRoles = ["anonymous", "authenticated"];
+  const version = ApiGetCall({
+    url: '/version.json',
+    queryKey: 'LocalVersion',
+  })
+
+  const blockedRoles = ['anonymous', 'authenticated']
   // Use useMemo to derive userRoles directly
   const userRoles = useMemo(() => {
     if (orgData.isSuccess && orgData.data?.clientPrincipal?.userRoles) {
-      return orgData.data.clientPrincipal.userRoles.filter((role) => !blockedRoles.includes(role));
+      return orgData.data.clientPrincipal.userRoles.filter((role) => !blockedRoles.includes(role))
     }
-    return [];
-  }, [orgData.isSuccess, orgData.data?.clientPrincipal?.userRoles]);
+    return []
+  }, [orgData.isSuccess, orgData.data?.clientPrincipal?.userRoles])
 
   const canReturnHome =
-    swaStatus.isSuccess && !!swaStatus?.data?.clientPrincipal && userRoles.length > 0;
+    swaStatus.isSuccess && !!swaStatus?.data?.clientPrincipal && userRoles.length > 0
+  const signedInAs = swaStatus?.data?.clientPrincipal?.userDetails
+
+  const isSessionEnded = reason === 'session'
+
+  const sessionProps = {
+    title: 'Sign in to CIPP',
+    // reading localStorage during render is safe here: the gate below keeps this
+    // subtree off the prerender and off the first client render, so the server
+    // and client can never disagree on the wording
+    description: hasSeenSession()
+      ? 'Your session has expired. Sign in again to continue.'
+      : 'Sign in with your Microsoft account to continue.',
+    actionText: 'Sign in with Microsoft',
+    actionHref: loginUrl(),
+  }
+
+  const permissionProps = {
+    title: 'Access Denied',
+    description: (
+      <>
+        <Typography variant="body1">
+          {orgData?.data?.message || "Your account doesn't have permission to view this page."}
+        </Typography>
+        {signedInAs && (
+          <Stack
+            direction="row"
+            spacing={1.25}
+            alignItems="center"
+            sx={{
+              mt: 2.5,
+              px: 1.5,
+              py: 1.25,
+              borderRadius: 1,
+              border: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'action.hover',
+              color: 'text.primary',
+            }}
+          >
+            <SvgIcon fontSize="small" sx={{ color: 'text.secondary' }}>
+              <PersonOutlineOutlined />
+            </SvgIcon>
+            <Typography variant="body2">
+              Signed in as{' '}
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                {signedInAs}
+              </Box>
+            </Typography>
+          </Stack>
+        )}
+      </>
+    ),
+    // switching account is only offerable once we know which account is signed in
+    actionText: signedInAs ? 'Sign in with a different account' : 'Login',
+    actionHref: loginUrl(),
+    secondaryText: canReturnHome ? 'Return to Home' : undefined,
+    secondaryHref: canReturnHome ? '/' : undefined,
+  }
+
   return (
     <>
       <Head>
-        <title>401 - Access Denied</title>
+        <title>{isSessionEnded ? 'Sign in - CIPP' : '401 - Access Denied'}</title>
       </Head>
-      <Box
-        sx={{
-          flexGrow: 1,
-          py: 4,
-          height: "100vh", // Full height of the viewport
-        }}
-      >
-        <Container maxWidth={false}>
-          <Stack spacing={6} sx={{ height: "100%" }}>
-            <Grid
-              container
-              spacing={3}
-              justifyContent="center" // Center horizontally
-              alignItems="center" // Center vertically
-              sx={{ height: "100%" }} // Ensure the container takes full height
-            >
-              <Grid size={{ md: 6, xs: 12 }}>
-                {(orgData.isSuccess || swaStatus.isSuccess) && Array.isArray(userRoles) && (
-                  <CippImageCard
-                    isFetching={false}
-                    imageUrl="/assets/illustrations/undraw_online_test_re_kyfx.svg"
-                    text={
-                      orgData?.data?.message ||
-                      "You're not allowed to be here, or are logged in under the wrong account."
-                    }
-                    title="Access Denied"
-                    linkText={canReturnHome ? "Return to Home" : "Login"}
-                    link={
-                      canReturnHome
-                        ? "/"
-                        : `/.auth/login/aad?prompt=select_account&post_login_redirect_uri=${encodeURIComponent(
-                            window.location.href
-                          )}`
-                    }
-                  />
-                )}
-              </Grid>
-            </Grid>
-          </Stack>
-        </Container>
-      </Box>
+      {(orgData.isSuccess || swaStatus.isSuccess) && Array.isArray(userRoles) && (
+        <CippAuthShell
+          version={version?.data?.version}
+          {...(isSessionEnded ? sessionProps : permissionProps)}
+        />
+      )}
     </>
-  );
-};
+  )
+}
 
-export default Page;
+export default Page

--- a/frontend/src/utils/auth-session.js
+++ b/frontend/src/utils/auth-session.js
@@ -1,0 +1,25 @@
+// The frontend can't tell an expired session from a first-ever visit — both look
+// like an empty /.auth/me. Remembering that a session once existed on this device
+// lets the sign-in screen say "your session has expired" only when that's true.
+//
+// A stale flag is harmless: it only ever picks the friendlier of two wordings.
+
+const STORAGE_KEY = 'cipp.hasSession'
+
+export const rememberSession = () => {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, '1')
+  } catch {
+    // private mode or a full quota, the wording just falls back
+  }
+}
+
+export const hasSeenSession = () => {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}

--- a/frontend/tests/components/CippComponents/CippAuthShell.stories.jsx
+++ b/frontend/tests/components/CippComponents/CippAuthShell.stories.jsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { within, expect } from 'storybook/test'
+import { Alert, Button, SvgIcon, Typography } from '@mui/material'
+import { ErrorOutlineOutlined } from '@mui/icons-material'
+import { CippAuthShell } from '../../../src/components/CippComponents/CippAuthShell'
+
+export default {
+  title: 'Components/CippAuthShell',
+  component: CippAuthShell,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+}
+
+// the four states PrivateRoute can put a signed-out user in
+
+export const SignIn = {
+  args: {
+    title: 'Sign in to CIPP',
+    description: 'Your session has expired. Sign in again to continue.',
+    actionText: 'Sign in with Microsoft',
+    actionHref: '/.auth/login/aad?prompt=select_account',
+    version: '10.7.5',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('heading', { name: 'Sign in to CIPP' })).toBeInTheDocument()
+    await expect(canvas.getByRole('link', { name: 'Sign in with Microsoft' })).toBeInTheDocument()
+  },
+}
+
+export const SignInDark = {
+  ...SignIn,
+  globals: { theme: 'dark' },
+}
+
+export const AccessDenied = {
+  args: {
+    title: 'Access Denied',
+    description: (
+      <>
+        <Typography variant="body1">
+          Your account doesn&apos;t have permission to view this page.
+        </Typography>
+        <Typography variant="body2" sx={{ mt: 2 }}>
+          Signed in as <strong>john@contoso.com</strong>
+        </Typography>
+      </>
+    ),
+    actionText: 'Sign in with a different account',
+    actionHref: '/.auth/login/aad?prompt=select_account',
+    secondaryText: 'Return to Home',
+    secondaryHref: '/',
+    version: '10.7.5',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('link', { name: 'Return to Home' })).toBeInTheDocument()
+    await expect(
+      canvas.getByRole('link', { name: 'Sign in with a different account' })
+    ).toBeInTheDocument()
+  },
+}
+
+export const Busy = {
+  args: {
+    busy: true,
+    title: 'Logging into CIPP',
+    description: 'Please wait while we log you in...',
+    version: '10.7.5',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('progressbar')).toBeInTheDocument()
+  },
+}
+
+export const ApiOffline = {
+  args: {
+    title: 'CIPP API Unreachable',
+    titleIcon: (
+      <SvgIcon sx={{ color: 'error.main' }}>
+        <ErrorOutlineOutlined />
+      </SvgIcon>
+    ),
+    description: (
+      <>
+        <Typography variant="body1">The CIPP API appears to be offline or out of date.</Typography>
+        <Typography variant="body1" sx={{ mt: 2 }}>
+          If you are self-hosting CIPP, please ensure your Function App is running and up to date.
+        </Typography>
+      </>
+    ),
+    actionText: 'Test API Connection',
+    onActionClick: () => {},
+    version: '10.7.5',
+    children: (
+      <Alert severity="error">
+        <Typography variant="body2">
+          No response received from API. Check if your Function App is running.
+        </Typography>
+        <Button variant="outlined" color="primary" sx={{ mt: 1 }}>
+          Refresh Page
+        </Button>
+      </Alert>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('button', { name: 'Test API Connection' })).toBeInTheDocument()
+    await expect(
+      canvas.getByText('No response received from API. Check if your Function App is running.')
+    ).toBeInTheDocument()
+  },
+}
+
+export const ApiOfflineDark = {
+  ...ApiOffline,
+  globals: { theme: 'dark' },
+}

--- a/frontend/tests/components/CippComponents/CippAuthShell.test.jsx
+++ b/frontend/tests/components/CippComponents/CippAuthShell.test.jsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Alert } from '@mui/material'
+import { renderWithTheme } from '../../test-utils'
+import { CippAuthShell } from '../../../src/components/CippComponents/CippAuthShell'
+
+describe('CippAuthShell', () => {
+  it('renders the title and a string description', () => {
+    renderWithTheme(<CippAuthShell title="Sign in to CIPP" description="Session has expired." />)
+
+    expect(screen.getByRole('heading', { name: 'Sign in to CIPP' })).toBeInTheDocument()
+    expect(screen.getByText('Session has expired.')).toBeInTheDocument()
+  })
+
+  it('renders a jsx description, the shape api-offline passes', () => {
+    renderWithTheme(
+      <CippAuthShell
+        title="CIPP API Unreachable"
+        description={
+          <>
+            <p>The CIPP API appears to be offline.</p>
+            <p>Check the Function App.</p>
+          </>
+        }
+      />
+    )
+
+    expect(screen.getByText('The CIPP API appears to be offline.')).toBeInTheDocument()
+    expect(screen.getByText('Check the Function App.')).toBeInTheDocument()
+  })
+
+  it('renders a link when given actionHref', () => {
+    renderWithTheme(
+      <CippAuthShell title="Access Denied" actionText="Login" actionHref="/.auth/login/aad" />
+    )
+
+    expect(screen.getByRole('link', { name: /Login/i })).toHaveAttribute('href', '/.auth/login/aad')
+  })
+
+  it('renders a button that fires onActionClick', async () => {
+    const onActionClick = vi.fn()
+    renderWithTheme(
+      <CippAuthShell
+        title="CIPP API Unreachable"
+        actionText="Test API Connection"
+        onActionClick={onActionClick}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Test API Connection' }))
+    expect(onActionClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders one control when both actionHref and onActionClick are passed', () => {
+    renderWithTheme(
+      <CippAuthShell
+        title="Access Denied"
+        actionText="Login"
+        actionHref="/.auth/login/aad"
+        onActionClick={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link', { name: /Login/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Login/i })).not.toBeInTheDocument()
+  })
+
+  it('renders both actions when a secondary is given', () => {
+    renderWithTheme(
+      <CippAuthShell
+        title="Access Denied"
+        actionText="Sign in with a different account"
+        actionHref="/.auth/login/aad"
+        secondaryText="Return to Home"
+        secondaryHref="/"
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Sign in with a different account' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Return to Home' })).toHaveAttribute('href', '/')
+  })
+
+  it('renders no controls when no action props are given', () => {
+    renderWithTheme(<CippAuthShell title="Logging into CIPP" description="Please wait..." />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  // separate renders rather than rerender: renderWithTheme's rerender would
+  // replace the ThemeProvider wrapper along with the subject
+  it('shows a progress bar only while busy', () => {
+    const { unmount } = renderWithTheme(<CippAuthShell title="Logging into CIPP" busy />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    unmount()
+
+    renderWithTheme(<CippAuthShell title="Logging into CIPP" />)
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+  })
+
+  it('renders children below the card', () => {
+    renderWithTheme(
+      <CippAuthShell title="CIPP API Unreachable">
+        <Alert severity="error">Connection failed.</Alert>
+      </CippAuthShell>
+    )
+
+    expect(screen.getByText('Connection failed.')).toBeInTheDocument()
+  })
+
+  it('renders the version only when one is given', () => {
+    const { unmount } = renderWithTheme(<CippAuthShell title="Access Denied" version="10.7.5" />)
+    expect(screen.getByText('v10.7.5')).toBeInTheDocument()
+    unmount()
+
+    renderWithTheme(<CippAuthShell title="Access Denied" />)
+    expect(screen.queryByText(/^v\d/)).not.toBeInTheDocument()
+  })
+
+  it('renders the brand lockup and tagline, with no link in the panel', () => {
+    renderWithTheme(<CippAuthShell title="Access Denied" />)
+
+    expect(screen.getByRole('img', { name: 'CIPP' })).toHaveAttribute('src', '/logo.png')
+    expect(screen.getByText('CyberDrain Improved Partner Portal')).toBeInTheDocument()
+    // the panel must stay link-free: unauthenticated.js asserts no Login link
+    // survives in the return-to-home case
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/tests/components/PrivateRoute.stories.jsx
+++ b/frontend/tests/components/PrivateRoute.stories.jsx
@@ -36,7 +36,7 @@ export const Unauthenticated = {
     await step('null clientPrincipal blocks the app content', async () => {
       await waitFor(
         () => {
-          expect(canvas.getByText('Access Denied')).toBeInTheDocument()
+          expect(canvas.getByText('Sign in to CIPP')).toBeInTheDocument()
         })
       expect(canvas.queryByText('app content')).not.toBeInTheDocument()
     })

--- a/frontend/tests/components/PrivateRoute.test.jsx
+++ b/frontend/tests/components/PrivateRoute.test.jsx
@@ -63,26 +63,28 @@ const renderRoute = (routeType) => {
 }
 
 describe('PrivateRoute', () => {
-  it('shows unauthenticated page when the session request errors', async () => {
-    // api reachable, session errored, unauthenticated page needs one settled query to render
+  it('shows the sign-in page when the session request errors', async () => {
+    // api reachable, session errored, sign-in page needs one settled query to render
     authState.swa = result({ isError: true, isSuccess: false, error: new Error('boom') })
     authState.me = result({ data: { message: 'Permission Denied' } })
     renderRoute()
 
     await waitFor(() => {
-      expect(screen.getByText('Access Denied')).toBeInTheDocument()
+      expect(screen.getByText('Sign in to CIPP')).toBeInTheDocument()
     })
+    // no identity means nothing was denied
+    expect(screen.queryByText('Access Denied')).not.toBeInTheDocument()
     expect(screen.queryByText('app content')).not.toBeInTheDocument()
   })
 
-  it('shows unauthenticated page when the session has no identity in either shape', async () => {
+  it('shows the sign-in page when the session has no identity in either shape', async () => {
     // settled /.auth/me with neither clientPrincipal nor easyauth array
     authState.swa = result({ data: {} })
     authState.me = result({ isPending: true, isSuccess: false })
     renderRoute()
 
     await waitFor(() => {
-      expect(screen.getByText('Access Denied')).toBeInTheDocument()
+      expect(screen.getByText('Sign in to CIPP')).toBeInTheDocument()
     })
   })
 
@@ -115,7 +117,7 @@ describe('PrivateRoute', () => {
     expect(screen.getByText('CIPP API Unreachable')).toBeInTheDocument()
   })
 
-  it('shows unauthenticated page when only blocked roles remain', async () => {
+  it('shows access denied, naming the account, when only blocked roles remain', async () => {
     authState.swa = result({ data: swaPrincipal() })
     authState.me = result({ data: cippPrincipal(['anonymous', 'authenticated']) })
     renderRoute()
@@ -123,6 +125,9 @@ describe('PrivateRoute', () => {
     await waitFor(() => {
       expect(screen.getByText('Access Denied')).toBeInTheDocument()
     })
+    // a real identity was denied, so say which one
+    expect(screen.getByText('john@contoso.com')).toBeInTheDocument()
+    expect(screen.queryByText('Sign in to CIPP')).not.toBeInTheDocument()
     expect(screen.queryByText('app content')).not.toBeInTheDocument()
   })
 
@@ -163,7 +168,7 @@ describe('PrivateRoute', () => {
     const { rerender } = renderRoute()
 
     await waitFor(() => {
-      expect(screen.getByText('Access Denied')).toBeInTheDocument()
+      expect(screen.getByText('Sign in to CIPP')).toBeInTheDocument()
     })
 
     // refetch in flight must not flip back to the loading page
@@ -180,7 +185,7 @@ describe('PrivateRoute', () => {
       </Provider>
     )
 
-    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+    expect(screen.getByText('Sign in to CIPP')).toBeInTheDocument()
     expect(screen.queryByText('Logging into CIPP')).not.toBeInTheDocument()
   })
 })

--- a/frontend/tests/pages/ApiOfflinePage.test.jsx
+++ b/frontend/tests/pages/ApiOfflinePage.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import axios from 'axios'
+import { renderWithTheme } from '../test-utils'
+import ApiOfflinePage from '../../src/pages/api-offline'
+
+vi.mock('axios', () => ({ default: { get: vi.fn() } }))
+
+vi.mock('../../src/api/ApiCall', () => ({
+  ApiGetCall: () => ({ isSuccess: true, data: { version: '10.7.5' } }),
+}))
+
+describe('ApiOfflinePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the offline state and the connection test action', () => {
+    renderWithTheme(<ApiOfflinePage />)
+
+    expect(screen.getByText('CIPP API Unreachable')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Test API Connection' })).toBeInTheDocument()
+    // no result yet, so nothing is in flight
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+  })
+
+  it('offers a reload when the connection test succeeds', async () => {
+    axios.get.mockResolvedValue({
+      headers: { 'content-type': 'application/json' },
+      data: {},
+    })
+    renderWithTheme(<ApiOfflinePage />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Test API Connection' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Connection successful! Try refreshing the page.')
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Refresh Page' })).toBeInTheDocument()
+  })
+
+  it('reports a no-response failure', async () => {
+    axios.get.mockRejectedValue({ request: {} })
+    renderWithTheme(<ApiOfflinePage />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Test API Connection' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No response received from API. Check if your Function App is running.')
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Refresh Page' })).not.toBeInTheDocument()
+  })
+
+  it('shows exactly one progress indicator while the test is in flight', async () => {
+    let settle
+    axios.get.mockReturnValue(
+      new Promise((resolve) => {
+        settle = () => resolve({ headers: { 'content-type': 'application/json' }, data: {} })
+      })
+    )
+    renderWithTheme(<ApiOfflinePage />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Test API Connection' }))
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('progressbar')).toHaveLength(1)
+    })
+    expect(screen.getByRole('button', { name: 'Testing Connection...' })).toBeDisabled()
+
+    settle()
+    await waitFor(() => {
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+  })
+
+  // hosted subscriptions are handled elsewhere now
+  it('does not point at a GitHub subscription', () => {
+    renderWithTheme(<ApiOfflinePage />)
+
+    expect(screen.queryByText(/subscription in GitHub/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/tests/pages/LoadingPage.test.jsx
+++ b/frontend/tests/pages/LoadingPage.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { act, screen } from '@testing-library/react'
+import { renderWithTheme } from '../test-utils'
+import LoadingPage from '../../src/pages/loading'
+
+vi.mock('../../src/api/ApiCall', () => ({
+  ApiGetCall: () => ({ isSuccess: true, data: { version: '10.7.5' } }),
+}))
+
+describe('LoadingPage', () => {
+  it('renders the waiting state with a progress bar', () => {
+    renderWithTheme(<LoadingPage />)
+
+    expect(screen.getByText('Logging into CIPP')).toBeInTheDocument()
+    expect(screen.getByText('Please wait while we log you in...')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  // regression lock: a 20s timer used to swap in cold-start copy here. CIPP runs
+  // as a container now, so there is no cold start to blame and no timer to fire.
+  it('never mentions a cold start, however long it waits', () => {
+    vi.useFakeTimers()
+    try {
+      renderWithTheme(<LoadingPage />)
+      act(() => {
+        vi.advanceTimersByTime(120000)
+      })
+
+      expect(screen.queryByText(/cold start/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/function app/i)).not.toBeInTheDocument()
+      expect(screen.getByText('Please wait while we log you in...')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/tests/pages/UnauthenticatedPage.stories.jsx
+++ b/frontend/tests/pages/UnauthenticatedPage.stories.jsx
@@ -7,26 +7,22 @@ export default {
   title: 'Pages/Unauthenticated',
   component: UnauthenticatedPage,
   tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
 }
 
+const authHandlers = (me, swa) => [
+  http.get('/api/me', () => HttpResponse.json(me)),
+  http.get('/.auth/me', () => HttpResponse.json(swa)),
+  http.get('*/api/me', () => HttpResponse.json(me)),
+  http.get('*/.auth/me', () => HttpResponse.json(swa)),
+]
+
+// a real identity CIPP won't let through
 export const AccessDenied = {
-  render: () => <UnauthenticatedPage />,
+  render: () => <UnauthenticatedPage reason="permissions" />,
   parameters: {
     msw: {
-      handlers: [
-        http.get('/api/me', () => {
-          return HttpResponse.json({ message: 'Permission Denied' })
-        }),
-        http.get('/.auth/me', () => {
-          return HttpResponse.json({ clientPrincipal: null })
-        }),
-        http.get('*/api/me', () => {
-          return HttpResponse.json({ message: 'Permission Denied' })
-        }),
-        http.get('*/.auth/me', () => {
-          return HttpResponse.json({ clientPrincipal: null })
-        }),
-      ],
+      handlers: authHandlers({ message: 'Permission Denied' }, { clientPrincipal: null }),
     },
   },
   play: async ({ canvasElement, step }) => {
@@ -39,4 +35,57 @@ export const AccessDenied = {
       await expect(canvas.getByRole('link', { name: /Login/i })).toBeInTheDocument()
     })
   },
+}
+
+export const AccessDeniedNamedAccount = {
+  render: () => <UnauthenticatedPage reason="permissions" />,
+  parameters: {
+    msw: {
+      handlers: authHandlers(
+        {
+          clientPrincipal: {
+            userRoles: ['anonymous', 'authenticated', 'admin'],
+          },
+        },
+        { clientPrincipal: { userDetails: 'john@contoso.com' } }
+      ),
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    await step('the denied account is named and switching is offered', async () => {
+      await waitFor(() => {
+        expect(canvas.getByText('john@contoso.com')).toBeInTheDocument()
+      })
+      await expect(
+        canvas.getByRole('link', { name: 'Sign in with a different account' })
+      ).toBeInTheDocument()
+      await expect(canvas.getByRole('link', { name: /Return to Home/i })).toBeInTheDocument()
+    })
+  },
+}
+
+// no identity at all, which is a sign-in prompt rather than a denial
+export const SignIn = {
+  render: () => <UnauthenticatedPage reason="session" />,
+  parameters: {
+    msw: { handlers: authHandlers({}, { clientPrincipal: null }) },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    await step('sign-in page renders without any denial language', async () => {
+      await waitFor(() => {
+        expect(canvas.getByText('Sign in to CIPP')).toBeInTheDocument()
+      })
+      await expect(canvas.queryByText('Access Denied')).not.toBeInTheDocument()
+      await expect(
+        canvas.getByRole('link', { name: /Sign in with Microsoft/i })
+      ).toBeInTheDocument()
+    })
+  },
+}
+
+export const SignInDark = {
+  ...SignIn,
+  globals: { theme: 'dark' },
 }

--- a/frontend/tests/pages/UnauthenticatedPage.test.jsx
+++ b/frontend/tests/pages/UnauthenticatedPage.test.jsx
@@ -15,7 +15,7 @@ vi.mock('../../src/api/ApiCall', () => ({
     if (url === '/api/me') {
       return authState.me
     }
-    // /.auth/me
+    // /.auth/me and /version.json
     return authState.swa
   },
 }))
@@ -41,24 +41,28 @@ const mockStore = configureStore({
   },
 })
 
-const renderPage = () => {
+const renderPage = (reason) => {
   const queryClient = new QueryClient()
   return render(
     <Provider store={mockStore}>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
-          <UnauthenticatedPage />
+          <UnauthenticatedPage reason={reason} />
         </ThemeProvider>
       </QueryClientProvider>
     </Provider>
   )
 }
 
-describe('UnauthenticatedPage', () => {
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('UnauthenticatedPage, permissions', () => {
   it('renders access denied with login link', async () => {
     authState.me = successResult({ message: 'Permission Denied' })
     authState.swa = successResult({ clientPrincipal: null })
-    renderPage()
+    renderPage('permissions')
 
     await waitFor(() => {
       expect(screen.getByText('Access Denied')).toBeInTheDocument()
@@ -79,7 +83,7 @@ describe('UnauthenticatedPage', () => {
     authState.swa = successResult({
       clientPrincipal: { userDetails: 'john@contoso.com' },
     })
-    renderPage()
+    renderPage('permissions')
 
     await waitFor(() => {
       expect(screen.getByText('Access Denied')).toBeInTheDocument()
@@ -87,5 +91,64 @@ describe('UnauthenticatedPage', () => {
     const homeButton = screen.getByRole('link', { name: /Return to Home/i })
     expect(homeButton).toHaveAttribute('href', '/')
     expect(screen.queryByRole('link', { name: /Login/i })).not.toBeInTheDocument()
+  })
+
+  it('names the signed-in account and offers switching once the identity is known', async () => {
+    authState.me = successResult({
+      clientPrincipal: { userRoles: ['anonymous'] },
+    })
+    authState.swa = successResult({
+      clientPrincipal: { userDetails: 'wrong.account@contoso.com' },
+    })
+    renderPage('permissions')
+
+    await waitFor(() => {
+      expect(screen.getByText('wrong.account@contoso.com')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByRole('link', { name: 'Sign in with a different account' })
+    ).toBeInTheDocument()
+    // no usable roles, so there is nowhere to return to
+    expect(screen.queryByRole('link', { name: /Return to Home/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('UnauthenticatedPage, session', () => {
+  it('renders a sign-in screen rather than a denial', async () => {
+    authState.me = successResult({ message: 'Permission Denied' })
+    authState.swa = successResult({ clientPrincipal: null })
+    renderPage('session')
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign in to CIPP')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Access Denied')).not.toBeInTheDocument()
+    // the /api/me denial message belongs to the permissions screen, not this one
+    expect(screen.queryByText('Permission Denied')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Sign in with Microsoft/i })).toHaveAttribute(
+      'href',
+      expect.stringContaining('/.auth/login/aad?prompt=select_account&post_login_redirect_uri=')
+    )
+  })
+
+  it('says the session expired only when one existed on this device', async () => {
+    authState.me = successResult({})
+    authState.swa = successResult({ clientPrincipal: null })
+
+    const first = renderPage('session')
+    await waitFor(() => {
+      expect(
+        screen.getByText('Sign in with your Microsoft account to continue.')
+      ).toBeInTheDocument()
+    })
+    first.unmount()
+
+    window.localStorage.setItem('cipp.hasSession', '1')
+    renderPage('session')
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your session has expired. Sign in again to continue.')
+      ).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
Replaces the three disparate full-page auth layouts (unauthenticated, loading, api-offline) with a single two-panel CippAuthShell component that owns its own viewport.

Key changes:
- Add CippAuthShell: branded left panel (navy, logo, tagline, version) + right card panel with optional progress bar, actions, and children slot
- Split the single UnauthenticatedPage into two distinct states: UNAUTH_SESSION (no identity → sign-in prompt) and UNAUTH_PERMISSIONS (identity denied → access denied with account name and account-switching)
- Add auth-session.js util to remember that a session once existed, so the sign-in screen can say "session expired" vs "first visit"
- Simplify LoadingPage and ApiOfflinePage to delegate layout to CippAuthShell
- Remove cold-start indicator from table toolbar and cold-start copy from loading page
- Add full unit + story coverage for all new/changed components