### PR TITLE
feat(dashboard): add all-tenants dashboard view

### DIFF
--- a/backend/Modules/CIPPCore/Public/Get-CIPPSecureScoreReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPSecureScoreReport.ps1
@@ -1,0 +1,127 @@
+function Get-CIPPSecureScoreReport {
+    <#
+    .SYNOPSIS
+        Generates a Secure Score summary from the CIPP Reporting database
+
+    .DESCRIPTION
+        Returns the latest Secure Score per tenant from the nightly cache, with no live Graph calls.
+
+        Each cached SecureScore record carries the full controlScores breakdown, averageComparativeScores
+        and enabledServices — roughly 15 KB per record, and the cache keeps 14 days per tenant. Reading
+        those in full to report a single percentage costs megabytes across an estate, so this function
+        projects to currentScore / maxScore / createdDateTime at parse time. CippJson skips every other
+        field without materializing it, which is the only real memory lever available here.
+
+        Use -IncludeHistory to also return the retained daily scores as a compact trend. This costs
+        nothing extra: the daily records must be read anyway to find the most recent one, and the
+        projection keeps each point to three fields.
+
+    .PARAMETER TenantFilter
+        The tenant to report on, or 'AllTenants' for every tenant.
+
+    .PARAMETER IncludeHistory
+        Include the retained per-day scores for each tenant as a History array.
+
+    .EXAMPLE
+        Get-CIPPSecureScoreReport -TenantFilter 'AllTenants'
+
+    .EXAMPLE
+        Get-CIPPSecureScoreReport -TenantFilter 'contoso.onmicrosoft.com' -IncludeHistory
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantFilter,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$IncludeHistory
+    )
+
+    try {
+        $IsAllTenants = $TenantFilter -eq 'AllTenants'
+
+        if ($IsAllTenants) {
+            $Rows = Get-CIPPDbItem -TenantFilter 'allTenants' -Type 'SecureScore'
+        } else {
+            $Tenant = (Get-Tenants -TenantFilter $TenantFilter).defaultDomainName
+            if (-not $Tenant) { throw "Tenant '$TenantFilter' not found" }
+            $Rows = Get-CIPPDbItem -TenantFilter $Tenant -Type 'SecureScore'
+        }
+
+        # The type prefix filter also matches the '<Type>-Count' bookkeeping row, which carries no Data.
+        $Rows = @($Rows | Where-Object { $_.RowKey -ne 'SecureScore-Count' })
+        if ($Rows.Count -eq 0) { return @() }
+
+        $TenantLookup = @{}
+        foreach ($KnownTenant in (Get-Tenants -IncludeErrors)) {
+            if ($KnownTenant.defaultDomainName) {
+                $TenantLookup[$KnownTenant.defaultDomainName] = $KnownTenant
+            }
+        }
+
+        # Only these three fields are ever materialized; controlScores and friends are skipped by the parser.
+        $Projection = [string[]]@('currentScore', 'maxScore', 'createdDateTime')
+
+        $ByTenant = @{}
+        foreach ($Row in $Rows) {
+            if ([string]::IsNullOrWhiteSpace($Row.Data)) { continue }
+            try {
+                $Parsed = [CIPP.CippJson]::ConvertFromJson($Row.Data, $Projection)
+            } catch {
+                Write-Information "Skipping unparseable SecureScore row for '$($Row.PartitionKey)': $($_.Exception.Message)"
+                continue
+            }
+
+            foreach ($Record in @($Parsed)) {
+                if ($null -eq $Record) { continue }
+                $Key = $Row.PartitionKey
+                if (-not $ByTenant.ContainsKey($Key)) {
+                    $ByTenant[$Key] = [System.Collections.Generic.List[object]]::new()
+                }
+                [void]$ByTenant[$Key].Add($Record)
+            }
+        }
+
+        $Results = foreach ($Key in $ByTenant.Keys) {
+            $Points = @($ByTenant[$Key] | Sort-Object -Property { [datetime]($_.createdDateTime) } -Descending)
+            $Latest = $Points | Select-Object -First 1
+            if (-not $Latest) { continue }
+
+            $Current = [double]($Latest.currentScore ?? 0)
+            $Max = [double]($Latest.maxScore ?? 0)
+            $TenantInfo = $TenantLookup[$Key]
+
+            $Output = [PSCustomObject]@{
+                Tenant          = $Key
+                TenantId        = $TenantInfo.customerId ?? ''
+                TenantName      = $TenantInfo.displayName ?? $Key
+                CurrentScore    = [math]::Round($Current, 2)
+                MaxScore        = $Max
+                PercentageScore = if ($Max -gt 0) { [math]::Round(($Current / $Max) * 100, 1) } else { 0 }
+                CapturedAt      = $Latest.createdDateTime
+            }
+
+            if ($IncludeHistory) {
+                $Output | Add-Member -NotePropertyName 'History' -NotePropertyValue @(
+                    $Points | Sort-Object -Property { [datetime]($_.createdDateTime) } | ForEach-Object {
+                        $PointMax = [double]($_.maxScore ?? 0)
+                        [PSCustomObject]@{
+                            Date            = $_.createdDateTime
+                            CurrentScore    = [math]::Round([double]($_.currentScore ?? 0), 2)
+                            PercentageScore = if ($PointMax -gt 0) {
+                                [math]::Round(([double]($_.currentScore ?? 0) / $PointMax) * 100, 1)
+                            } else { 0 }
+                        }
+                    }
+                ) -Force
+            }
+
+            $Output
+        }
+
+        return @($Results | Sort-Object -Property PercentageScore)
+    } catch {
+        Write-LogMessage -API 'SecureScoreReport' -tenant $TenantFilter -message "Failed to build secure score report: $($_.Exception.Message)" -sev Error
+        throw
+    }
+}

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Invoke-ListDBCache.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Invoke-ListDBCache.ps1
@@ -1,7 +1,7 @@
 function Invoke-ListDBCache {
     <#
     .FUNCTIONALITY
-        Entrypoint
+        Entrypoint,AnyTenant
     .ROLE
         CIPP.Core.Read
     .DESCRIPTION
@@ -12,6 +12,15 @@ function Invoke-ListDBCache {
         Required query parameters:
           - tenantFilter: The tenant domain or 'AllTenants' to query all managed tenants.
           - type: The cache collection to retrieve (e.g. Users, Groups, Mailboxes, Devices, etc.).
+                  Not required when countsOnly=true.
+
+        Optional query parameters:
+          - countsOnly: When 'true', returns one row per tenant per collection containing only the record
+                        count and the time that collection was last cached. This reads the pre-computed
+                        '<Type>-Count' rows, so it is a single table query regardless of tenant count and
+                        never materializes the underlying records. Combine with tenantFilter=AllTenants to
+                        get an estate-wide inventory and per-tenant cache freshness in one call. Pass a
+                        type alongside it to restrict the result to a single collection.
 
         Use type=_availableTypes to discover which cache collections exist for a given tenant. Omitting the
         type parameter also returns the available types.
@@ -21,6 +30,10 @@ function Invoke-ListDBCache {
         Individual endpoints make live API calls per tenant which is significantly slower and may hit
         throttling limits. ListDBCache reads pre-cached data from Azure Table Storage and returns results
         in seconds regardless of tenant count.
+
+        Note that tenantFilter=AllTenants WITH a type performs a cross-partition scan and materializes every
+        record of that collection across every tenant, so it grows with the size of the estate. Where only
+        totals are needed, countsOnly=true is dramatically cheaper and should always be preferred.
 
         Recommended workflow for MCP tool selection:
           1. Call ListDBCache with type=_availableTypes to discover available cache collections.
@@ -37,10 +50,10 @@ function Invoke-ListDBCache {
         $TriggerMetadata
     )
 
+    $APIName = $TriggerMetadata.FunctionName
     $TenantFilter = $Request.Query.tenantFilter
     $Type = $Request.Query.type
-
-    $Tenant = if ($TenantFilter -ne 'AllTenants') { (Get-Tenants -TenantFilter $TenantFilter).defaultDomainName } else { $TenantFilter }
+    $CountsOnly = $Request.Query.countsOnly -eq 'true'
 
     if (-not $TenantFilter) {
         return ([HttpResponseContext]@{
@@ -49,34 +62,127 @@ function Invoke-ListDBCache {
             })
     }
 
-    if (-not $Type) {
-        $Types = Get-CIPPDbItem -CountsOnly -TenantFilter $Tenant | Select-Object -ExpandProperty RowKey
-        $Types = $Types | ForEach-Object { $_ -replace '-Count$', '' } | Sort-Object
+    try {
+        $IsAllTenants = $TenantFilter -eq 'AllTenants'
 
-        return ([HttpResponseContext]@{
-                StatusCode = [HttpStatusCode]::BadRequest
-                Body       = @{
-                    Results        = 'Error: type query parameter is required'
-                    AvailableTypes = $Types
+        if ($IsAllTenants) {
+            # Get-CIPPDbItem drops the PartitionKey clause for this sentinel, querying every tenant.
+            $Tenant = 'allTenants'
+        } else {
+            $Tenant = (Get-Tenants -TenantFilter $TenantFilter).defaultDomainName
+            if (-not $Tenant) {
+                throw "Tenant '$TenantFilter' not found"
+            }
+        }
+
+        # This endpoint is marked AnyTenant so that tenantFilter=AllTenants is reachable, which means the
+        # framework's per-tenant check in Test-CIPPAccess is skipped for custom-role users. Scoping is
+        # therefore enforced here, for BOTH paths. Test-CIPPAccess returns permitted customerIds (or
+        # 'AllTenants' when unrestricted); CippReportingDB partitions by defaultDomainName, so the ids have
+        # to be translated before they can be matched against rows.
+        $AllowedDomains = $null
+        $AllowedTenants = Test-CIPPAccess -Request $Request -TenantList
+        if ($AllowedTenants -notcontains 'AllTenants') {
+            $AllowedDomains = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($AllowedTenant in (Get-Tenants -IncludeErrors | Where-Object { $_.customerId -in $AllowedTenants })) {
+                if ($AllowedTenant.defaultDomainName) {
+                    [void]$AllowedDomains.Add([string]$AllowedTenant.defaultDomainName)
                 }
-            })
-    }
+            }
 
-    if ($Type -eq '_availableTypes') {
-        $Types = Get-CIPPDbItem -CountsOnly -TenantFilter $Tenant | Select-Object -ExpandProperty RowKey
-        $Types = $Types | ForEach-Object { $_ -replace '-Count$', '' } | Sort-Object
+            # A single-tenant request would otherwise be unguarded now that AnyTenant is set.
+            if (-not $IsAllTenants -and -not $AllowedDomains.Contains([string]$Tenant)) {
+                throw 'Access to this tenant is not allowed'
+            }
+        }
+
+        if ($CountsOnly) {
+            $CountParams = @{ CountsOnly = $true; TenantFilter = $Tenant }
+            if ($Type -and $Type -ne '_availableTypes') { $CountParams.Type = $Type }
+            $Rows = @(Get-CIPPDbItem @CountParams)
+
+            if ($null -ne $AllowedDomains) {
+                $Rows = @($Rows | Where-Object { $AllowedDomains.Contains([string]$_.PartitionKey) })
+            }
+
+            $Results = @($Rows | ForEach-Object {
+                    [PSCustomObject]@{
+                        Tenant      = $_.PartitionKey
+                        Type        = $_.RowKey -replace '-Count$', ''
+                        Count       = $_.DataCount
+                        LastRefresh = $_.Timestamp
+                    }
+                })
+
+            return ([HttpResponseContext]@{
+                    StatusCode = [HttpStatusCode]::OK
+                    Body       = @{ Results = $Results }
+                })
+        }
+
+        if (-not $Type -or $Type -eq '_availableTypes') {
+            $TypeRows = @(Get-CIPPDbItem -CountsOnly -TenantFilter $Tenant)
+            if ($null -ne $AllowedDomains) {
+                $TypeRows = @($TypeRows | Where-Object { $AllowedDomains.Contains([string]$_.PartitionKey) })
+            }
+            $Types = @($TypeRows.RowKey | ForEach-Object { $_ -replace '-Count$', '' } | Sort-Object -Unique)
+
+            if (-not $Type) {
+                return ([HttpResponseContext]@{
+                        StatusCode = [HttpStatusCode]::BadRequest
+                        Body       = @{
+                            Results        = 'Error: type query parameter is required'
+                            AvailableTypes = $Types
+                        }
+                    })
+            }
+
+            return ([HttpResponseContext]@{
+                    StatusCode = [HttpStatusCode]::OK
+                    Body       = @{ Results = $Types }
+                })
+        }
+
+        if ($IsAllTenants) {
+            # New-CIPPDbRequest resolves the tenant through Get-Tenants, which has no 'AllTenants' entry, so
+            # it cannot serve this path. Read the rows directly and parse them the same way it would.
+            $Rows = @(Get-CIPPDbItem -TenantFilter 'allTenants' -Type $Type)
+            if ($null -ne $AllowedDomains) {
+                $Rows = @($Rows | Where-Object { $AllowedDomains.Contains([string]$_.PartitionKey) })
+            }
+
+            $Results = foreach ($Row in $Rows) {
+                if ([string]::IsNullOrWhiteSpace($Row.Data)) { continue }
+                try {
+                    $Parsed = [CIPP.CippJson]::ConvertFromJson($Row.Data, $null)
+                } catch {
+                    Write-Information "Skipping unparseable CippReportingDB row for '$($Row.PartitionKey)'/'$Type': $($_.Exception.Message)"
+                    continue
+                }
+                # A row whose Data is a JSON array unrolls into multiple records; stamp the owning tenant on
+                # each so cross-tenant results stay attributable (CippDataTable renders a Tenant column from it).
+                foreach ($Record in @($Parsed)) {
+                    if ($Record -is [System.Management.Automation.PSObject] -or $Record -is [PSCustomObject]) {
+                        $Record | Add-Member -MemberType NoteProperty -Name 'Tenant' -Value $Row.PartitionKey -Force
+                    }
+                    $Record
+                }
+            }
+            $Results = @($Results)
+        } else {
+            $Results = @(New-CIPPDbRequest -TenantFilter $Tenant -Type $Type)
+        }
+
         return ([HttpResponseContext]@{
                 StatusCode = [HttpStatusCode]::OK
-                Body       = @{ Results = @($Types) }
+                Body       = @{ Results = $Results }
+            })
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -API $APIName -tenant $TenantFilter -message "Failed to list DB cache: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::BadRequest
+                Body       = @{ Results = $ErrorMessage.NormalizedError }
             })
     }
-
-    if ($Tenant) {
-        $Results = New-CIPPDbRequest -TenantFilter $Tenant -Type $Type
-    }
-
-    return ([HttpResponseContext]@{
-            StatusCode = [HttpStatusCode]::OK
-            Body       = @{ Results = $Results }
-        })
 }

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Reports/Invoke-ListSecureScoreReport.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Reports/Invoke-ListSecureScoreReport.ps1
@@ -1,0 +1,51 @@
+function Invoke-ListSecureScoreReport {
+    <#
+    .FUNCTIONALITY
+        Entrypoint,AnyTenant
+    .ROLE
+        Tenant.Reports.Read
+    .DESCRIPTION
+        Returns the latest Microsoft Secure Score per tenant from the CIPP reporting database, with no
+        live Graph calls. Reads the nightly cache and projects to the score fields only, so the large
+        controlScores breakdown on each cached record is never materialized.
+
+        Query parameters:
+          - tenantFilter: A tenant domain, or 'AllTenants' for every tenant the caller can see.
+          - includeHistory: When 'true', each tenant also carries a History array of the retained
+                            daily scores (date / score / percentage) for trend display.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $TriggerMetadata.FunctionName
+    $TenantFilter = $Request.Query.tenantFilter ?? 'AllTenants'
+    $IncludeHistory = $Request.Query.includeHistory -eq 'true'
+
+    try {
+        $Results = @(Get-CIPPSecureScoreReport -TenantFilter $TenantFilter -IncludeHistory:$IncludeHistory)
+
+        # AnyTenant is set so AllTenants is reachable, which means the framework's per-tenant check is
+        # skipped for custom-role users. Scope the output here instead, for both paths.
+        $AllowedTenants = Test-CIPPAccess -Request $Request -TenantList
+        if ($AllowedTenants -notcontains 'AllTenants') {
+            $AllowedSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($Allowed in $AllowedTenants) {
+                if ($Allowed) { [void]$AllowedSet.Add([string]$Allowed) }
+            }
+            $Results = @($Results | Where-Object { $_.TenantId -and $AllowedSet.Contains([string]$_.TenantId) })
+        }
+
+        $StatusCode = [HttpStatusCode]::OK
+        $Body = @{ Results = @($Results) }
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -API $APIName -tenant $TenantFilter -message "Failed to retrieve secure score report: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::BadRequest
+        $Body = @{ Error = $ErrorMessage.NormalizedError }
+    }
+
+    return ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = $Body
+        })
+}

--- a/frontend/src/components/CippAllTenants/AllTenantsDashboard.jsx
+++ b/frontend/src/components/CippAllTenants/AllTenantsDashboard.jsx
@@ -1,0 +1,657 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { Grid } from '@mui/system'
+import Link from 'next/link'
+import { Button } from '@mui/material'
+import {
+  BuildingOffice2Icon,
+  DevicePhoneMobileIcon,
+  EnvelopeIcon,
+  UsersIcon,
+} from '@heroicons/react/24/outline'
+import { getCippError } from '../../utils/get-cipp-error'
+import { CippInfoBar } from '../CippCards/CippInfoBar'
+import { useAllTenantsDashboard } from './useAllTenantsDashboard'
+import {
+  AllTenantsBandHeading,
+  AllTenantsBarList,
+  AllTenantsMeterList,
+  AllTenantsRowList,
+  AllTenantsTrendChart,
+  AllTenantsStatTile,
+  severityColor,
+} from './AllTenantsPrimitives'
+
+/** Card shell that renders its own fetch error inline rather than blanking the section. */
+const DashboardCard = ({ title, subheader, api, children, action }) => {
+  const isError = Array.isArray(api)
+    ? api.some((item) => item?.isError)
+    : api?.isError
+  const error = Array.isArray(api)
+    ? api.find((item) => item?.isError)?.error
+    : api?.error
+
+  return (
+    <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <CardHeader
+        title={title}
+        subheader={subheader}
+        action={action}
+        titleTypographyProps={{ variant: 'h6' }}
+        subheaderTypographyProps={{ variant: 'caption' }}
+      />
+      <Divider />
+      <CardContent sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        {isError ? (
+          <Typography
+            variant="body2"
+            color="error"
+            sx={{ py: 2, textAlign: 'center' }}
+          >
+            {getCippError(error)}
+          </Typography>
+        ) : (
+          children
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export const AllTenantsDashboard = () => {
+  const {
+    tenantCount,
+    tenants,
+    alignmentApi,
+    failedTestsApi,
+    domainsApi,
+    countsApi,
+    logsApi,
+    secureScoreApi,
+    delegation,
+    alignment,
+    tests,
+    mail,
+    cache,
+    logs,
+    secureScore,
+    attention,
+  } = useAllTenantsDashboard()
+
+  // Four items exactly — CippInfoBar lays out md:3 across and its divider rules target the 3rd and
+  // 4th cells. The collections that don't fit hang off the first item's off-canvas.
+  const portfolioBarItems = [
+    {
+      name: 'Tenants',
+      data: tenantCount.toLocaleString(),
+      icon: <BuildingOffice2Icon />,
+      toolTip:
+        'Tenants under management. Select for every cached collection total.',
+      offcanvas: {
+        title: 'Cached collection totals',
+        propertyItems: cache.allTotals.map((item) => ({
+          label: item.type,
+          value: item.value.toLocaleString(),
+        })),
+      },
+    },
+    ...cache.scale.map((item) => ({
+      name: item.label,
+      data: item.value.toLocaleString(),
+      icon:
+        item.label === 'Users' ? (
+          <UsersIcon />
+        ) : item.label === 'Mailboxes' ? (
+          <EnvelopeIcon />
+        ) : (
+          <DevicePhoneMobileIcon />
+        ),
+      toolTip: `${item.average.toLocaleString()} per tenant on average`,
+    })),
+  ]
+
+  const alignmentBuckets = [
+    { label: '90% and above', value: alignment.buckets.strong, severity: 'ok' },
+    { label: '75 – 89%', value: alignment.buckets.good, severity: 'info' },
+    { label: '50 – 74%', value: alignment.buckets.weak, severity: 'warning' },
+    { label: 'Below 50%', value: alignment.buckets.poor, severity: 'critical' },
+  ]
+
+  return (
+    <Stack spacing={5}>
+      {/* ----------------------------------------------------------- portfolio */}
+      <Box>
+        <AllTenantsBandHeading
+          title="Portfolio"
+          description={`Scale across ${tenantCount || 'all'} tenants`}
+        />
+        <CippInfoBar
+          isFetching={countsApi.isLoading || tenants.isLoading}
+          data={portfolioBarItems}
+        />
+        {!countsApi.isLoading && !cache.hasData && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ mt: 1.5, display: 'block' }}
+          >
+            No cached collections were returned. The nightly cache job may not
+            have run yet.
+          </Typography>
+        )}
+      </Box>
+
+      {/* ------------------------------------------------------------ security */}
+      <Box>
+        <AllTenantsBandHeading
+          title="Security posture"
+          description="How the estate is trending"
+        />
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, lg: 5 }}>
+            <DashboardCard
+              title="Secure score"
+              subheader="Portfolio average, from the nightly cache"
+              api={secureScoreApi}
+            >
+              <Stack
+                direction="row"
+                spacing={3}
+                alignItems="baseline"
+                sx={{ mb: 2 }}
+              >
+                <Box>
+                  <Typography
+                    variant="h4"
+                    sx={{ fontVariantNumeric: 'tabular-nums' }}
+                  >
+                    {secureScore.average}%
+                  </Typography>
+                  <Typography variant="caption" color="text.disabled">
+                    across {secureScore.scored} tenants
+                  </Typography>
+                </Box>
+                {secureScore.delta !== null &&
+                  secureScore.delta !== undefined && (
+                    <Box>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{
+                          fontVariantNumeric: 'tabular-nums',
+                          color: severityColor(
+                            secureScore.delta > 0
+                              ? 'ok'
+                              : secureScore.delta < 0
+                                ? 'critical'
+                                : 'neutral'
+                          ),
+                        }}
+                      >
+                        {secureScore.delta > 0
+                          ? '▲'
+                          : secureScore.delta < 0
+                            ? '▼'
+                            : '■'}{' '}
+                        {Math.abs(secureScore.delta)} pts
+                      </Typography>
+                      <Typography variant="caption" color="text.disabled">
+                        over {secureScore.trend.length} days
+                      </Typography>
+                    </Box>
+                  )}
+              </Stack>
+
+              {secureScore.scored > 0 ? (
+                <>
+                  <Box sx={{ mb: 2 }}>
+                    <AllTenantsTrendChart
+                      points={secureScore.trend}
+                      isFetching={secureScoreApi.isLoading}
+                      severity={
+                        secureScore.delta < 0
+                          ? 'critical'
+                          : secureScore.delta > 0
+                            ? 'ok'
+                            : 'info'
+                      }
+                    />
+                  </Box>
+                  <Stack
+                    direction="row"
+                    justifyContent="space-between"
+                    sx={{ mb: 2 }}
+                  >
+                    <Box sx={{ minWidth: 0, pr: 1 }}>
+                      <Typography variant="caption" color="text.disabled">
+                        Best
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        noWrap
+                        title={secureScore.best?.name}
+                      >
+                        {secureScore.best?.name}
+                      </Typography>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{
+                          color: severityColor('ok'),
+                          fontVariantNumeric: 'tabular-nums',
+                        }}
+                      >
+                        {secureScore.best?.percent}%
+                      </Typography>
+                    </Box>
+                    <Box sx={{ minWidth: 0, textAlign: 'right' }}>
+                      <Typography variant="caption" color="text.disabled">
+                        Worst
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        noWrap
+                        title={secureScore.worst?.name}
+                      >
+                        {secureScore.worst?.name}
+                      </Typography>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{
+                          color: severityColor('critical'),
+                          fontVariantNumeric: 'tabular-nums',
+                        }}
+                      >
+                        {secureScore.worst?.percent}%
+                      </Typography>
+                    </Box>
+                  </Stack>
+                </>
+              ) : (
+                !secureScoreApi.isLoading && (
+                  <Typography variant="body2" color="text.secondary">
+                    No cached secure scores yet.
+                  </Typography>
+                )
+              )}
+            </DashboardCard>
+          </Grid>
+
+          <Grid size={{ xs: 12, lg: 4 }}>
+            <DashboardCard
+              title="Identity posture"
+              subheader="Counted in tenants, not users"
+              api={failedTestsApi}
+            >
+              <Stack direction="row" spacing={4} sx={{ mb: 2 }}>
+                <Box>
+                  <Typography
+                    variant="h4"
+                    sx={{
+                      fontVariantNumeric: 'tabular-nums',
+                      color: severityColor('warning'),
+                    }}
+                  >
+                    {tests.identityTenantCount}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    of {tenantCount} tenants failing
+                    <br />
+                    an identity check
+                  </Typography>
+                </Box>
+              </Stack>
+              {tests.identityRows.length > 0 ? (
+                <Stack spacing={0.5}>
+                  <Typography variant="overline" color="text.disabled">
+                    Most widespread
+                  </Typography>
+                  {tests.identityRows.map((row) => (
+                    <Stack
+                      key={row.label}
+                      direction="row"
+                      justifyContent="space-between"
+                      spacing={2}
+                    >
+                      <Typography variant="body2" noWrap title={row.label}>
+                        {row.label}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontVariantNumeric: 'tabular-nums',
+                          fontWeight: 600,
+                        }}
+                      >
+                        {row.tenantCount}
+                      </Typography>
+                    </Stack>
+                  ))}
+                </Stack>
+              ) : (
+                !failedTestsApi.isLoading && (
+                  <Typography variant="body2" color="text.secondary">
+                    No failing identity checks.
+                  </Typography>
+                )
+              )}
+            </DashboardCard>
+          </Grid>
+
+          <Grid size={{ xs: 12, lg: 3 }}>
+            <DashboardCard
+              title="Mail hygiene"
+              subheader={
+                mail.total ? `${mail.total} domains` : 'Domain analyser results'
+              }
+              api={domainsApi}
+            >
+              {mail.meters.length ? (
+                <AllTenantsMeterList
+                  meters={mail.meters}
+                  isFetching={domainsApi.isLoading}
+                />
+              ) : (
+                !domainsApi.isLoading && (
+                  <Typography variant="body2" color="text.secondary">
+                    No analysed domains yet.
+                  </Typography>
+                )
+              )}
+            </DashboardCard>
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <DashboardCard
+              title="Standards alignment"
+              subheader="Tenants bucketed by combined alignment score"
+              api={alignmentApi}
+              action={
+                <Button
+                  component={Link}
+                  href="/tenant/standards/alignment"
+                  size="small"
+                >
+                  View
+                </Button>
+              }
+            >
+              <Stack
+                direction="row"
+                spacing={3}
+                alignItems="center"
+                sx={{ mb: 2 }}
+              >
+                <Box>
+                  <Typography
+                    variant="h4"
+                    sx={{ fontVariantNumeric: 'tabular-nums' }}
+                  >
+                    {alignment.average}%
+                  </Typography>
+                  <Typography variant="caption" color="text.disabled">
+                    portfolio average
+                  </Typography>
+                </Box>
+              </Stack>
+              <AllTenantsBarList
+                isFetching={alignmentApi.isLoading}
+                emptyText="No alignment data yet"
+                max={Math.max(alignment.scores.length, 1)}
+                rows={alignmentBuckets.map((bucket) => ({
+                  label: bucket.label,
+                  total: bucket.value,
+                  segments: [
+                    { value: bucket.value, severity: bucket.severity },
+                  ],
+                }))}
+              />
+              {alignment.lowest.length > 0 && (
+                <Box sx={{ mt: 2 }}>
+                  <Typography variant="overline" color="text.disabled">
+                    Lowest scoring
+                  </Typography>
+                  <Stack spacing={0.5} sx={{ mt: 0.5 }}>
+                    {alignment.lowest.map((item) => (
+                      <Stack
+                        key={item.tenant}
+                        direction="row"
+                        justifyContent="space-between"
+                        spacing={2}
+                      >
+                        <Typography variant="body2" noWrap title={item.name}>
+                          {item.name}
+                        </Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontVariantNumeric: 'tabular-nums',
+                            fontWeight: 600,
+                            color: severityColor(
+                              item.score < 50 ? 'critical' : 'warning'
+                            ),
+                          }}
+                        >
+                          {item.score}%
+                        </Typography>
+                      </Stack>
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+            </DashboardCard>
+          </Grid>
+        </Grid>
+      </Box>
+
+      {/* ---------------------------------------------------------- operations */}
+      <Box>
+        <AllTenantsBandHeading
+          title="Operations & triage"
+          description="What is broken, expiring, or stuck right now"
+        />
+
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+            <AllTenantsStatTile
+              isFetching={logsApi.isLoading}
+              severity={logs.tenantCount ? 'critical' : 'ok'}
+              value={logs.tenantCount}
+              label="Tenants logging errors today"
+              meta={`${logs.total} entries · Error or Critical`}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+            <AllTenantsStatTile
+              isFetching={tenants.isLoading}
+              severity={delegation.expiringSoon ? 'warning' : 'ok'}
+              value={delegation.expiringSoon}
+              label="Delegations expiring within 30 days"
+              meta={`${delegation.noAutoExtendSoon} without auto-extend`}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+            <AllTenantsStatTile
+              isFetching={failedTestsApi.isLoading}
+              severity={tests.high ? 'critical' : 'ok'}
+              value={tests.high}
+              label="High-risk checks failing"
+              meta={`across ${tests.highRiskTenantCount} tenants`}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+            <AllTenantsStatTile
+              isFetching={alignmentApi.isLoading}
+              severity={alignment.pendingDeviations ? 'info' : 'ok'}
+              value={alignment.pendingDeviations}
+              label="Standards deviations awaiting approval"
+              meta={`${alignment.pendingTenantCount} tenants`}
+            />
+          </Grid>
+        </Grid>
+
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, lg: 7 }}>
+            <DashboardCard
+              title="Tenants needing attention"
+              subheader="Delegation state and error activity, worst first"
+              api={[tenants, logsApi]}
+            >
+              <AllTenantsRowList
+                rows={attention.rows}
+                isFetching={tenants.isLoading || logsApi.isLoading}
+                emptyText="Every tenant is responding with delegation active."
+              />
+            </DashboardCard>
+          </Grid>
+
+          <Grid size={{ xs: 12, lg: 5 }}>
+            <DashboardCard
+              title="Delegation expiry horizon"
+              subheader="GDAP and CSP relationships by time remaining"
+              api={tenants}
+            >
+              <AllTenantsBarList
+                isFetching={tenants.isLoading}
+                max={tenantCount || 1}
+                emptyText="No relationship end dates recorded"
+                rows={[
+                  {
+                    label: 'Expired',
+                    total: delegation.buckets.expired,
+                    segments: [
+                      {
+                        value: delegation.buckets.expired,
+                        severity: 'critical',
+                      },
+                    ],
+                  },
+                  {
+                    label: '0 – 7 days',
+                    total: delegation.buckets.week,
+                    segments: [
+                      { value: delegation.buckets.week, severity: 'critical' },
+                    ],
+                  },
+                  {
+                    label: '8 – 30 days',
+                    total: delegation.buckets.month,
+                    segments: [
+                      { value: delegation.buckets.month, severity: 'warning' },
+                    ],
+                  },
+                  {
+                    label: '31 – 90 days',
+                    total: delegation.buckets.quarter,
+                    segments: [
+                      { value: delegation.buckets.quarter, severity: 'info' },
+                    ],
+                  },
+                  {
+                    label: 'Over 90 days',
+                    total: delegation.buckets.healthy,
+                    segments: [
+                      { value: delegation.buckets.healthy, severity: 'ok' },
+                    ],
+                  },
+                ]}
+              />
+              {delegation.noAutoExtendSoon > 0 && (
+                <Box
+                  sx={{
+                    mt: 2,
+                    px: 1.5,
+                    py: 1.25,
+                    borderRadius: 1,
+                    backgroundColor: 'action.hover',
+                    borderLeft: 3,
+                    borderLeftColor: severityColor('critical'),
+                  }}
+                >
+                  <Typography variant="subtitle2" color="error">
+                    {delegation.noAutoExtendSoon} expiring without auto-extend
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {delegation.urgent
+                      .filter((item) => !item.hasAutoExtend)
+                      .slice(0, 3)
+                      .map((item) => item.name)
+                      .join(' · ')}
+                  </Typography>
+                </Box>
+              )}
+            </DashboardCard>
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <DashboardCard
+              title="Cache freshness"
+              subheader="Which tenants quietly failed to sync"
+              api={[countsApi, tenants]}
+            >
+              <Grid container spacing={3}>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <Stack direction="row" spacing={3}>
+                    <Box>
+                      <Typography
+                        variant="h5"
+                        sx={{
+                          fontVariantNumeric: 'tabular-nums',
+                          color: severityColor('ok'),
+                        }}
+                      >
+                        {cache.freshness.fresh}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        fresh
+                      </Typography>
+                    </Box>
+                    <Box>
+                      <Typography
+                        variant="h5"
+                        sx={{
+                          fontVariantNumeric: 'tabular-nums',
+                          color: severityColor('warning'),
+                        }}
+                      >
+                        {cache.freshness.stale}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        stale
+                      </Typography>
+                    </Box>
+                    <Box>
+                      <Typography
+                        variant="h5"
+                        sx={{
+                          fontVariantNumeric: 'tabular-nums',
+                          color: severityColor('critical'),
+                        }}
+                      >
+                        {cache.freshness.missing}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        never cached
+                      </Typography>
+                    </Box>
+                  </Stack>
+                </Grid>
+                <Grid size={{ xs: 12, md: 8 }}>
+                  <AllTenantsRowList
+                    rows={cache.staleTenants}
+                    isFetching={countsApi.isLoading || tenants.isLoading}
+                    emptyText="Every tenant was cached within the last 30 hours."
+                  />
+                </Grid>
+              </Grid>
+            </DashboardCard>
+          </Grid>
+        </Grid>
+      </Box>
+    </Stack>
+  )
+}

