### PR TITLE
Feat: Add Purview Message Encryption tools and configuration standard

### DIFF
--- a/backend/Config/standards.json
+++ b/backend/Config/standards.json
@@ -7589,6 +7589,28 @@
     ]
   },
   {
+    "name": "standards.MessageEncryption",
+    "cat": "Exchange Standards",
+    "tag": [],
+    "helpText": "Enables Microsoft Purview Message Encryption by turning on Azure RMS licensing for Exchange Online. Skipped with a warning when the tenant still points at an on-premises AD RMS cluster, because AD RMS has to be migrated to Azure RMS first. This standard only turns the feature on: branding, one-time passcodes, and social ID sign-in for encrypted messages are configured in the [Configure Encrypted Message Branding (OME)](https://standards.cipp.app/standards/omebranding) standard. [Read more](https://learn.microsoft.com/en-us/purview/set-up-new-message-encryption-capabilities)",
+    "docsDescription": "Sets AzureRMSLicensingEnabled to true, the only prerequisite for Microsoft Purview Message Encryption. Reports the IRM licensing state per tenant, including the licensing location, so you can see at a glance which tenants have message encryption available. Remediation is deliberately skipped for tenants with an on-premises AD RMS licensing location, as Purview Message Encryption is not compatible with AD RMS and those tenants need to be migrated to Azure RMS first.",
+    "executiveText": "Turns on the built-in encryption that lets staff send protected email to anyone, including recipients outside the organization. Uses licensing the organization already owns, removing the need for a separate secure-email product.",
+    "addedComponent": [],
+    "label": "Enable Purview Message Encryption",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "addedDate": "2026-08-04",
+    "powershellEquivalent": "Set-IRMConfiguration -AzureRMSLicensingEnabled $true",
+    "recommendedBy": [],
+    "requiredCapabilities": [
+      "EXCHANGE_S_STANDARD",
+      "EXCHANGE_S_ENTERPRISE",
+      "EXCHANGE_S_STANDARD_GOV",
+      "EXCHANGE_S_ENTERPRISE_GOV",
+      "EXCHANGE_LITE"
+    ]
+  },
+  {
     "name": "standards.OMEBranding",
     "cat": "Exchange Standards",
     "tag": [],

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Tools/Invoke-ExecIRMConfiguration.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Tools/Invoke-ExecIRMConfiguration.ps1
@@ -1,0 +1,54 @@
+function Invoke-ExecIRMConfiguration {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Mailbox.ReadWrite
+    .DESCRIPTION
+        Enables or disables Microsoft Purview Message Encryption for a tenant by setting AzureRMSLicensingEnabled, or runs Test-IRMConfiguration to verify that encryption and decryption work end to end.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+    $TenantFilter = $Request.Body.tenantFilter
+    $Action = $Request.Body.Action
+
+    try {
+        switch ($Action) {
+            'Test' {
+                $SenderAddress = $Request.Body.Sender
+                $RecipientAddress = $Request.Body.Recipient
+                if (!$SenderAddress -or !$RecipientAddress) {
+                    throw 'A sender and a recipient are required to test the message encryption configuration.'
+                }
+                $TestResult = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Test-IRMConfiguration' -cmdParams @{ Sender = $SenderAddress; Recipient = $RecipientAddress }
+                # Test-IRMConfiguration returns one object per check, the summary lives in the Results property.
+                $Results = @($TestResult.Results | Where-Object { $_ })
+                if (!$Results) { $Results = @($TestResult | Out-String) }
+                Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message "Tested the message encryption configuration for $SenderAddress" -Sev Info
+            }
+            'Set' {
+                $AzureRMSLicensingEnabled = [System.Convert]::ToBoolean($Request.Body.AzureRMSLicensingEnabled)
+                $null = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Set-IRMConfiguration' -cmdParams @{ AzureRMSLicensingEnabled = $AzureRMSLicensingEnabled }
+                $Results = "Successfully $(if ($AzureRMSLicensingEnabled) { 'enabled' } else { 'disabled' }) Microsoft Purview Message Encryption."
+                Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Results -Sev Info
+            }
+            default {
+                throw "Invalid action: $Action"
+            }
+        }
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        $Results = "Failed to run the '$Action' action on the message encryption configuration. Error: $($ErrorMessage.NormalizedError)"
+        Write-LogMessage -Headers $Headers -API $APIName -tenant $TenantFilter -message $Results -Sev Error -LogData $ErrorMessage
+        $StatusCode = [HttpStatusCode]::InternalServerError
+    }
+
+    return ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @{ 'Results' = $Results }
+        })
+}

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Tools/Invoke-ListIRMConfiguration.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Tools/Invoke-ListIRMConfiguration.ps1
@@ -1,0 +1,46 @@
+function Invoke-ListIRMConfiguration {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Exchange.Mailbox.Read
+    .DESCRIPTION
+        Lists the Information Rights Management (IRM) configuration for a tenant. Used to check whether Microsoft Purview Message Encryption is active and whether an on-premises AD RMS deployment still has to be migrated to Azure RMS first.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $TenantFilter = $Request.Query.tenantFilter ?? $Request.Body.tenantFilter
+
+    try {
+        $IRMConfig = New-ExoRequest -tenantid $TenantFilter -cmdlet 'Get-IRMConfiguration' | Select-Object -First 1
+
+        # Purview Message Encryption is not compatible with on-premises AD RMS. A licensing location
+        # that is not an Azure RMS URL means the tenant still points at an AD RMS cluster and has to
+        # be migrated before message encryption can be enabled.
+        # ponytail: URL-shape heuristic, the only signal Get-IRMConfiguration gives us. Get-AipServiceConfiguration would confirm it, but that needs the AIPService module which CIPP does not ship.
+        $LicensingLocation = @($IRMConfig.LicensingLocation | Where-Object { $_ })
+        $AdRmsDetected = @($LicensingLocation | Where-Object { $_ -notmatch 'aadrm\.|azurerms|\.microsoft\.(com|us)' }).Count -gt 0
+
+        $Results = [PSCustomObject]@{
+            AzureRMSLicensingEnabled       = $IRMConfig.AzureRMSLicensingEnabled
+            InternalLicensingEnabled       = $IRMConfig.InternalLicensingEnabled
+            ExternalLicensingEnabled       = $IRMConfig.ExternalLicensingEnabled
+            SimplifiedClientAccessEnabled  = $IRMConfig.SimplifiedClientAccessEnabled
+            TransportDecryptionSetting     = $IRMConfig.TransportDecryptionSetting
+            JournalReportDecryptionEnabled = $IRMConfig.JournalReportDecryptionEnabled
+            LicensingLocation              = $LicensingLocation
+            MessageEncryptionEnabled       = [bool]$IRMConfig.AzureRMSLicensingEnabled
+            AdRmsDetected                  = $AdRmsDetected
+        }
+        $StatusCode = [HttpStatusCode]::OK
+    } catch {
+        $Results = Get-NormalizedError -Message $_.Exception.Message
+        $StatusCode = [HttpStatusCode]::InternalServerError
+    }
+
+    return ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = $Results
+        })
+}

