### PR TITLE
test: fix storybook dev server rendering

### DIFF
--- a/frontend/.storybook/preview.jsx
+++ b/frontend/.storybook/preview.jsx
@@ -14,6 +14,9 @@ import en from 'javascript-time-ago/locale/en.json'
 import { createTheme } from '../src/theme'
 import { SettingsContext } from '../src/contexts/settings-context'
 import { handlers } from '../tests/mocks/handlers'
+// require.context polyfill must load in the storybook dev server too, the vitest
+// setup files don't run there
+import '../tests/mocks/require-context'
 
 const mockSettings = {
   currentTenant: 'testdomain.com',

--- a/frontend/tests/components/CippComponents/CippFormComponent.stories.jsx
+++ b/frontend/tests/components/CippComponents/CippFormComponent.stories.jsx
@@ -32,6 +32,8 @@ export default {
   component: CippFormComponent,
   tags: ['autodocs'],
   decorators: [FormDecorator],
+  // formControl holds live dom refs, dynamic jsx source serialization stack-overflows on them
+  parameters: { docs: { source: { type: 'code' } } },
   argTypes: {
     type: {
       control: { type: 'select' },

--- a/frontend/tests/components/CippComponents/CippFormCondition.stories.jsx
+++ b/frontend/tests/components/CippComponents/CippFormCondition.stories.jsx
@@ -7,6 +7,8 @@ export default {
   component: CippFormCondition,
   tags: ['autodocs'],
   decorators: [FormDecorator],
+  // formControl holds live dom refs, dynamic jsx source serialization stack-overflows on them
+  parameters: { docs: { source: { type: 'code' } } },
   argTypes: {
     compareType: {
       control: { type: 'select' },

--- a/frontend/tests/mocks/require-context.js
+++ b/frontend/tests/mocks/require-context.js
@@ -51,8 +51,25 @@ const requireShim = () => {
 }
 requireShim.context = createContext
 
-if (typeof globalThis.require === 'undefined') {
-  globalThis.require = requireShim
-} else if (typeof globalThis.require.context === 'undefined') {
-  globalThis.require.context = createContext
+// amd loaders (monaco) assign their own window.require after setup runs, trap the
+// assignment and keep .context attached to whatever gets installed
+let currentRequire = typeof globalThis.require === 'undefined' ? requireShim : globalThis.require
+if (typeof currentRequire.context === 'undefined') {
+  currentRequire.context = createContext
+}
+try {
+  Object.defineProperty(globalThis, 'require', {
+    configurable: true,
+    get() {
+      return currentRequire
+    },
+    set(value) {
+      currentRequire = value
+      if (value && typeof value.context === 'undefined') {
+        value.context = createContext
+      }
+    },
+  })
+} catch {
+  globalThis.require = currentRequire
 }


### PR DESCRIPTION
Issue:
Layout stories throw `require is not defined` on the storybook dev server
Form component stories (number/switch/checkbox/hidden) and their docs pages crash the tab with Maximum call stack size exceeded

Fix:
Load the require.context polyfill from #187 in preview.jsx, the vitest setup files don't run under the dev server
Keep the polyfill attached when another dep (monaco's amd loader) replaces window.require in the dev server
Use static docs source snippets for the FormDecorator story files: those story types leave live dom refs in formControl args, and storybook's dynamic "show code" serializer recurses infinitely walking them

Tested:
`yarn test` green
rendered each component story for similar issues, no page errors