### PR TITLE
fix: update Recommended Roles doc links to maintaining-cipp path

### DIFF
--- a/backend/Modules/CIPPCore/Public/Test-CIPPGDAPRelationships.ps1
+++ b/backend/Modules/CIPPCore/Public/Test-CIPPGDAPRelationships.ps1
@@ -31,7 +31,7 @@ function Test-CIPPGDAPRelationships {
                             Issue        = 'The relationship has global administrator access. Auto-Extend is not available.'
                             Tenant       = [string]$Group.customer.displayName
                             Relationship = [string]$Group.displayName
-                            Link         = 'https://docs.cipp.app/setup/installation/recommended-roles'
+                            Link         = 'https://docs.cipp.app/setup/maintaining-cipp/recommended-roles'
 
                         }) | Out-Null
                 }
@@ -80,7 +80,7 @@ function Test-CIPPGDAPRelationships {
                         Issue        = "$($ExpectedGroup) is not assigned to the SAM user $me. If you have migrated outside of CIPP this is to be expected. Please perform an access check to make sure you have the correct set of permissions."
                         Tenant       = '*Partner Tenant'
                         Relationship = 'None'
-                        Link         = 'https://docs.cipp.app/setup/installation/recommended-roles'
+                        Link         = 'https://docs.cipp.app/setup/maintaining-cipp/recommended-roles'
 
                     }) | Out-Null
                 $MissingGroups.Add([PSCustomObject]@{
@@ -95,7 +95,7 @@ function Test-CIPPGDAPRelationships {
                     Issue        = "We only found $($CIPPGroupCount) of the 15 required groups. If you have migrated outside of CIPP this is to be expected. Please perform an access check to make sure you have the correct set of permissions."
                     Tenant       = '*Partner Tenant'
                     Relationship = 'None'
-                    Link         = 'https://docs.cipp.app/setup/installation/recommended-roles'
+                    Link         = 'https://docs.cipp.app/setup/maintaining-cipp/recommended-roles'
 
                 }) | Out-Null
         }
@@ -119,7 +119,7 @@ function Test-CIPPGDAPRelationships {
                             Issue        = "The GDAP role mapping for '$($MappingResult.GroupName)' references a security group that no longer exists in the partner tenant. Onboarding group mapping will fail until the GDAP roles are recreated."
                             Tenant       = '*Partner Tenant'
                             Relationship = 'None'
-                            Link         = 'https://docs.cipp.app/setup/installation/recommended-roles'
+                            Link         = 'https://docs.cipp.app/setup/maintaining-cipp/recommended-roles'
                         }) | Out-Null
                 } elseif ($MappingResult.Status -eq 'Stale') {
                     $GDAPissues.add([PSCustomObject]@{
@@ -128,7 +128,7 @@ function Test-CIPPGDAPRelationships {
                             Issue        = "The GDAP role mapping for '$($MappingResult.GroupName)' points at a stale group id but a matching group still exists. Use 'Repair Role Mappings' under Details to correct the stored group id."
                             Tenant       = '*Partner Tenant'
                             Relationship = 'None'
-                            Link         = 'https://docs.cipp.app/setup/installation/recommended-roles'
+                            Link         = 'https://docs.cipp.app/setup/maintaining-cipp/recommended-roles'
                         }) | Out-Null
                 }
             }

--- a/frontend/src/pages/tenant/gdap-management/relationships/relationship/index.js
+++ b/frontend/src/pages/tenant/gdap-management/relationships/relationship/index.js
@@ -177,7 +177,7 @@ const Page = () => {
               <Alert severity="warning">
                 This relationship does not have all the CIPP recommended roles. See the{" "}
                 <Link
-                  href="https://docs.cipp.app/setup/installation/recommended-roles"
+                  href="https://docs.cipp.app/setup/maintaining-cipp/recommended-roles"
                   target="_blank"
                   rel="noreferrer"
                 >


### PR DESCRIPTION
## Summary

The Recommended Roles documentation page moved from `/setup/installation/recommended-roles` to `/setup/maintaining-cipp/recommended-roles`, but several places in the app still linked to the old (dead) URL.

- **Frontend**: the "Recommended Roles" link on the GDAP relationship detail page (`frontend/src/pages/tenant/gdap-management/relationships/relationship/index.js`)
- **Backend**: all four `Link` values on GDAP access-check issues in `Test-CIPPGDAPRelationships.ps1`, which surface in the access check UI

All five now point to https://docs.cipp.app/setup/maintaining-cipp/recommended-roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)