--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMessageEncryption.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardMessageEncryption.ps1
@@ -1,0 +1,110 @@
+function Invoke-CIPPStandardMessageEncryption {
+    <#
+    .FUNCTIONALITY
+        Internal
+    .COMPONENT
+        (APIName) MessageEncryption
+    .SYNOPSIS
+        (Label) Enable Purview Message Encryption
+    .DESCRIPTION
+        (Helptext) Enables Microsoft Purview Message Encryption by turning on Azure RMS licensing for Exchange Online. Skipped with a warning when the tenant still points at an on-premises AD RMS cluster, because AD RMS has to be migrated to Azure RMS first. This standard only turns the feature on: branding, one-time passcodes, and social ID sign-in for encrypted messages are configured in the [Configure Encrypted Message Branding (OME)](https://standards.cipp.app/standards/omebranding) standard. [Read more](https://learn.microsoft.com/en-us/purview/set-up-new-message-encryption-capabilities)
+        (DocsDescription) Sets AzureRMSLicensingEnabled to true, the only prerequisite for Microsoft Purview Message Encryption. Reports the IRM licensing state per tenant, including the licensing location, so you can see at a glance which tenants have message encryption available. Remediation is deliberately skipped for tenants with an on-premises AD RMS licensing location, as Purview Message Encryption is not compatible with AD RMS and those tenants need to be migrated to Azure RMS first.
+    .NOTES
+        CAT
+            Exchange Standards
+        TAG
+        EXECUTIVETEXT
+            Turns on the built-in encryption that lets staff send protected email to anyone, including recipients outside the organization. Uses licensing the organization already owns, removing the need for a separate secure-email product.
+        ADDEDCOMPONENT
+        IMPACT
+            Low Impact
+        ADDEDDATE
+            2026-08-04
+        POWERSHELLEQUIVALENT
+            Set-IRMConfiguration -AzureRMSLicensingEnabled \$true
+        RECOMMENDEDBY
+        REQUIREDCAPABILITIES
+            "EXCHANGE_S_STANDARD"
+            "EXCHANGE_S_ENTERPRISE"
+            "EXCHANGE_S_STANDARD_GOV"
+            "EXCHANGE_S_ENTERPRISE_GOV"
+            "EXCHANGE_LITE"
+        UPDATECOMMENTBLOCK
+            Run the Tools\Update-StandardsComments.ps1 script to update this comment block
+    .LINK
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
+    #>
+
+    param($Tenant, $Settings)
+    $TestResult = Test-CIPPStandardLicense -StandardName 'MessageEncryption' -TenantFilter $Tenant -Preset Exchange
+
+    if ($TestResult -eq $false) {
+        return $true
+    }
+
+    try {
+        $CurrentState = New-ExoRequest -tenantid $Tenant -cmdlet 'Get-IRMConfiguration' | Select-Object -First 1
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the IRM configuration for $Tenant. Error: $($ErrorMessage.NormalizedError)" -Sev Error -LogData $ErrorMessage
+        return
+    }
+
+    # Purview Message Encryption is not compatible with on-premises AD RMS. A licensing location that
+    # is not an Azure RMS URL means the tenant still points at an AD RMS cluster and has to be
+    # migrated before message encryption can be enabled.
+    # ponytail: URL-shape heuristic, the only signal Get-IRMConfiguration gives us. Get-AipServiceConfiguration would confirm it, but that needs the AIPService module which CIPP does not ship.
+    $LicensingLocation = @($CurrentState.LicensingLocation | Where-Object { $_ })
+    $AdRmsDetected = @($LicensingLocation | Where-Object { $_ -notmatch 'aadrm\.|azurerms|\.microsoft\.(com|us)' }).Count -gt 0
+    $StateIsCorrect = $CurrentState.AzureRMSLicensingEnabled -eq $true -and $AdRmsDetected -eq $false
+
+    if ($Settings.remediate -eq $true) {
+        if ($AdRmsDetected) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "An on-premises AD RMS licensing location was found ($($LicensingLocation -join ', ')). Migrate to Azure RMS before enabling Purview Message Encryption. Skipping remediation." -sev Warning
+        } elseif ($StateIsCorrect) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Purview Message Encryption is already enabled.' -sev Info
+        } else {
+            try {
+                $null = New-ExoRequest -tenantid $Tenant -cmdlet 'Set-IRMConfiguration' -cmdParams @{ AzureRMSLicensingEnabled = $true }
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Enabled Purview Message Encryption.' -sev Info
+            } catch {
+                $ErrorMessage = Get-CippException -Exception $_
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to enable Purview Message Encryption. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+            }
+        }
+    }
+
+    if ($Settings.alert -eq $true) {
+        if ($StateIsCorrect) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Purview Message Encryption is enabled.' -sev Info
+        } else {
+            $Message = if ($AdRmsDetected) {
+                'Purview Message Encryption cannot be used, the tenant still uses an on-premises AD RMS licensing location.'
+            } else {
+                'Purview Message Encryption is not enabled.'
+            }
+            $Object = [PSCustomObject]@{
+                AzureRMSLicensingEnabled = $CurrentState.AzureRMSLicensingEnabled
+                LicensingLocation        = $LicensingLocation
+                AdRmsDetected            = $AdRmsDetected
+            }
+            Write-StandardsAlert -message $Message -object $Object -tenant $Tenant -standardName 'MessageEncryption' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message $Message -sev Info
+        }
+    }
+
+    if ($Settings.report -eq $true) {
+        $ReportCurrent = [PSCustomObject]@{
+            AzureRMSLicensingEnabled = $CurrentState.AzureRMSLicensingEnabled
+            LicensingLocation        = $LicensingLocation
+            AdRmsDetected            = $AdRmsDetected
+        }
+        $ReportExpected = [PSCustomObject]@{
+            AzureRMSLicensingEnabled = $true
+            LicensingLocation        = $LicensingLocation
+            AdRmsDetected            = $false
+        }
+        Set-CIPPStandardsCompareField -FieldName 'standards.MessageEncryption' -CurrentValue $ReportCurrent -ExpectedValue $ReportExpected -TenantFilter $Tenant
+        Add-CIPPBPAField -FieldName 'messageEncryptionEnabled' -FieldValue $StateIsCorrect -StoreAs bool -Tenant $Tenant
+    }
+}

