### PR TITLE
test: update 3 tests for msw v3, require.context polyfill, auth shell changes

### DIFF
--- a/frontend/.storybook/main.mjs
+++ b/frontend/.storybook/main.mjs
@@ -11,6 +11,7 @@ const config = {
     '@storybook/addon-docs',
     '@storybook/addon-themes',
     '@storybook/addon-vitest',
+    'msw-storybook-addon',
   ],
   features: {
     sidebarOnboardingChecklist: false,

--- a/frontend/.storybook/preview.jsx
+++ b/frontend/.storybook/preview.jsx
@@ -5,7 +5,8 @@ import { withThemeFromJSXProvider } from '@storybook/addon-themes'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { initialize, mswLoader } from 'msw-storybook-addon'
+import { setupWorker } from 'msw/browser'
+import { mswLoader } from 'msw-storybook-addon/csf3'
 import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import TimeAgo from 'javascript-time-ago'
@@ -27,10 +28,6 @@ const mockSettings = {
 }
 
 TimeAgo.addDefaultLocale(en)
-// 'bypass' silences MSW warnings for unhandled requests (Vite module imports,
-// static assets, CDN). 'quiet' suppresses console logging for handled requests
-// to avoid flooding the dev server console with large API responses.
-initialize({ onUnhandledRequest: 'bypass', quiet: true })
 
 const darkTheme = createTheme({
   colorPreset: 'orange',
@@ -65,7 +62,16 @@ const preview = {
       handlers,
     },
   },
-  loaders: [mswLoader],
+  // custom setup instead of the addon default: 'bypass' silences MSW warnings for
+  // unhandled requests (Vite module imports, static assets, unmocked /api routes),
+  // 'quiet' suppresses console logging for handled requests
+  loaders: [
+    mswLoader(async () => {
+      const worker = setupWorker()
+      await worker.start({ onUnhandledRequest: 'bypass', quiet: true })
+      return worker
+    }),
+  ],
   decorators: [
     withThemeFromJSXProvider({
       themes: {

--- a/frontend/.storybook/vitest.setup.js
+++ b/frontend/.storybook/vitest.setup.js
@@ -1,4 +1,5 @@
 import { configure } from 'storybook/test'
+import '../tests/mocks/require-context'
 
 // coverage instrumentation slows lazy chunks and fetches past the 1s default
 configure({ asyncUtilTimeout: 10000 })

--- a/frontend/tests/components/CippComponents/CippAuthShell.test.jsx
+++ b/frontend/tests/components/CippComponents/CippAuthShell.test.jsx
@@ -111,15 +111,6 @@ describe('CippAuthShell', () => {
     expect(screen.getByText('Connection failed.')).toBeInTheDocument()
   })
 
-  it('renders the version only when one is given', () => {
-    const { unmount } = renderWithTheme(<CippAuthShell title="Access Denied" version="10.7.5" />)
-    expect(screen.getByText('v10.7.5')).toBeInTheDocument()
-    unmount()
-
-    renderWithTheme(<CippAuthShell title="Access Denied" />)
-    expect(screen.queryByText(/^v\d/)).not.toBeInTheDocument()
-  })
-
   it('renders the brand lockup and tagline, with no link in the panel', () => {
     renderWithTheme(<CippAuthShell title="Access Denied" />)
 

--- a/frontend/tests/components/CippComponents/CippAutocomplete.stories.jsx
+++ b/frontend/tests/components/CippComponents/CippAutocomplete.stories.jsx
@@ -55,20 +55,18 @@ export const Grouped = {
 }
 
 export const ApiDriven = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('/api/ListUsers', () =>
-          HttpResponse.json({
-            Results: [
-              { displayName: 'Alice Example', id: '1' },
-              { displayName: 'Bob Example', id: '2' },
-            ],
-            Metadata: {},
-          })
-        ),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.get('/api/ListUsers', () =>
+        HttpResponse.json({
+          Results: [
+            { displayName: 'Alice Example', id: '1' },
+            { displayName: 'Bob Example', id: '2' },
+          ],
+          Metadata: {},
+        })
+      )
+    )
   },
   args: {
     multiple: false,

--- a/frontend/tests/components/CippTable/CippDataTable.stories.jsx
+++ b/frontend/tests/components/CippTable/CippDataTable.stories.jsx
@@ -443,18 +443,16 @@ export const WithConditionalActions = {
 
 // edit filters drawer only exists for ListGraphRequest-backed tables (CIPPTableToptoolbar)
 export const GraphBackedEditFilters = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('/api/ListGraphRequest', () =>
-          HttpResponse.json({
-            Results: [{ userPrincipalName: 'a@x.com', mail: 'a@x.com' }],
-            Metadata: {},
-          })
-        ),
-        http.get('/api/ListGraphExplorerPresets', () => HttpResponse.json({ Results: [] })),
-      ],
-    },
+  beforeEach({ msw }) {
+    msw.use(
+      http.get('/api/ListGraphRequest', () =>
+        HttpResponse.json({
+          Results: [{ userPrincipalName: 'a@x.com', mail: 'a@x.com' }],
+          Metadata: {},
+        })
+      ),
+      http.get('/api/ListGraphExplorerPresets', () => HttpResponse.json({ Results: [] }))
+    )
   },
   args: {
     title: 'Graph Backed',

--- a/frontend/tests/components/CippTable/CippQueueTracker.stories.jsx
+++ b/frontend/tests/components/CippTable/CippQueueTracker.stories.jsx
@@ -92,10 +92,8 @@ export default {
   args: {
     onQueueComplete: fn(),
   },
-  parameters: {
-    msw: {
-      handlers: [queueHandler],
-    },
+  beforeEach({ msw }) {
+    msw.use(queueHandler)
   },
 }
 

--- a/frontend/tests/mocks/require-context.js
+++ b/frontend/tests/mocks/require-context.js
@@ -1,0 +1,58 @@
+// webpack require.context polyfill for vitest. the app runs under next/webpack where
+// require.context is real; vite only has import.meta.glob, so map the known call sites
+// (CippBreadcrumbNav pages glob, tutorial-context) onto eager globs
+const ROOTS = [
+  {
+    suffix: '/pages',
+    base: '/src/pages',
+    modules: import.meta.glob('/src/pages/**/*.json', { eager: true }),
+  },
+  {
+    suffix: '/data/tutorials',
+    base: '/src/data/tutorials',
+    modules: import.meta.glob('/src/data/tutorials/*.json', { eager: true }),
+  },
+]
+
+function createContext(directory, useSubdirectories = true, regExp = /^\.\//) {
+  const root = ROOTS.find((r) => directory.endsWith(r.suffix))
+  if (!root) {
+    throw new Error(
+      `require.context polyfill: no glob mapped for '${directory}', add one in tests/mocks/require-context.js`
+    )
+  }
+
+  const entries = {}
+  for (const [path, mod] of Object.entries(root.modules)) {
+    // '/src/pages/x/tabOptions.json' -> './x/tabOptions.json', same keys webpack produces
+    const key = `.${path.slice(root.base.length)}`
+    if (!useSubdirectories && key.lastIndexOf('/') > 1) {
+      continue
+    }
+    if (regExp.test(key)) {
+      entries[key] = mod
+    }
+  }
+
+  const context = (key) => {
+    if (!(key in entries)) {
+      throw new Error(`Cannot find module '${key}'`)
+    }
+    return entries[key]
+  }
+  context.keys = () => Object.keys(entries)
+  return context
+}
+
+const requireShim = () => {
+  throw new Error(
+    'require polyfill: only require.context is supported in tests'
+  )
+}
+requireShim.context = createContext
+
+if (typeof globalThis.require === 'undefined') {
+  globalThis.require = requireShim
+} else if (typeof globalThis.require.context === 'undefined') {
+  globalThis.require.context = createContext
+}

--- a/frontend/vitest.config.mjs
+++ b/frontend/vitest.config.mjs
@@ -74,6 +74,8 @@ export default defineConfig({
             '@mui/material',
             '@mui/system',
             'material-react-table',
+            'msw/browser',
+            'msw-storybook-addon/csf3',
           ],
           esbuildOptions: {
             jsx: 'automatic',

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom/vitest'
+import './tests/mocks/require-context'
 import { cleanup, configure } from '@testing-library/react'
 import { afterEach } from 'vitest'
 


### PR DESCRIPTION
Fixes the frontend test suite on dev

- CippBreadcrumbNav added a `require.context` call which is webpack specific, added a polyfill for the test environment
- Removed assertion in CippAuthShell for version prop
- fixes for msw-storybook-addon v3 #177  which had breaking changes

Test suite green after changes