--- a/frontend/src/components/CippAllTenants/AllTenantsPrimitives.jsx
+++ b/frontend/src/components/CippAllTenants/AllTenantsPrimitives.jsx
@@ -1,0 +1,442 @@
+import {
+  Box,
+  Card,
+  Chip,
+  LinearProgress,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+// Shared severity vocabulary for the All Tenants dashboard. Kept separate from the primary accent
+// so a card's colour always encodes state, never branding.
+export const SEVERITY_COLORS = {
+  critical: 'error.main',
+  warning: 'warning.main',
+  ok: 'success.main',
+  info: 'info.main',
+  neutral: 'divider',
+}
+
+export const severityColor = (severity) =>
+  SEVERITY_COLORS[severity] ?? SEVERITY_COLORS.neutral
+
+const CHIP_COLOR = {
+  critical: 'error',
+  warning: 'warning',
+  ok: 'success',
+  info: 'info',
+  neutral: 'default',
+}
+
+/**
+ * KPI tile with a severity stripe down the left edge, so the thing needing attention reads at a
+ * glance without parsing the number first.
+ */
+export const AllTenantsStatTile = ({
+  value,
+  label,
+  meta,
+  severity = 'neutral',
+  isFetching,
+}) => (
+  <Card
+    sx={{
+      height: '100%',
+      p: 2,
+      borderLeft: 3,
+      borderLeftColor: severityColor(severity),
+    }}
+  >
+    <Typography
+      variant="h4"
+      sx={{
+        fontVariantNumeric: 'tabular-nums',
+        lineHeight: 1.1,
+        color:
+          severity === 'neutral' ? 'text.primary' : severityColor(severity),
+      }}
+    >
+      {isFetching ? <Skeleton width={64} /> : value}
+    </Typography>
+    <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
+      {isFetching ? <Skeleton width="80%" /> : label}
+    </Typography>
+    {(meta || isFetching) && (
+      <Typography
+        variant="caption"
+        color="text.disabled"
+        sx={{ display: 'block', mt: 0.5 }}
+      >
+        {isFetching ? <Skeleton width="45%" /> : meta}
+      </Typography>
+    )}
+  </Card>
+)
+
+/**
+ * Rows of `label — stacked bar — value`. Segments are drawn proportionally to `max` so bars stay
+ * comparable across rows rather than each normalising to its own total.
+ */
+export const AllTenantsBarList = ({
+  rows = [],
+  max,
+  isFetching,
+  emptyText = 'No data',
+}) => {
+  if (isFetching) {
+    return (
+      <Stack spacing={1.5}>
+        {[0, 1, 2, 3].map((key) => (
+          <Skeleton key={key} variant="rounded" height={22} />
+        ))}
+      </Stack>
+    )
+  }
+
+  if (!rows.length) {
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ py: 2, textAlign: 'center' }}
+      >
+        {emptyText}
+      </Typography>
+    )
+  }
+
+  const scale = max ?? Math.max(...rows.map((row) => row.total ?? 0), 1)
+
+  return (
+    <Stack spacing={1.5}>
+      {rows.map((row) => (
+        <Box
+          key={row.label}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '110px 1fr 52px',
+            gap: 1.25,
+            alignItems: 'center',
+          }}
+        >
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            noWrap
+            title={row.label}
+          >
+            {row.label}
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              height: 8,
+              borderRadius: 5,
+              overflow: 'hidden',
+              backgroundColor: 'action.hover',
+            }}
+          >
+            {(row.segments ?? []).map((segment, index) => (
+              <Tooltip
+                key={index}
+                title={`${segment.label ?? ''} ${segment.value}`.trim()}
+              >
+                <Box
+                  sx={{
+                    width: `${((segment.value ?? 0) / scale) * 100}%`,
+                    backgroundColor: severityColor(segment.severity),
+                  }}
+                />
+              </Tooltip>
+            ))}
+          </Box>
+          <Typography
+            variant="body2"
+            sx={{
+              textAlign: 'right',
+              fontVariantNumeric: 'tabular-nums',
+              fontWeight: 600,
+            }}
+          >
+            {row.total}
+          </Typography>
+        </Box>
+      ))}
+    </Stack>
+  )
+}
+
+/**
+ * Severity-striped rows with an optional status chip. Used wherever a card is a short worklist
+ * rather than a chart.
+ */
+export const AllTenantsRowList = ({
+  rows = [],
+  isFetching,
+  emptyText = 'Nothing to report',
+}) => {
+  if (isFetching) {
+    return (
+      <Stack spacing={0.5}>
+        {[0, 1, 2].map((key) => (
+          <Skeleton key={key} variant="rounded" height={48} />
+        ))}
+      </Stack>
+    )
+  }
+
+  if (!rows.length) {
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ py: 2, textAlign: 'center' }}
+      >
+        {emptyText}
+      </Typography>
+    )
+  }
+
+  return (
+    <Stack spacing={0.5}>
+      {rows.map((row, index) => (
+        <Stack
+          key={row.key ?? `${row.name}-${index}`}
+          direction="row"
+          alignItems="center"
+          spacing={1.5}
+          sx={{
+            px: 1.25,
+            py: 1.25,
+            borderRadius: 1,
+            borderLeft: 3,
+            borderLeftColor: severityColor(row.severity),
+            backgroundColor: 'action.hover',
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography
+              variant="subtitle2"
+              component="div"
+              noWrap
+              title={row.name}
+            >
+              {row.name}
+            </Typography>
+            {row.detail && (
+              // component="div" matters: caption renders as a <span> by default, and noWrap's
+              // overflow/text-overflow do nothing on an inline element — the text would run under
+              // the chip instead of truncating.
+              <Typography
+                variant="caption"
+                component="div"
+                color="text.secondary"
+                noWrap
+                title={row.detail}
+              >
+                {row.detail}
+              </Typography>
+            )}
+          </Box>
+          {row.chipLabel && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color={CHIP_COLOR[row.severity] ?? 'default'}
+              label={row.chipLabel}
+              sx={{ flexShrink: 0 }}
+            />
+          )}
+        </Stack>
+      ))}
+    </Stack>
+  )
+}
+
+/** Labelled percentage meters, for pass-rate style measures. */
+export const AllTenantsMeterList = ({ meters = [], isFetching }) => {
+  if (isFetching) {
+    return (
+      <Stack spacing={2}>
+        {[0, 1, 2, 3].map((key) => (
+          <Skeleton key={key} variant="rounded" height={26} />
+        ))}
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack spacing={2}>
+      {meters.map((meter) => (
+        <Box key={meter.label}>
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="baseline"
+          >
+            <Typography variant="body2" color="text.secondary">
+              {meter.label}
+            </Typography>
+            <Typography
+              variant="subtitle2"
+              sx={{
+                fontVariantNumeric: 'tabular-nums',
+                color: severityColor(meter.severity),
+              }}
+            >
+              {meter.percent}%
+            </Typography>
+          </Stack>
+          <LinearProgress
+            variant="determinate"
+            value={Math.min(100, Math.max(0, meter.percent))}
+            sx={{
+              mt: 0.75,
+              height: 8,
+              borderRadius: 5,
+              backgroundColor: 'action.hover',
+              '& .MuiLinearProgress-bar': {
+                borderRadius: 5,
+                backgroundColor: severityColor(meter.severity),
+              },
+            }}
+          />
+          {meter.caption && (
+            <Typography variant="caption" color="text.disabled">
+              {meter.caption}
+            </Typography>
+          )}
+        </Box>
+      ))}
+    </Stack>
+  )
+}
+
+/**
+ * Compact trend area chart, built on recharts to match the charts on the Worker Health page.
+ *
+ * The Y axis is scaled to the series' own range (padded, never narrower than 10 points) rather than
+ * a full 0-100, so small real movements stay legible instead of flattening into a straight line.
+ */
+export const AllTenantsTrendChart = ({
+  points = [],
+  severity = 'ok',
+  height = 150,
+  unit = '%',
+  isFetching,
+}) => {
+  const theme = useTheme()
+
+  if (isFetching) {
+    return <Skeleton variant="rounded" height={height} />
+  }
+
+  if (points.length < 2) {
+    return (
+      <Box
+        sx={{
+          height,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Typography variant="caption" color="text.disabled">
+          Not enough history yet for a trend
+        </Typography>
+      </Box>
+    )
+  }
+
+  const values = points.map((point) => point.percent)
+  const lo = Math.min(...values)
+  const hi = Math.max(...values)
+  const mid = (lo + hi) / 2
+  const span = Math.max(hi - lo, 10)
+  const min = Math.max(0, Math.floor(mid - span / 2 - span * 0.2))
+  const max = Math.min(100, Math.ceil(mid + span / 2 + span * 0.2))
+
+  const stroke =
+    {
+      critical: theme.palette.error.main,
+      warning: theme.palette.warning.main,
+      ok: theme.palette.success.main,
+      info: theme.palette.info.main,
+    }[severity] ?? theme.palette.primary.main
+
+  return (
+    <Box sx={{ height }}>
+      {/* numeric height, recharts warns before its first measure when both sizes are percentages */}
+      <ResponsiveContainer width="100%" height={height}>
+        <AreaChart
+          data={points}
+          margin={{ left: 0, right: 8, top: 8, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 10 }}
+            tickMargin={6}
+            minTickGap={24}
+          />
+          <YAxis
+            domain={[min, max]}
+            tick={{ fontSize: 10 }}
+            tickMargin={4}
+            width={40}
+            unit={unit}
+          />
+          <RechartsTooltip
+            formatter={(value) => [`${value}${unit}`, 'Average']}
+            contentStyle={{
+              backgroundColor: theme.palette.background.paper,
+              border: `1px solid ${theme.palette.divider}`,
+              borderRadius: 4,
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="percent"
+            name="Average"
+            stroke={stroke}
+            fill={stroke}
+            fillOpacity={0.2}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </Box>
+  )
+}
+
+/** Band heading that separates the dashboard into Portfolio / Security / Operations. */
+export const AllTenantsBandHeading = ({ title, description }) => (
+  <Stack
+    direction="row"
+    alignItems="baseline"
+    spacing={1.5}
+    sx={{
+      pb: 1,
+      mb: 2,
+      borderBottom: 1,
+      borderColor: 'divider',
+      flexWrap: 'wrap',
+    }}
+  >
+    <Typography variant="h6">{title}</Typography>
+    <Typography variant="caption" color="text.disabled">
+      {description}
+    </Typography>
+  </Stack>
+)

--- a/frontend/src/components/CippAllTenants/useAllTenantsDashboard.js
+++ b/frontend/src/components/CippAllTenants/useAllTenantsDashboard.js
@@ -1,0 +1,554 @@
+import { useMemo } from 'react'
+import { ApiGetCall } from '../../api/ApiCall.jsx'
+
+// Some CIPP endpoints return a bare array, others wrap in { Results: [...] }. Normalise both.
+const asArray = (payload) => {
+  if (Array.isArray(payload)) return payload
+  if (Array.isArray(payload?.Results)) return payload.Results
+  return []
+}
+
+const daysUntil = (value) => {
+  if (!value) return null
+  const end = new Date(value)
+  if (Number.isNaN(end.getTime())) return null
+  return Math.floor((end.getTime() - Date.now()) / 86400000)
+}
+
+const hoursSince = (value) => {
+  if (!value) return null
+  const then = new Date(value)
+  if (Number.isNaN(then.getTime())) return null
+  return (Date.now() - then.getTime()) / 3600000
+}
+
+const percent = (part, total) =>
+  total > 0 ? Math.round((part / total) * 100) : 0
+
+// Headline collections for the Portfolio info bar. Three, so that with the tenant count they fill
+// CippInfoBar's four-across grid exactly — its divider rules assume four items. Everything else the
+// cache holds is still reachable through the bar's off-canvas.
+const SCALE_TYPES = [
+  { type: 'Users', label: 'Users' },
+  { type: 'Mailboxes', label: 'Mailboxes' },
+  { type: 'ManagedDevices', label: 'Managed devices' },
+]
+
+/**
+ * Every read the All Tenants dashboard performs, plus the derivations each card needs.
+ *
+ * Deliberately built only from endpoints that a baseline `readonly` user can call, and only from
+ * data that was reduced to a number before the request arrived (test results, alignment scores,
+ * cache count rows). Nothing here hydrates per-user or per-device records across the estate.
+ */
+export const useAllTenantsDashboard = () => {
+  const tenantsApi = ApiGetCall({
+    url: '/api/ListTenants',
+    queryKey: 'AllTenantsDashboard-Tenants',
+  })
+
+  const alignmentApi = ApiGetCall({
+    url: '/api/ListTenantAlignment',
+    queryKey: 'AllTenantsDashboard-Alignment',
+  })
+
+  const failedTestsApi = ApiGetCall({
+    url: '/api/ListTestResultsTenants',
+    data: { status: 'Failed' },
+    queryKey: 'AllTenantsDashboard-FailedTests',
+  })
+
+  const domainsApi = ApiGetCall({
+    url: '/api/ListDomainAnalyser',
+    data: { tenantFilter: 'AllTenants' },
+    queryKey: 'AllTenantsDashboard-Domains',
+  })
+
+  // countsOnly reads the pre-computed '<Type>-Count' rows, so this stays a single table query
+  // regardless of how many tenants exist.
+  const countsApi = ApiGetCall({
+    url: '/api/ListDBCache',
+    data: { tenantFilter: 'AllTenants', countsOnly: 'true' },
+    queryKey: 'AllTenantsDashboard-Counts',
+  })
+
+  // ListLogs defaults to today's partition when no date is supplied, which keeps this cheap.
+  const logsApi = ApiGetCall({
+    url: '/api/ListLogs',
+    data: { Filter: 'True', Severity: 'Error,Critical' },
+    queryKey: 'AllTenantsDashboard-Logs',
+  })
+
+  // Score fields only — the endpoint projects away controlScores, which is ~15 KB per cached record.
+  // includeHistory adds the retained daily scores for the trend line; those rows have to be read to
+  // find the latest anyway, so the only cost is three more numbers per day per tenant.
+  const secureScoreApi = ApiGetCall({
+    url: '/api/ListSecureScoreReport',
+    data: { tenantFilter: 'AllTenants', includeHistory: 'true' },
+    queryKey: 'AllTenantsDashboard-SecureScore',
+  })
+
+  const tenants = useMemo(
+    () =>
+      asArray(tenantsApi.data).filter(
+        (tenant) => tenant?.customerId !== 'AllTenants'
+      ),
+    [tenantsApi.data]
+  )
+
+  const tenantCount = tenants.length
+
+  const displayNameByDomain = useMemo(() => {
+    const map = new Map()
+    tenants.forEach((tenant) => {
+      if (tenant?.defaultDomainName) {
+        map.set(
+          tenant.defaultDomainName,
+          tenant.displayName || tenant.defaultDomainName
+        )
+      }
+    })
+    return map
+  }, [tenants])
+
+  /* ---------------------------------------------------------------- delegation */
+
+  const delegation = useMemo(() => {
+    const buckets = { expired: 0, week: 0, month: 0, quarter: 0, healthy: 0 }
+    const urgent = []
+    let noAutoExtendSoon = 0
+
+    tenants.forEach((tenant) => {
+      const days = daysUntil(tenant?.relationshipEnd)
+      if (days === null) {
+        buckets.healthy += 1
+        return
+      }
+      if (days < 0) buckets.expired += 1
+      else if (days <= 7) buckets.week += 1
+      else if (days <= 30) buckets.month += 1
+      else if (days <= 90) buckets.quarter += 1
+      else buckets.healthy += 1
+
+      if (days <= 30) {
+        if (!tenant?.hasAutoExtend) noAutoExtendSoon += 1
+        urgent.push({
+          name: tenant.displayName || tenant.defaultDomainName,
+          days,
+          hasAutoExtend: !!tenant?.hasAutoExtend,
+        })
+      }
+    })
+
+    urgent.sort((a, b) => a.days - b.days)
+
+    return {
+      buckets,
+      urgent,
+      noAutoExtendSoon,
+      expiringSoon: buckets.expired + buckets.week + buckets.month,
+    }
+  }, [tenants])
+
+  /* ---------------------------------------------------------------- alignment */
+
+  const alignment = useMemo(() => {
+    const rows = asArray(alignmentApi.data)
+    const byTenant = new Map()
+    let pendingDeviations = 0
+    const pendingByTenant = new Map()
+
+    // ListTenantAlignment serialises camelCase on the wire even though the PowerShell object that
+    // builds it is PascalCase. Accept both so this keeps working if that ever normalises.
+    rows.forEach((row) => {
+      const key = row?.tenantFilter ?? row?.TenantFilter
+      if (!key) return
+      const score = Number(
+        row?.combinedAlignmentScore ??
+          row?.CombinedScore ??
+          row?.alignmentScore ??
+          row?.AlignmentScore ??
+          0
+      )
+      const existing = byTenant.get(key) ?? { total: 0, count: 0 }
+      byTenant.set(key, {
+        total: existing.total + score,
+        count: existing.count + 1,
+      })
+
+      const pending = Number(
+        row?.pendingDeviationsCount ?? row?.PendingDeviationsCount ?? 0
+      )
+      if (pending > 0) {
+        pendingDeviations += pending
+        pendingByTenant.set(key, (pendingByTenant.get(key) ?? 0) + pending)
+      }
+    })
+
+    const scores = []
+    byTenant.forEach((value, key) => {
+      scores.push({
+        tenant: key,
+        name: displayNameByDomain.get(key) ?? key,
+        score: value.count ? Math.round(value.total / value.count) : 0,
+      })
+    })
+
+    const buckets = { strong: 0, good: 0, weak: 0, poor: 0 }
+    scores.forEach(({ score }) => {
+      if (score >= 90) buckets.strong += 1
+      else if (score >= 75) buckets.good += 1
+      else if (score >= 50) buckets.weak += 1
+      else buckets.poor += 1
+    })
+
+    const average = scores.length
+      ? Math.round(
+          scores.reduce((sum, item) => sum + item.score, 0) / scores.length
+        )
+      : 0
+
+    return {
+      scores,
+      buckets,
+      average,
+      lowest: [...scores].sort((a, b) => a.score - b.score).slice(0, 4),
+      pendingDeviations,
+      pendingTenantCount: pendingByTenant.size,
+    }
+  }, [alignmentApi.data, displayNameByDomain])
+
+  /* ------------------------------------------------------------- test results */
+
+  const tests = useMemo(() => {
+    const rows = asArray(failedTestsApi.data)
+    const identityChecks = new Map()
+    const highRiskTenants = new Set()
+    let high = 0
+
+    rows.forEach((row) => {
+      if (String(row?.Risk ?? '').toLowerCase() === 'high') {
+        high += 1
+        if (row?.Tenant) highRiskTenants.add(row.Tenant)
+      }
+
+      if (
+        String(row?.TestType ?? '').toLowerCase() === 'identity' &&
+        row?.Name
+      ) {
+        const tenantSet = identityChecks.get(row.Name) ?? new Set()
+        if (row?.Tenant) tenantSet.add(row.Tenant)
+        identityChecks.set(row.Name, tenantSet)
+      }
+    })
+
+    const identityRows = [...identityChecks.entries()]
+      .map(([label, tenantSet]) => ({ label, tenantCount: tenantSet.size }))
+      .sort((a, b) => b.tenantCount - a.tenantCount)
+      .slice(0, 4)
+
+    const identityTenantCount = new Set(
+      rows
+        .filter(
+          (row) =>
+            String(row?.TestType ?? '').toLowerCase() === 'identity' &&
+            row?.Tenant
+        )
+        .map((row) => row.Tenant)
+    ).size
+
+    return {
+      identityRows,
+      identityTenantCount,
+      high,
+      highRiskTenantCount: highRiskTenants.size,
+    }
+  }, [failedTestsApi.data])
+
+  /* ------------------------------------------------------------ mail hygiene */
+
+  const mail = useMemo(() => {
+    const rows = asArray(domainsApi.data)
+    const total = rows.length
+    if (!total) return { total: 0, meters: [] }
+
+    const spf = rows.filter((row) => row?.SPFPassAll).length
+    const dkim = rows.filter((row) => row?.DKIMEnabled).length
+    const dmarc = rows.filter((row) =>
+      ['quarantine', 'reject'].includes(
+        String(row?.DMARCActionPolicy ?? '').toLowerCase()
+      )
+    ).length
+    const dnssec = rows.filter((row) => row?.DNSSECPresent).length
+
+    const meter = (label, value) => {
+      const pct = percent(value, total)
+      return {
+        label,
+        percent: pct,
+        caption: `${value} of ${total} domains`,
+        severity: pct >= 80 ? 'ok' : pct >= 50 ? 'warning' : 'critical',
+      }
+    }
+
+    return {
+      total,
+      meters: [
+        meter('SPF valid', spf),
+        meter('DKIM signing', dkim),
+        meter('DMARC enforced', dmarc),
+        meter('DNSSEC', dnssec),
+      ],
+    }
+  }, [domainsApi.data])
+
+  /* ------------------------------------------------------ scale and freshness */
+
+  const cache = useMemo(() => {
+    const rows = asArray(countsApi.data)
+
+    const totals = new Map()
+    const tenantOldest = new Map()
+
+    rows.forEach((row) => {
+      const type = row?.Type
+      const count = Number(row?.Count ?? 0)
+      if (type) totals.set(type, (totals.get(type) ?? 0) + count)
+
+      const age = hoursSince(row?.LastRefresh)
+      if (row?.Tenant && age !== null) {
+        const current = tenantOldest.get(row.Tenant)
+        if (current === undefined || age > current)
+          tenantOldest.set(row.Tenant, age)
+      }
+    })
+
+    const scale = SCALE_TYPES.map(({ type, label }) => ({
+      label,
+      value: totals.get(type) ?? 0,
+      average: tenantCount
+        ? Math.round((totals.get(type) ?? 0) / tenantCount)
+        : 0,
+    }))
+
+    let fresh = 0
+    let stale = 0
+    let missing = 0
+    const staleTenants = []
+
+    // A tenant the cache has never written has no rows at all, so absence is the signal here —
+    // iterate the tenant list rather than the returned rows.
+    tenants.forEach((tenant) => {
+      const domain = tenant?.defaultDomainName
+      const age = domain ? tenantOldest.get(domain) : undefined
+      const name = tenant?.displayName || domain
+      if (age === undefined) {
+        missing += 1
+        staleTenants.push({
+          name,
+          detail: 'No cached collections found',
+          severity: 'critical',
+        })
+      } else if (age > 72) {
+        stale += 1
+        staleTenants.push({
+          name,
+          detail: `Oldest collection ${Math.round(age / 24)} days old`,
+          severity: 'critical',
+        })
+      } else if (age > 30) {
+        stale += 1
+        staleTenants.push({
+          name,
+          detail: `Oldest collection ${Math.round(age)} hours old`,
+          severity: 'warning',
+        })
+      } else {
+        fresh += 1
+      }
+    })
+
+    // Every cached collection, biggest first — shown in the Portfolio info bar's off-canvas so the
+    // headline four don't have to be the whole story.
+    const allTotals = [...totals.entries()]
+      .filter(([, value]) => value > 0)
+      .sort((a, b) => b[1] - a[1])
+      .map(([type, value]) => ({ type, value }))
+
+    return {
+      scale,
+      allTotals,
+      hasData: rows.length > 0,
+      freshness: { fresh, stale, missing },
+      staleTenants: staleTenants.slice(0, 5),
+    }
+  }, [countsApi.data, tenants, tenantCount])
+
+  /* ------------------------------------------------------------ secure score */
+
+  const secureScore = useMemo(() => {
+    const rows = asArray(secureScoreApi.data)
+    if (!rows.length) return { average: 0, best: null, worst: null, scored: 0 }
+
+    const scored = rows.filter((row) => Number(row?.MaxScore) > 0)
+    if (!scored.length)
+      return { average: 0, best: null, worst: null, scored: 0 }
+
+    const withNames = scored.map((row) => ({
+      tenant: row.Tenant,
+      name: row.TenantName || displayNameByDomain.get(row.Tenant) || row.Tenant,
+      percent: Number(row.PercentageScore ?? 0),
+      current: Number(row.CurrentScore ?? 0),
+      max: Number(row.MaxScore ?? 0),
+    }))
+
+    const sorted = [...withNames].sort((a, b) => a.percent - b.percent)
+
+    // Portfolio trend: average the per-tenant percentage for each captured day. Each day is averaged
+    // only over the tenants that actually reported it, so a tenant that started reporting mid-window
+    // does not drag the earlier points down.
+    const byDate = new Map()
+    scored.forEach((row) => {
+      ;(row.History ?? []).forEach((point) => {
+        const date = String(point?.Date ?? '').slice(0, 10)
+        if (!date) return
+        const entry = byDate.get(date) ?? { total: 0, count: 0 }
+        entry.total += Number(point?.PercentageScore ?? 0)
+        entry.count += 1
+        byDate.set(date, entry)
+      })
+    })
+
+    const trend = [...byDate.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([date, value]) => ({
+        date,
+        percent: value.count
+          ? Math.round((value.total / value.count) * 10) / 10
+          : 0,
+      }))
+
+    const delta =
+      trend.length > 1
+        ? Math.round(
+            (trend[trend.length - 1].percent - trend[0].percent) * 10
+          ) / 10
+        : null
+
+    return {
+      average: Math.round(
+        withNames.reduce((sum, row) => sum + row.percent, 0) / withNames.length
+      ),
+      worst: sorted[0],
+      best: sorted[sorted.length - 1],
+      scored: withNames.length,
+      trend,
+      delta,
+    }
+  }, [secureScoreApi.data, displayNameByDomain])
+
+  /* -------------------------------------------------------------------- logs */
+
+  const logs = useMemo(() => {
+    const rows = asArray(logsApi.data).filter((row) =>
+      ['error', 'critical'].includes(String(row?.Severity ?? '').toLowerCase())
+    )
+
+    const byTenant = new Map()
+    rows.forEach((row) => {
+      const tenant = row?.Tenant
+      if (!tenant || tenant === 'CIPP') return
+      const entry = byTenant.get(tenant) ?? { count: 0, latest: null }
+      entry.count += 1
+      if (!entry.latest) entry.latest = row?.Message
+      byTenant.set(tenant, entry)
+    })
+
+    const offenders = [...byTenant.entries()]
+      .map(([tenant, value]) => ({
+        tenant,
+        name: displayNameByDomain.get(tenant) ?? tenant,
+        count: value.count,
+        latest: value.latest,
+      }))
+      .sort((a, b) => b.count - a.count)
+
+    return { total: rows.length, offenders, tenantCount: byTenant.size }
+  }, [logsApi.data, displayNameByDomain])
+
+  /* --------------------------------------------------- tenants needing attention */
+
+  const attention = useMemo(() => {
+    const rows = []
+
+    tenants.forEach((tenant) => {
+      const name = tenant?.displayName || tenant?.defaultDomainName
+      const status = String(
+        tenant?.delegatedPrivilegeStatus ?? ''
+      ).toLowerCase()
+      if (status && !status.includes('delegatedadminprivileges')) {
+        rows.push({
+          key: `${tenant.customerId}-delegation`,
+          name,
+          detail: `Delegated privilege status: ${tenant.delegatedPrivilegeStatus}`,
+          severity: 'critical',
+          chipLabel: 'Delegation',
+        })
+      } else if (tenant?.RequiresRefresh) {
+        rows.push({
+          key: `${tenant.customerId}-refresh`,
+          name,
+          detail: 'Cached tenant details are stale and need a refresh',
+          severity: 'warning',
+          chipLabel: 'Needs refresh',
+        })
+      }
+    })
+
+    logs.offenders.slice(0, 3).forEach((offender) => {
+      // The count goes in the chip rather than the detail, so the detail line is free to carry the
+      // actual message — repeating "Errors logged" on every row said nothing the stripe didn't.
+      rows.push({
+        key: `${offender.tenant}-errors`,
+        name: offender.name,
+        detail: offender.latest || 'Logged an error today',
+        severity: 'critical',
+        chipLabel: `${offender.count} error${offender.count === 1 ? '' : 's'}`,
+      })
+    })
+
+    const order = { critical: 0, warning: 1, ok: 2 }
+    rows.sort((a, b) => (order[a.severity] ?? 3) - (order[b.severity] ?? 3))
+
+    return { rows: rows.slice(0, 6), total: rows.length }
+  }, [tenants, logs.offenders])
+
+  const isLoading =
+    tenantsApi.isLoading ||
+    alignmentApi.isLoading ||
+    failedTestsApi.isLoading ||
+    domainsApi.isLoading ||
+    countsApi.isLoading ||
+    logsApi.isLoading ||
+    secureScoreApi.isLoading
+
+  return {
+    tenantCount,
+    tenants: tenantsApi,
+    alignmentApi,
+    failedTestsApi,
+    domainsApi,
+    countsApi,
+    logsApi,
+    secureScoreApi,
+    delegation,
+    alignment,
+    tests,
+    mail,
+    cache,
+    logs,
+    secureScore,
+    attention,
+    isLoading,
+  }
+}

--- a/frontend/src/pages/dashboardv2/index.js
+++ b/frontend/src/pages/dashboardv2/index.js
@@ -33,11 +33,16 @@ import { CippReportToolbar } from '../../components/CippComponents/CippReportToo
 import { Assessment as AssessmentIcon } from '@mui/icons-material'
 import ChevronDownIcon from '@heroicons/react/24/outline/ChevronDownIcon'
 import { CippHead } from '../../components/CippComponents/CippHead.jsx'
+import { AllTenantsDashboard } from '../../components/CippAllTenants/AllTenantsDashboard'
 
 const Page = () => {
   const settings = useSettings()
   const router = useRouter()
   const { currentTenant } = settings
+  // The per-tenant cards below are all scoped to a single tenant's Graph data. Under AllTenants —
+  // which is also the state on first login, before a tenant has been picked — swap in the
+  // cross-tenant view rather than letting the layout render "Not supported".
+  const isAllTenants = !currentTenant || currentTenant === 'AllTenants'
   const [portalMenuItems, setPortalMenuItems] = useState([])
   const isWide = useMediaQuery('(min-width:1513px)')
   const [reportsMenuAnchor, setReportsMenuAnchor] = useState(null)
@@ -64,6 +69,7 @@ const Page = () => {
     url: '/api/ListGraphRequest',
     queryKey: `${currentTenant}-ListGraphRequest-organization`,
     data: { tenantFilter: currentTenant, Endpoint: 'organization' },
+    waiting: !isAllTenants,
   })
 
   const organizationRecord = organization.data?.Results?.[0]
@@ -72,7 +78,7 @@ const Page = () => {
     url: '/api/ListTests',
     data: { tenantFilter: currentTenant, reportId: selectedReport },
     queryKey: `${currentTenant}-ListTests-${selectedReport}`,
-    waiting: !!currentTenant && !!selectedReport,
+    waiting: !isAllTenants && !!currentTenant && !!selectedReport,
   })
 
   const currentTenantInfo = ApiGetCall({
@@ -94,20 +100,26 @@ const Page = () => {
             IdentityPassed: testsApi.data.TestCounts?.Identity?.Passed || 0,
             IdentityFailed: testsApi.data.TestCounts?.Identity?.Failed || 0,
             IdentitySkipped: testsApi.data.TestCounts?.Identity?.Skipped || 0,
-            IdentityInformational: testsApi.data.TestCounts?.Identity?.Informational || 0,
-            IdentityNeedsAttention: testsApi.data.TestCounts?.Identity?.NeedsAttention || 0,
+            IdentityInformational:
+              testsApi.data.TestCounts?.Identity?.Informational || 0,
+            IdentityNeedsAttention:
+              testsApi.data.TestCounts?.Identity?.NeedsAttention || 0,
             IdentityTotal: testsApi.data.TestCounts?.Identity?.Total || 0,
             DevicesPassed: testsApi.data.TestCounts?.Devices?.Passed || 0,
             DevicesFailed: testsApi.data.TestCounts?.Devices?.Failed || 0,
             DevicesSkipped: testsApi.data.TestCounts?.Devices?.Skipped || 0,
-            DevicesInformational: testsApi.data.TestCounts?.Devices?.Informational || 0,
-            DevicesNeedsAttention: testsApi.data.TestCounts?.Devices?.NeedsAttention || 0,
+            DevicesInformational:
+              testsApi.data.TestCounts?.Devices?.Informational || 0,
+            DevicesNeedsAttention:
+              testsApi.data.TestCounts?.Devices?.NeedsAttention || 0,
             DevicesTotal: testsApi.data.TestCounts?.Devices?.Total || 0,
             CustomPassed: testsApi.data.TestCounts?.Custom?.Passed || 0,
             CustomFailed: testsApi.data.TestCounts?.Custom?.Failed || 0,
             CustomSkipped: testsApi.data.TestCounts?.Custom?.Skipped || 0,
-            CustomInformational: testsApi.data.TestCounts?.Custom?.Informational || 0,
-            CustomNeedsAttention: testsApi.data.TestCounts?.Custom?.NeedsAttention || 0,
+            CustomInformational:
+              testsApi.data.TestCounts?.Custom?.Informational || 0,
+            CustomNeedsAttention:
+              testsApi.data.TestCounts?.Custom?.NeedsAttention || 0,
             CustomTotal: testsApi.data.TestCounts?.Custom?.Total || 0,
             DataPassed: 0,
             DataTotal: 0,
@@ -118,12 +130,15 @@ const Page = () => {
               UserCount: testsApi.data.TenantCounts.Users || 0,
               GuestCount: testsApi.data.TenantCounts.Guests || 0,
               GroupCount: testsApi.data.TenantCounts.Groups || 0,
-              ApplicationCount: testsApi.data.TenantCounts.ServicePrincipals || 0,
+              ApplicationCount:
+                testsApi.data.TenantCounts.ServicePrincipals || 0,
               DeviceCount: testsApi.data.TenantCounts.Devices || 0,
-              ManagedDeviceCount: testsApi.data.TenantCounts.ManagedDevices || 0,
+              ManagedDeviceCount:
+                testsApi.data.TenantCounts.ManagedDevices || 0,
             },
             MFAState: testsApi.data.MFAState,
-            OverviewCaDevicesAllUsers: dashboardDemoData.TenantInfo.OverviewCaDevicesAllUsers,
+            OverviewCaDevicesAllUsers:
+              dashboardDemoData.TenantInfo.OverviewCaDevicesAllUsers,
             OverviewAuthMethodsPrivilegedUsers:
               dashboardDemoData.TenantInfo.OverviewAuthMethodsPrivilegedUsers,
             DeviceOverview: dashboardDemoData.TenantInfo.DeviceOverview,
@@ -149,7 +164,10 @@ const Page = () => {
 
     let portalLinks
     if (settings.UserSpecificSettings?.portalLinks) {
-      portalLinks = { ...defaultLinks, ...settings.UserSpecificSettings.portalLinks }
+      portalLinks = {
+        ...defaultLinks,
+        ...settings.UserSpecificSettings.portalLinks,
+      }
     } else if (settings.portalLinks) {
       portalLinks = { ...defaultLinks, ...settings.portalLinks }
     } else {
@@ -180,7 +198,10 @@ const Page = () => {
         link:
           portal.field && tenantLookup?.[portal.field]
             ? tenantLookup[portal.field]
-            : portal.url.replace(portal.variable, tenantLookup?.[portal.variable]),
+            : portal.url.replace(
+                portal.variable,
+                tenantLookup?.[portal.variable]
+              ),
         icon: portal.icon,
       }))
       setPortalMenuItems(menuItems)
@@ -198,6 +219,18 @@ const Page = () => {
       return (num / 1000).toFixed(1) + 'K'
     }
     return num.toLocaleString()
+  }
+
+  if (isAllTenants) {
+    // No top margin, matching CippTablePage: the layout's breadcrumb Divider already carries mb: 2.
+    // The per-tenant view below needs mt: 12 only because it sits under the test-suite tab bar,
+    // which AllTenants does not render.
+    return (
+      <Container maxWidth={false} sx={{ mb: 6 }}>
+        <CippHead title="Dashboard" />
+        <AllTenantsDashboard />
+      </Container>
+    )
   }
 
   return (
@@ -228,7 +261,9 @@ const Page = () => {
                 <BulkActionsMenu
                   buttonName="Portals"
                   actions={portalMenuItems}
-                  disabled={!currentTenantInfo.isSuccess || portalMenuItems.length === 0}
+                  disabled={
+                    !currentTenantInfo.isSuccess || portalMenuItems.length === 0
+                  }
                 />
               </Box>
               {isWide ? (
@@ -268,7 +303,10 @@ const Page = () => {
                         transition: 'all 0.2s ease-in-out',
                       }}
                     >
-                      <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      <Box
+                        component="span"
+                        sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+                      >
                         Report Builder
                       </Box>
                     </Button>
@@ -293,7 +331,10 @@ const Page = () => {
                         textOverflow: 'ellipsis',
                       }}
                     >
-                      <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      <Box
+                        component="span"
+                        sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+                      >
                         Dashboard Reports
                       </Box>
                     </Button>
@@ -336,11 +377,17 @@ const Page = () => {
         <Grid container spacing={2} sx={{ mb: 2 }}>
           {/* Column 1: Tenant Information */}
           <Grid size={{ xs: 12, lg: 4 }} data-tutorial="dashboard-tenant-info">
-            <TenantInfoCard data={organizationRecord} isLoading={organization.isFetching} />
+            <TenantInfoCard
+              data={organizationRecord}
+              isLoading={organization.isFetching}
+            />
           </Grid>
 
           {/* Column 2: Tenant Metrics - 2x3 Grid */}
-          <Grid size={{ xs: 12, lg: 4 }} data-tutorial="dashboard-tenant-metrics">
+          <Grid
+            size={{ xs: 12, lg: 4 }}
+            data-tutorial="dashboard-tenant-metrics"
+          >
             <TenantMetricsGrid
               data={reportData.TenantInfo.TenantOverview}
               isLoading={testsApi.isFetching}
@@ -353,7 +400,9 @@ const Page = () => {
               data={reportData}
               isLoading={testsApi.isFetching}
               title={reports.find((r) => r.id === selectedReport)?.name}
-              description={reports.find((r) => r.id === selectedReport)?.description}
+              description={
+                reports.find((r) => r.id === selectedReport)?.description
+              }
             />
           </Grid>
         </Grid>
@@ -368,15 +417,28 @@ const Page = () => {
           <Grid container spacing={2}>
             {/* Left Column */}
             <Grid size={{ xs: 12, lg: 6 }}>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
-                <Box sx={{ height: 450 }} data-tutorial="dashboard-secure-score">
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                  height: '100%',
+                }}
+              >
+                <Box
+                  sx={{ height: 450 }}
+                  data-tutorial="dashboard-secure-score"
+                >
                   <SecureScoreCard
                     data={testsApi.data?.SecureScore}
                     isLoading={testsApi.isFetching}
                     sx={{ height: '100%' }}
                   />
                 </Box>
-                <Box sx={{ height: 450 }} data-tutorial="dashboard-auth-methods">
+                <Box
+                  sx={{ height: 450 }}
+                  data-tutorial="dashboard-auth-methods"
+                >
                   <AuthMethodCard
                     data={testsApi.data?.MFAState}
                     isLoading={testsApi.isFetching}
@@ -388,7 +450,14 @@ const Page = () => {
 
             {/* Right Column */}
             <Grid size={{ xs: 12, lg: 6 }}>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                  height: '100%',
+                }}
+              >
                 <Box sx={{ height: 450 }} data-tutorial="dashboard-mfa">
                   <MFACard
                     data={testsApi.data?.MFAState}
@@ -412,9 +481,22 @@ const Page = () => {
   )
 }
 
+// The Identity / Devices / Custom tabs are all views onto a single tenant's ListTests run, which
+// returns nothing under AllTenants — so the tabs would just lead to empty pages. Drop them there
+// and show the cross-tenant dashboard on its own.
+const DashboardTabs = ({ children }) => {
+  const { currentTenant } = useSettings()
+  if (!currentTenant || currentTenant === 'AllTenants') {
+    return children
+  }
+  return <TabbedLayout tabOptions={tabOptions}>{children}</TabbedLayout>
+}
+
+// No allTenantsSupport={false} here: the page handles AllTenants itself (see isAllTenants above).
+// Leaving the opt-out in place would make the layout render "Not supported" and never mount this page.
 Page.getLayout = (page) => (
-  <DashboardLayout allTenantsSupport={false}>
-    <TabbedLayout tabOptions={tabOptions}>{page}</TabbedLayout>
+  <DashboardLayout>
+    <DashboardTabs>{page}</DashboardTabs>
   </DashboardLayout>
 )
 


### PR DESCRIPTION
Adds a cross-tenant dashboard shown when no specific tenant is selected. Includes:
- Backend: Get-CIPPSecureScoreReport function and Invoke-ListSecureScoreReport endpoint
- Backend: ListDBCache countsOnly mode and AnyTenant access with scoped authz
- Frontend: AllTenantsDashboard with portfolio, security posture, and operations sections
- Frontend: Reusable primitives (stat tiles, bar lists, trend chart, meter list)
- Frontend: useAllTenantsDashboard hook aggregating tenants, alignment, tests, domains, cache counts, logs, and secure scores