--- a/backend/Tests/Endpoint/Invoke-ListIRMConfiguration.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListIRMConfiguration.Tests.ps1
@@ -1,0 +1,168 @@
+# Pester tests for Invoke-ListIRMConfiguration
+#
+# The load-bearing logic here is AdRmsDetected. Purview Message Encryption is not compatible with
+# on-premises AD RMS, and Get-IRMConfiguration's only hint is the shape of LicensingLocation: an
+# Azure RMS URL means cloud, anything else means the tenant still points at an AD RMS cluster and
+# has to be migrated first. A false negative would let CIPP enable message encryption on a tenant
+# where it cannot work.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-ListIRMConfiguration.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Invoke-ListIRMConfiguration.ps1 under Modules/' }
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    # The function uses the short [HttpStatusCode] (the Functions host supplies `using namespace
+    # System.Net`). Register a type accelerator so it resolves when the function is dot-sourced here.
+    $TypeAccelerators = [PowerShell].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+    if (-not ([System.Management.Automation.PSTypeName]'HttpStatusCode').Type) {
+        $TypeAccelerators::Add('HttpStatusCode', [System.Net.HttpStatusCode])
+    }
+
+    function New-ExoRequest { param($tenantid, $cmdlet, $cmdParams) }
+    function Get-NormalizedError { param($Message) $Message }
+
+    . $FunctionPath
+
+    function New-IRMRequest {
+        [pscustomobject]@{
+            Params = @{ CIPPEndpoint = 'ListIRMConfiguration' }
+            Query  = @{ tenantFilter = 'contoso.com' }
+            Body   = $null
+        }
+    }
+
+    function New-IRMConfig {
+        param($LicensingLocation, $AzureRMSLicensingEnabled = $true)
+        [pscustomobject]@{
+            AzureRMSLicensingEnabled       = $AzureRMSLicensingEnabled
+            InternalLicensingEnabled       = $true
+            ExternalLicensingEnabled       = $false
+            SimplifiedClientAccessEnabled  = $false
+            TransportDecryptionSetting     = 'Optional'
+            JournalReportDecryptionEnabled = $true
+            LicensingLocation              = $LicensingLocation
+        }
+    }
+}
+
+Describe 'Invoke-ListIRMConfiguration' {
+    BeforeEach {
+        Mock -CommandName Get-NormalizedError -MockWith { $Message }
+    }
+
+    Context 'AD RMS detection' {
+        It 'does not flag AD RMS for an Azure RMS licensing location' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -LicensingLocation @('https://5c6bb73b-1234.rms.na.aadrm.com/_wmcs/licensing')
+            }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.Body.AdRmsDetected | Should -BeFalse
+            $Response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        }
+
+        It 'does not flag AD RMS when the licensing location is empty' {
+            Mock -CommandName New-ExoRequest -MockWith { New-IRMConfig -LicensingLocation @() }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.Body.AdRmsDetected | Should -BeFalse
+            $Response.Body.LicensingLocation | Should -BeNullOrEmpty
+        }
+
+        It 'does not flag AD RMS when the licensing location is null' {
+            Mock -CommandName New-ExoRequest -MockWith { New-IRMConfig -LicensingLocation $null }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.Body.AdRmsDetected | Should -BeFalse
+        }
+
+        It 'flags AD RMS for an on-premises licensing location' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -LicensingLocation @('https://rms.contoso.local/_wmcs/licensing')
+            }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.Body.AdRmsDetected | Should -BeTrue
+        }
+
+        It 'flags AD RMS when an on-premises location is mixed in with the Azure RMS one' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -LicensingLocation @(
+                    'https://5c6bb73b-1234.rms.na.aadrm.com/_wmcs/licensing'
+                    'https://rms.contoso.local/_wmcs/licensing'
+                )
+            }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.Body.AdRmsDetected | Should -BeTrue
+            $Response.Body.LicensingLocation.Count | Should -Be 2
+        }
+
+        It 'strips empty entries out of the licensing location' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -LicensingLocation @('https://5c6bb73b.rms.na.aadrm.com/_wmcs/licensing', '', $null)
+            }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            # An empty string would not match the Azure RMS pattern and would fake an AD RMS hit.
+            $Response.Body.AdRmsDetected | Should -BeFalse
+            $Response.Body.LicensingLocation.Count | Should -Be 1
+        }
+    }
+
+    Context 'reported state' {
+        It 'reports message encryption as enabled when Azure RMS licensing is on' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -LicensingLocation @() -AzureRMSLicensingEnabled $true
+            }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.Body.MessageEncryptionEnabled | Should -BeTrue
+            $Response.Body.TransportDecryptionSetting | Should -Be 'Optional'
+        }
+
+        It 'reports message encryption as disabled when Azure RMS licensing is off' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -LicensingLocation @() -AzureRMSLicensingEnabled $false
+            }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.Body.MessageEncryptionEnabled | Should -BeFalse
+        }
+
+        It 'queries Get-IRMConfiguration against the requested tenant' {
+            Mock -CommandName New-ExoRequest -MockWith { New-IRMConfig -LicensingLocation @() }
+
+            $null = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Get-IRMConfiguration' -and $tenantid -eq 'contoso.com'
+            }
+        }
+    }
+
+    Context 'failures' {
+        It 'returns an error status when the Exchange request throws' {
+            Mock -CommandName New-ExoRequest -MockWith { throw 'no exchange for you' }
+
+            $Response = Invoke-ListIRMConfiguration -Request (New-IRMRequest)
+
+            $Response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::InternalServerError)
+            $Response.Body | Should -Be 'no exchange for you'
+        }
+    }
+}

--- a/backend/Tests/Standards/Invoke-CIPPStandardMessageEncryption.Tests.ps1
+++ b/backend/Tests/Standards/Invoke-CIPPStandardMessageEncryption.Tests.ps1
@@ -1,0 +1,166 @@
+# Pester tests for Invoke-CIPPStandardMessageEncryption
+#
+# The standard enables Purview Message Encryption by turning on AzureRMSLicensingEnabled. The one
+# case it must NOT act on is a tenant still pointed at an on-premises AD RMS cluster: Purview
+# Message Encryption is incompatible with AD RMS, so remediating there would silently half-configure
+# a tenant that first needs a migration. That skip is what these tests pin down.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    # Resolve by name under Modules/ so the test survives the function moving between modules.
+    $StandardPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-CIPPStandardMessageEncryption.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $StandardPath) { throw 'Could not locate Invoke-CIPPStandardMessageEncryption.ps1 under Modules/' }
+
+    # Stubs mirror the real signatures and are advanced functions on purpose: strict parameter
+    # binding makes signature drift in the standard fail loudly here instead of silently landing in
+    # $args and leaving the captured value $null.
+    function Test-CIPPStandardLicense { [CmdletBinding()] param($StandardName, $TenantFilter, $RequiredCapabilities, $Preset, [switch]$SkipLog) }
+    function New-ExoRequest { [CmdletBinding()] param($tenantid, $cmdlet, $cmdParams) }
+    function Write-LogMessage { [CmdletBinding()] param($API, $tenant, $message, $sev, $LogData) }
+    function Write-StandardsAlert { [CmdletBinding()] param($message, $object, $tenant, $standardName, $standardId) }
+    function Set-CIPPStandardsCompareField { [CmdletBinding()] param($FieldName, $CurrentValue, $ExpectedValue, $TenantFilter) }
+    function Add-CIPPBPAField { [CmdletBinding()] param($FieldName, $FieldValue, $StoreAs, $Tenant) }
+    function Get-CippException { [CmdletBinding()] param($Exception) }
+
+    . $StandardPath
+
+    # Pester v5: anything assigned in a Describe body only exists during Discovery, so these live
+    # here or they are $null by the time an It runs.
+    $tenant = 'contoso.onmicrosoft.com'
+    $AzureRmsLocation = 'https://5c6bb73b-1234.rms.na.aadrm.com/_wmcs/licensing'
+    $AdRmsLocation = 'https://rms.contoso.local/_wmcs/licensing'
+
+    function New-IRMConfig {
+        param($AzureRMSLicensingEnabled = $false, $LicensingLocation = @())
+        [pscustomobject]@{
+            AzureRMSLicensingEnabled = $AzureRMSLicensingEnabled
+            LicensingLocation        = $LicensingLocation
+        }
+    }
+}
+
+Describe 'Invoke-CIPPStandardMessageEncryption' {
+    BeforeEach {
+        Mock -CommandName Test-CIPPStandardLicense -MockWith { $true }
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Write-StandardsAlert -MockWith { }
+        Mock -CommandName Set-CIPPStandardsCompareField -MockWith { }
+        Mock -CommandName Add-CIPPBPAField -MockWith { }
+        Mock -CommandName Get-CippException -MockWith { @{ NormalizedError = 'boom' } }
+    }
+
+    Context 'licensing guard' {
+        It 'bails out when the tenant is not licensed' {
+            Mock -CommandName Test-CIPPStandardLicense -MockWith { $false }
+            Mock -CommandName New-ExoRequest -MockWith { New-IRMConfig }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ remediate = $true }
+
+            Should -Invoke New-ExoRequest -Times 0 -Exactly
+        }
+    }
+
+    Context 'remediation' {
+        It 'enables Azure RMS licensing when message encryption is off' {
+            Mock -CommandName New-ExoRequest -MockWith { New-IRMConfig -AzureRMSLicensingEnabled $false }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ remediate = $true }
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Set-IRMConfiguration' -and $cmdParams.AzureRMSLicensingEnabled -eq $true
+            }
+        }
+
+        It 'does nothing when message encryption is already enabled' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -AzureRMSLicensingEnabled $true -LicensingLocation @($AzureRmsLocation)
+            }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ remediate = $true }
+
+            Should -Invoke New-ExoRequest -Times 0 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Set-IRMConfiguration'
+            }
+        }
+
+        It 'refuses to remediate a tenant that still uses on-premises AD RMS' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -AzureRMSLicensingEnabled $false -LicensingLocation @($AdRmsLocation)
+            }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ remediate = $true }
+
+            Should -Invoke New-ExoRequest -Times 0 -Exactly -ParameterFilter {
+                $cmdlet -eq 'Set-IRMConfiguration'
+            }
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter {
+                $sev -eq 'Warning' -and $message -match 'AD RMS'
+            }
+        }
+
+        It 'does not remediate when the Exchange read fails' {
+            Mock -CommandName New-ExoRequest -MockWith { throw 'no exchange for you' }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ remediate = $true }
+
+            Should -Invoke New-ExoRequest -Times 1 -Exactly
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $Sev -eq 'Error' }
+        }
+    }
+
+    Context 'alerting' {
+        It 'alerts when message encryption is disabled' {
+            Mock -CommandName New-ExoRequest -MockWith { New-IRMConfig -AzureRMSLicensingEnabled $false }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ alert = $true }
+
+            Should -Invoke Write-StandardsAlert -Times 1 -Exactly -ParameterFilter {
+                $message -match 'not enabled'
+            }
+        }
+
+        It 'alerts about the AD RMS blocker even when Azure RMS licensing is on' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -AzureRMSLicensingEnabled $true -LicensingLocation @($AdRmsLocation)
+            }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ alert = $true }
+
+            Should -Invoke Write-StandardsAlert -Times 1 -Exactly -ParameterFilter {
+                $message -match 'AD RMS'
+            }
+        }
+
+        It 'stays quiet when the tenant is correctly configured' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -AzureRMSLicensingEnabled $true -LicensingLocation @($AzureRmsLocation)
+            }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ alert = $true }
+
+            Should -Invoke Write-StandardsAlert -Times 0 -Exactly
+        }
+    }
+
+    Context 'reporting' {
+        It 'reports the current and expected IRM state' {
+            Mock -CommandName New-ExoRequest -MockWith {
+                New-IRMConfig -AzureRMSLicensingEnabled $false -LicensingLocation @($AdRmsLocation)
+            }
+
+            Invoke-CIPPStandardMessageEncryption -Tenant $tenant -Settings @{ report = $true }
+
+            Should -Invoke Set-CIPPStandardsCompareField -Times 1 -Exactly -ParameterFilter {
+                $FieldName -eq 'standards.MessageEncryption' -and
+                $CurrentValue.AzureRMSLicensingEnabled -eq $false -and
+                $CurrentValue.AdRmsDetected -eq $true -and
+                $ExpectedValue.AzureRMSLicensingEnabled -eq $true -and
+                $ExpectedValue.AdRmsDetected -eq $false
+            }
+            Should -Invoke Add-CIPPBPAField -Times 1 -Exactly -ParameterFilter {
+                $FieldName -eq 'messageEncryptionEnabled' -and $FieldValue -eq $false
+            }
+        }
+    }
+}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -373,6 +373,7 @@
     * [Message Trace](user-documentation/tools/email-tools/message-trace.md)
     * [Message Viewer](user-documentation/tools/email-tools/message-viewer.md)
     * [Mailbox Restores](user-documentation/tools/email-tools/mailbox-restores.md)
+    * [Message Encryption](user-documentation/tools/email-tools/message-encryption.md)
   * [Intune Tools](user-documentation/tools/intune-tools/README.md)
     * [Compare Policies](user-documentation/tools/intune-tools/compare-policies.md)
   * [Dark Web Tools](user-documentation/tools/dark-web-tools/README.md)

--- a/docs/user-documentation/tools/email-tools/message-encryption.md
+++ b/docs/user-documentation/tools/email-tools/message-encryption.md
@@ -1,0 +1,39 @@
+# Message Encryption
+
+Microsoft Purview Message Encryption lets users send protected email to any recipient, including Gmail and Outlook.com. This page shows the Information Rights Management (IRM) configuration for the selected tenant, lets you turn message encryption on, and verifies that it actually works.
+
+{% hint style="info" %}
+The only prerequisite for Purview Message Encryption is that Azure Rights Management is active for the tenant. For most eligible plans it is activated automatically. See [Set up Message Encryption](https://learn.microsoft.com/en-us/purview/set-up-new-message-encryption-capabilities).
+{% endhint %}
+
+## Current Configuration
+
+| Field                                | Description                                                                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Purview Message Encryption           | Whether Azure RMS licensing is enabled. This is the switch that makes message encryption available to the tenant.              |
+| Internal Licensing Enabled           | Whether IRM features are enabled for messages sent to internal recipients.                                                     |
+| External Licensing Enabled           | Whether Exchange tries to acquire licenses from clusters other than the one it is configured to use.                           |
+| Protect Button in Outlook on the Web | Whether the Protect button is shown in Outlook on the web. Defaults to disabled.                                               |
+| Transport Decryption                 | Whether transport decryption is Disabled, Optional, or Mandatory.                                                              |
+| Journal Report Decryption            | Whether a decrypted copy of a protected message is attached to the journal report.                                             |
+| Licensing Location                   | The RMS licensing URLs for the tenant. Used to work out whether the tenant is on Azure RMS or still on on-premises AD RMS.     |
+
+## AD RMS migration warning
+
+Purview Message Encryption is **not compatible with Active Directory Rights Management Services (AD RMS)**. When the licensing location points at something other than an Azure RMS URL, the page shows a warning: that tenant is still using an on-premises AD RMS cluster and has to be [migrated to Azure RMS](https://learn.microsoft.com/en-us/azure/information-protection/migrate-from-ad-rms-to-azure-rms) before message encryption can be used.
+
+The warning does not block the toggle, so you can still act on a tenant you know has already been migrated. The `Enable Purview Message Encryption` standard is stricter: it skips remediation entirely for these tenants and logs a warning instead, because it runs unattended.
+
+## Actions
+
+<table><thead><tr><th>Action</th><th>Details</th></tr></thead><tbody><tr><td>Enable Purview Message Encryption</td><td>Toggles Azure RMS licensing for the tenant, then Submit applies it. This is the only setting this page writes.</td></tr><tr><td>Run Test</td><td>Runs a test against the tenant that acquires the RMS templates and verifies that encryption and decryption both work. Enter any mailbox in the tenant as both the sender and the recipient. The button stays disabled until both addresses are filled in.</td></tr></tbody></table>
+
+## Rolling this out across tenants
+
+This page configures one tenant at a time. To deploy message encryption to many tenants and keep it that way, use the **Enable Purview Message Encryption** standard under Exchange Standards. In report mode it records the licensing state per tenant, including whether AD RMS was detected, which gives you the same pre-check across the whole estate without changing anything.
+
+Encrypted message branding, one-time passcodes, and social ID sign-in are configured separately, through the **Configure Encrypted Message Branding (OME)** standard.
+
+***
+
+{% include "../../../../.gitbook/includes/feature-request.md" %}

--- a/frontend/src/data/standards.json
+++ b/frontend/src/data/standards.json
@@ -7589,6 +7589,28 @@
     ]
   },
   {
+    "name": "standards.MessageEncryption",
+    "cat": "Exchange Standards",
+    "tag": [],
+    "helpText": "Enables Microsoft Purview Message Encryption by turning on Azure RMS licensing for Exchange Online. Skipped with a warning when the tenant still points at an on-premises AD RMS cluster, because AD RMS has to be migrated to Azure RMS first. This standard only turns the feature on: branding, one-time passcodes, and social ID sign-in for encrypted messages are configured in the [Configure Encrypted Message Branding (OME)](https://standards.cipp.app/standards/omebranding) standard. [Read more](https://learn.microsoft.com/en-us/purview/set-up-new-message-encryption-capabilities)",
+    "docsDescription": "Sets AzureRMSLicensingEnabled to true, the only prerequisite for Microsoft Purview Message Encryption. Reports the IRM licensing state per tenant, including the licensing location, so you can see at a glance which tenants have message encryption available. Remediation is deliberately skipped for tenants with an on-premises AD RMS licensing location, as Purview Message Encryption is not compatible with AD RMS and those tenants need to be migrated to Azure RMS first.",
+    "executiveText": "Turns on the built-in encryption that lets staff send protected email to anyone, including recipients outside the organization. Uses licensing the organization already owns, removing the need for a separate secure-email product.",
+    "addedComponent": [],
+    "label": "Enable Purview Message Encryption",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "addedDate": "2026-08-04",
+    "powershellEquivalent": "Set-IRMConfiguration -AzureRMSLicensingEnabled $true",
+    "recommendedBy": [],
+    "requiredCapabilities": [
+      "EXCHANGE_S_STANDARD",
+      "EXCHANGE_S_ENTERPRISE",
+      "EXCHANGE_S_STANDARD_GOV",
+      "EXCHANGE_S_ENTERPRISE_GOV",
+      "EXCHANGE_LITE"
+    ]
+  },
+  {
     "name": "standards.OMEBranding",
     "cat": "Exchange Standards",
     "tag": [],

--- a/frontend/src/layouts/config.js
+++ b/frontend/src/layouts/config.js
@@ -1076,6 +1076,11 @@ export const nativeMenuItems = [
             path: '/email/tools/mailbox-restores',
             permissions: ['Exchange.Mailbox.*'],
           },
+          {
+            title: 'Message Encryption',
+            path: '/email/tools/message-encryption',
+            permissions: ['Exchange.Mailbox.*'],
+          },
         ],
       },
       {

--- a/frontend/src/pages/email/tools/message-encryption/index.js
+++ b/frontend/src/pages/email/tools/message-encryption/index.js
@@ -1,0 +1,226 @@
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { Alert, Button, Link, Typography } from '@mui/material'
+import { Grid } from '@mui/system'
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import CippFormPage from '../../../../components/CippFormPages/CippFormPage'
+import CippFormComponent from '../../../../components/CippComponents/CippFormComponent'
+import { CippPropertyListCard } from '../../../../components/CippCards/CippPropertyListCard'
+import { CippApiResults } from '../../../../components/CippComponents/CippApiResults'
+import { ApiGetCall, ApiPostCall } from '../../../../api/ApiCall'
+import { useSettings } from '../../../../hooks/use-settings.js'
+
+const yesNo = (value) => (value ? 'Yes' : 'No')
+
+const Page = () => {
+  const tenant = useSettings().currentTenant
+  const queryKey = `IRMConfiguration-${tenant}`
+
+  const formControl = useForm({ mode: 'onChange' })
+
+  const irmRequest = ApiGetCall({
+    url: '/api/ListIRMConfiguration',
+    data: { tenantFilter: tenant },
+    queryKey: queryKey,
+  })
+
+  const irm = irmRequest.data
+
+  const testCall = ApiPostCall({ datafromUrl: true })
+
+  useEffect(() => {
+    // Blank everything the moment the tenant changes, before the new GET lands. Otherwise a
+    // switch toggled for tenant A stays dirty and Submit stays enabled, which would write A's
+    // pending value against B's tenantFilter, and A's test output would read as B's.
+    formControl.reset({
+      AzureRMSLicensingEnabled: false,
+      Sender: '',
+      Recipient: '',
+    })
+    testCall.reset()
+  }, [tenant])
+
+  useEffect(() => {
+    if (irmRequest.isSuccess) {
+      // Spread the current values so a refetch does not wipe a half-typed test address.
+      formControl.reset({
+        ...formControl.getValues(),
+        AzureRMSLicensingEnabled: !!irm?.AzureRMSLicensingEnabled,
+      })
+    }
+  }, [irmRequest.isSuccess, irm])
+
+  const [testSender, testRecipient] = formControl.watch(['Sender', 'Recipient'])
+
+  const runTest = () => {
+    testCall.mutate({
+      url: '/api/ExecIRMConfiguration',
+      data: {
+        tenantFilter: tenant,
+        Action: 'Test',
+        Sender: testSender?.value ?? testSender,
+        Recipient: testRecipient?.value ?? testRecipient,
+      },
+    })
+  }
+
+  const propertyItems = [
+    {
+      label: 'Purview Message Encryption',
+      value: irm?.AzureRMSLicensingEnabled ? 'Enabled' : 'Disabled',
+    },
+    {
+      label: 'Internal Licensing Enabled',
+      value: yesNo(irm?.InternalLicensingEnabled),
+    },
+    {
+      label: 'External Licensing Enabled',
+      value: yesNo(irm?.ExternalLicensingEnabled),
+    },
+    {
+      label: 'Protect Button in Outlook on the Web',
+      value: yesNo(irm?.SimplifiedClientAccessEnabled),
+    },
+    {
+      label: 'Transport Decryption',
+      value: irm?.TransportDecryptionSetting ?? 'Unknown',
+    },
+    {
+      label: 'Journal Report Decryption',
+      value: yesNo(irm?.JournalReportDecryptionEnabled),
+    },
+    {
+      label: 'Licensing Location',
+      value: irm?.LicensingLocation?.length
+        ? irm.LicensingLocation.join(', ')
+        : 'None',
+    },
+  ]
+
+  return (
+    <CippFormPage
+      title="Message Encryption"
+      hidePageType={true}
+      hideBackButton={true}
+      formControl={formControl}
+      resetForm={false}
+      postUrl="/api/ExecIRMConfiguration"
+      queryKey={queryKey}
+      customDataformatter={(values) => ({
+        tenantFilter: tenant,
+        Action: 'Set',
+        AzureRMSLicensingEnabled: !!values?.AzureRMSLicensingEnabled,
+      })}
+      addedButtons={
+        <Button
+          variant="outlined"
+          disabled={!testSender || !testRecipient || testCall.isPending}
+          onClick={runTest}
+        >
+          Run Test
+        </Button>
+      }
+    >
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12 }}>
+          <Typography variant="body2" color="text.secondary">
+            Microsoft Purview Message Encryption lets users send protected email
+            to any recipient, including Gmail and Outlook.com. The only
+            prerequisite is that Azure Rights Management is active for the
+            tenant.
+          </Typography>
+        </Grid>
+        {irmRequest.isError && (
+          <Grid size={{ xs: 12 }}>
+            <Alert severity="error">
+              Failed to load the IRM configuration for this tenant.
+            </Alert>
+          </Grid>
+        )}
+        {irm?.AdRmsDetected && (
+          <Grid size={{ xs: 12 }}>
+            <Alert severity="warning">
+              This tenant has an on-premises AD RMS licensing location ({' '}
+              {irm.LicensingLocation.join(', ')} ). Purview Message Encryption
+              is not compatible with AD RMS, so the tenant has to be{' '}
+              <Link
+                href="https://learn.microsoft.com/en-us/azure/information-protection/migrate-from-ad-rms-to-azure-rms"
+                target="_blank"
+                rel="noreferrer"
+              >
+                migrated to Azure RMS
+              </Link>{' '}
+              before enabling it.
+            </Alert>
+          </Grid>
+        )}
+        {(irm || irmRequest.isFetching) && (
+          <Grid size={{ xs: 12 }}>
+            <CippPropertyListCard
+              title="Current Configuration"
+              propertyItems={propertyItems}
+              isFetching={irmRequest.isFetching}
+              layout="two"
+              showDivider={false}
+            />
+          </Grid>
+        )}
+        <Grid size={{ xs: 12 }}>
+          <CippFormComponent
+            type="switch"
+            name="AzureRMSLicensingEnabled"
+            label="Enable Purview Message Encryption (Azure RMS licensing)"
+            formControl={formControl}
+          />
+        </Grid>
+        <Grid size={{ xs: 12 }}>
+          <Typography variant="subtitle2">Test the configuration</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Runs Test-IRMConfiguration, which verifies that RMS templates can be
+            acquired and that encryption and decryption both work. Use any
+            mailbox in the tenant for both addresses.
+          </Typography>
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <CippFormComponent
+            type="autoComplete"
+            name="Sender"
+            label="Sender"
+            formControl={formControl}
+            multiple={false}
+            creatable={false}
+            api={{
+              url: '/api/ListMailboxes',
+              queryKey: 'MessageEncryption-Mailboxes',
+              labelField: (option) => `${option.displayName} (${option.UPN})`,
+              valueField: 'UPN',
+            }}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <CippFormComponent
+            type="autoComplete"
+            name="Recipient"
+            label="Recipient"
+            formControl={formControl}
+            multiple={false}
+            creatable={false}
+            api={{
+              url: '/api/ListMailboxes',
+              queryKey: 'MessageEncryption-Mailboxes',
+              labelField: (option) => `${option.displayName} (${option.UPN})`,
+              valueField: 'UPN',
+            }}
+          />
+        </Grid>
+        <Grid size={{ xs: 12 }}>
+          <CippApiResults apiObject={testCall} />
+        </Grid>
+      </Grid>
+    </CippFormPage>
+  )
+}
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
+
+export default Page

--- a/frontend/tests/pages/MessageEncryptionPage.test.jsx
+++ b/frontend/tests/pages/MessageEncryptionPage.test.jsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '../test-utils'
+import Page from '../../src/pages/email/tools/message-encryption/index.js'
+
+vi.mock('../../src/api/ApiCall', async () =>
+  (await import('../mocks/api-call')).apiCallMock()
+)
+import { api, getResult, paginatedResult, postResult } from '../mocks/api-call'
+
+const AZURE_RMS = 'https://5c6bb73b-1234.rms.na.aadrm.com/_wmcs/licensing'
+const AD_RMS = 'https://rms.contoso.local/_wmcs/licensing'
+
+// stable identity per the mock's own warning: a fresh literal per call spins the
+// effects that key off the data object
+const irmConfig = (overrides = {}) => ({
+  AzureRMSLicensingEnabled: true,
+  InternalLicensingEnabled: true,
+  ExternalLicensingEnabled: false,
+  SimplifiedClientAccessEnabled: false,
+  TransportDecryptionSetting: 'Optional',
+  JournalReportDecryptionEnabled: true,
+  LicensingLocation: [AZURE_RMS],
+  MessageEncryptionEnabled: true,
+  AdRmsDetected: false,
+  ...overrides,
+})
+
+describe('Message Encryption page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    api.post = postResult()
+    api.paginated = paginatedResult([
+      { displayName: 'Admin', UPN: 'admin@contoso.com' },
+      { displayName: 'Helpdesk', UPN: 'helpdesk@contoso.com' },
+    ])
+  })
+
+  it('renders the current IRM state for the tenant', async () => {
+    api.get = getResult({ data: irmConfig() })
+    renderWithProviders(<Page />)
+
+    expect(await screen.findByText('Current Configuration')).toBeInTheDocument()
+    expect(screen.getByText('Enabled')).toBeInTheDocument()
+    expect(screen.getByText(AZURE_RMS)).toBeInTheDocument()
+  })
+
+  it('hides the migration warning for a cloud-only tenant', async () => {
+    api.get = getResult({ data: irmConfig() })
+    renderWithProviders(<Page />)
+
+    await screen.findByText('Current Configuration')
+    expect(screen.queryByText(/not compatible with/i)).not.toBeInTheDocument()
+  })
+
+  it('warns that AD RMS has to be migrated before message encryption can be used', async () => {
+    api.get = getResult({
+      data: irmConfig({
+        AzureRMSLicensingEnabled: false,
+        MessageEncryptionEnabled: false,
+        LicensingLocation: [AD_RMS],
+        AdRmsDetected: true,
+      }),
+    })
+    renderWithProviders(<Page />)
+
+    expect(await screen.findByText(/not compatible with/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'migrated to Azure RMS' })
+    ).toBeInTheDocument()
+  })
+
+  it('keeps Run Test disabled until both mailboxes are selected', async () => {
+    const user = userEvent.setup()
+    api.get = getResult({ data: irmConfig() })
+    renderWithProviders(<Page />)
+
+    const runTest = await screen.findByRole('button', { name: 'Run Test' })
+    expect(runTest).toBeDisabled()
+
+    await user.click(screen.getByRole('combobox', { name: 'Sender' }))
+    await user.click(
+      await screen.findByRole('option', { name: 'Admin (admin@contoso.com)' })
+    )
+    expect(runTest).toBeDisabled()
+
+    await user.click(screen.getByRole('combobox', { name: 'Recipient' }))
+    await user.click(
+      await screen.findByRole('option', {
+        name: 'Helpdesk (helpdesk@contoso.com)',
+      })
+    )
+    expect(runTest).toBeEnabled()
+  })
+
+  it('posts the Test action with the entered addresses', async () => {
+    const user = userEvent.setup()
+    api.get = getResult({ data: irmConfig() })
+    renderWithProviders(<Page />)
+
+    await user.click(await screen.findByRole('combobox', { name: 'Sender' }))
+    await user.click(
+      await screen.findByRole('option', { name: 'Admin (admin@contoso.com)' })
+    )
+    await user.click(screen.getByRole('combobox', { name: 'Recipient' }))
+    await user.click(
+      await screen.findByRole('option', {
+        name: 'Helpdesk (helpdesk@contoso.com)',
+      })
+    )
+    await user.click(screen.getByRole('button', { name: 'Run Test' }))
+
+    expect(api.post.mutate).toHaveBeenCalledWith({
+      url: '/api/ExecIRMConfiguration',
+      data: {
+        tenantFilter: 'testdomain.com',
+        Action: 'Test',
+        Sender: 'admin@contoso.com',
+        Recipient: 'helpdesk@contoso.com',
+      },
+    })
+  })
+
+  it('surfaces a load failure', async () => {
+    api.get = getResult({ isSuccess: false, isError: true, data: undefined })
+    renderWithProviders(<Page />)
+
+    expect(
+      await screen.findByText(/Failed to load the IRM configuration/i)
+    ).toBeInTheDocument()
+    // no card, otherwise every undefined field renders as a confident "Disabled"/"No"
+    expect(screen.queryByText('Current Configuration')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Adds a new tools page for Microsoft Purview Message Encryption and adds a corresponding configuration standard.
And some docs too so we keep Brian happy and sane

I'm not sure if the permissions for the 2 new endpoints are correct. Could either be a Tenant.ReadWrite or the current Exchange ones.

Closes #141