### PR TITLE
feat(intune): handle MAA approvals and drift

### DIFF
--- a/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-ExecScheduledCommand.ps1
+++ b/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-ExecScheduledCommand.ps1
@@ -325,7 +325,11 @@ function Push-ExecScheduledCommand {
         }
     } catch {
         Write-Information "Failed to run task: $($_.Exception.Message)"
-        $errorMessage = $_.Exception.Message
+        # Captured before anything else can overwrite $_. Get-NormalizedError unwraps a JSON Graph or
+        # Exchange error body and returns the original string when it recognises nothing, so this is
+        # never less informative than the raw exception message it replaced.
+        $ExceptionData = Get-CippException -Exception $_
+        $errorMessage = $ExceptionData.NormalizedError
         #if recurrence is just a number, add it in days.
         if ($task.Recurrence -match '^\d+$') {
             $task.Recurrence = $task.Recurrence + 'd'
@@ -356,7 +360,7 @@ function Push-ExecScheduledCommand {
                 TaskState     = $State
             }
         }
-        Write-LogMessage -API 'Scheduler_UserTasks' -tenant $Tenant -tenantid $TenantInfo.customerId -message "Failed to execute task $($task.Name): $errorMessage" -sev Error -LogData (Get-CippExceptionData -Exception $_.Exception)
+        Write-LogMessage -API 'Scheduler_UserTasks' -tenant $Tenant -tenantid $TenantInfo.customerId -message "Failed to execute task $($task.Name): $errorMessage" -sev Error -LogData $ExceptionData
     }
 
     # For orchestrator-based commands, skip post-execution alerts as they will be handled by the orchestrator's post-execution function

--- a/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertIntuneApprovalRequests.ps1
+++ b/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertIntuneApprovalRequests.ps1
@@ -1,0 +1,42 @@
+function Get-CIPPAlertIntuneApprovalRequests {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [Alias('input')]
+        $InputValue,
+        $TenantFilter
+    )
+
+    try {
+        # Multi-admin approval holds a change until a second admin approves it. Nothing tells the
+        # requestor it is waiting, so a pending request is a change someone believes they already made.
+        # Filtered server side - a decided request is never of interest here, and this runs per tenant.
+        $Uri = "https://graph.microsoft.com/beta/deviceManagement/operationApprovalRequests?`$filter=status eq 'needsApproval'"
+        $ApprovalRequests = New-GraphGetRequest -uri $Uri -tenantid $TenantFilter -ErrorAction Stop
+
+        $AlertData = foreach ($ApprovalRequest in $ApprovalRequests) {
+            # payloadOperation and payloadName are absent from the published schema but are returned
+            # by the service. They are what makes the alert readable - the requestor identitySet is
+            # left null even for requests raised through Graph, so there is no 'who' to report.
+            $Operation = ($ApprovalRequest.payloadOperation ?? 'change').ToLower()
+            $Target = $ApprovalRequest.payloadName ?? (@($ApprovalRequest.requiredOperationApprovalPolicyTypes) -join ', ')
+            $Message = 'Intune {0} of "{1}" is waiting for multi-admin approval and expires {2}' -f $Operation, $Target, $ApprovalRequest.expirationDateTime
+
+            $ApprovalRequest | Select-Object -Property id, status, requestDateTime, expirationDateTime, requestJustification,
+            @{Name = 'operation'; Expression = { $ApprovalRequest.payloadOperation } },
+            @{Name = 'target'; Expression = { $ApprovalRequest.payloadName } },
+            @{Name = 'Message'; Expression = { $Message } }
+        }
+
+        if ($AlertData) {
+            Write-AlertTrace -cmdletName $MyInvocation.MyCommand -tenantFilter $TenantFilter -data $AlertData
+        }
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -API 'Alerts' -tenant $TenantFilter -message "Failed to check Intune multi-admin approval requests for $($TenantFilter): $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+    }
+}

--- a/backend/Modules/CIPPCore/Public/Baselines/Get-CIPPBaselineIntuneTemplateState.ps1
+++ b/backend/Modules/CIPPCore/Public/Baselines/Get-CIPPBaselineIntuneTemplateState.ps1
@@ -211,7 +211,7 @@ function Get-CIPPBaselineIntuneTemplateState {
         $AssignTo = "$(& $Unwrap $Variables.assignTo)"
         $CustomGroup = "$(& $Unwrap $Variables.customGroup)"
         if ($CustomGroup) { $AssignTo = 'customGroup' }
-        $AssignmentsMatch = Compare-CIPPIntuneAssignments -ExistingAssignments @($Live.assignments) -ExpectedAssignTo $AssignTo -ExpectedCustomGroup $CustomGroup -ExpectedExcludeGroup "$(& $Unwrap $Variables.excludeGroup)" -ExpectedAssignmentFilter "$(& $Unwrap $Variables.assignmentFilter)" -ExpectedAssignmentFilterType "$(& $Unwrap $Variables.assignmentFilterType)" -TenantFilter $TenantFilter
+        $AssignmentsMatch = Compare-CIPPIntuneAssignments -ExistingAssignments @($Live.assignments) -ExpectedAssignTo $AssignTo -ExpectedCustomGroup $CustomGroup -ExpectedExcludeGroup "$(& $Unwrap $Variables.excludeGroup)" -ExpectedAssignmentFilter "$(& $Unwrap $Variables.assignmentFilter)" -ExpectedAssignmentFilterType "$(& $Unwrap $Variables.assignmentFilterType)" -PolicyType $TemplateType -TenantFilter $TenantFilter
         $Current | Add-Member -NotePropertyName 'isAssigned' -NotePropertyValue ([bool]$AssignmentsMatch) -Force
         # The Catalog flatten compares ONLY the settings arrays - top-level properties
         # like isAssigned never reach it. StrictCompare makes the engine diff these

--- a/backend/Modules/CIPPCore/Public/Compare-CIPPIntuneAssignments.ps1
+++ b/backend/Modules/CIPPCore/Public/Compare-CIPPIntuneAssignments.ps1
@@ -1,134 +1,273 @@
 function Compare-CIPPIntuneAssignments {
     <#
     .SYNOPSIS
-        Compares existing Intune policy assignments against expected assignment settings.
+        Compares existing Intune policy assignments against a standard's expected assignment settings.
     .DESCRIPTION
-        Returns $true if the existing assignments match the expected settings, $false if they differ,
-        or $null if the comparison could not be completed (e.g. Graph error).
+        Returns a result object saying whether the assignments match and, when they do not, exactly
+        which include groups, exclusion groups or filters differ. The detail is the point: a bare
+        boolean gives an operator nothing to act on, which is how "assignments differ" deviations
+        end up unexplainable when the assignment in the portal looks correct.
+
+        The verdict is scoped to what remediation actually manages, via Get-CIPPIntuneAssignTarget:
+
+        - Include targets and groups are only asserted when the standard names a target (Managed).
+          With AssignTo unset or 'Do not assign', Set-CIPPIntunePolicy adds no include target, so
+          demanding a particular set of them produces a deviation no run can clear.
+        - Exclusion groups and filters that the standard specifies are asserted whenever remediation
+          touches assignments at all (Applied).
+        - Extra include groups, extra exclusions and unexpected filters are only asserted when the
+          standard owns the assignments (Managed), because that is the only case where remediation
+          replaces rather than appends and can therefore remove them.
+
+        Group names are resolved to ids the same way Set-CIPPAssignedPolicy resolves them, so the
+        two agree on which groups a wildcard covers. A name that matches nothing is reported rather
+        than silently dropped - a renamed group is a common cause of a policy that looks correctly
+        assigned but no longer matches the standard.
     .PARAMETER ExistingAssignments
         The current assignments on the policy, as returned by Get-CIPPIntunePolicyAssignments.
     .PARAMETER ExpectedAssignTo
-        The expected assignment target type: allLicensedUsers, AllDevices, AllDevicesAndUsers,
-        customGroup, or On (no assignment).
+        The expected assignment target: allLicensedUsers, AllDevices, AllDevicesAndUsers,
+        customGroup, or On (no include target). Accepts the { label, value } shape.
     .PARAMETER ExpectedCustomGroup
         The expected custom group name(s), comma-separated. Used when ExpectedAssignTo is 'customGroup'.
+        Wildcards supported.
     .PARAMETER ExpectedExcludeGroup
-        The expected exclusion group name(s), comma-separated.
+        The expected exclusion group name(s), comma-separated. Wildcards supported.
     .PARAMETER ExpectedAssignmentFilter
         The expected assignment filter display name. Wildcards supported.
     .PARAMETER ExpectedAssignmentFilterType
         'include' or 'exclude'. Defaults to 'include'.
+    .PARAMETER PolicyType
+        The policy's type, so the broad targets are read the same way remediation writes them. App
+        Protection expresses "all users" as a group assignment rather than an allLicensedUsers
+        target; without this the comparison would demand a target remediation never writes.
     .PARAMETER TenantFilter
         The tenant to query for group/filter resolution.
+    .OUTPUTS
+        PSCustomObject with:
+            Matched              - $true or $false, or $null when the comparison could not be completed
+            Unknown              - $true when the comparison could not be completed
+            Managed / Applied    - see Get-CIPPIntuneAssignTarget
+            MissingIncludeGroups - groups the standard expects that the policy is not assigned to
+            ExtraIncludeGroups   - groups the policy is assigned to that the standard does not expect
+            MissingExcludeGroups / ExtraExcludeGroups - the same for exclusions
+            UnresolvedGroups     - configured group names that matched no group in the tenant
+            Reasons              - one readable line per difference
     .FUNCTIONALITY
         Internal
     #>
     param(
         [object[]]$ExistingAssignments,
-        [string]$ExpectedAssignTo,
+        $ExpectedAssignTo,
         [string]$ExpectedCustomGroup,
         [string]$ExpectedExcludeGroup,
         [string]$ExpectedAssignmentFilter,
         [string]$ExpectedAssignmentFilterType = 'include',
+        [string]$PolicyType,
         [Parameter(Mandatory = $true)]
         [string]$TenantFilter
     )
 
+    $GroupType = '#microsoft.graph.groupAssignmentTarget'
+    $ExclusionType = '#microsoft.graph.exclusionGroupAssignmentTarget'
+    $GroupUri = 'https://graph.microsoft.com/beta/groups?$select=id,displayName&$top=999'
+    # Graph returns the empty GUID rather than null for "no filter" on some assignment shapes.
+    $NoFilterId = '00000000-0000-0000-0000-000000000000'
+
+    $ToGroupRefs = {
+        param($Ids, $NameMap)
+        @(foreach ($Id in $Ids) {
+                [PSCustomObject]@{ id = $Id; displayName = $NameMap[$Id] }
+            })
+    }
+
+    $Target = Get-CIPPIntuneAssignTarget -AssignTo $ExpectedAssignTo
+    $Reasons = [System.Collections.Generic.List[string]]::new()
+
     try {
-        # Normalize existing targets
-        $ExistingTargetTypes = @($ExistingAssignments.target.'@odata.type' | Where-Object { $_ })
+        $Assignments = @($ExistingAssignments | Where-Object { $_ })
+
+        $ExistingIncludeAssignments = @($Assignments | Where-Object { $_.target.'@odata.type' -ne $ExclusionType })
+        $ExistingIncludeTypes = @($ExistingIncludeAssignments.target.'@odata.type' | Where-Object { $_ })
         $ExistingIncludeGroupIds = @(
-            $ExistingAssignments |
-                Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' } |
+            $Assignments |
+                Where-Object { $_.target.'@odata.type' -eq $GroupType } |
                 ForEach-Object { $_.target.groupId }
         )
         $ExistingExcludeGroupIds = @(
-            $ExistingAssignments |
-                Where-Object { $_.target.'@odata.type' -eq '#microsoft.graph.exclusionGroupAssignmentTarget' } |
+            $Assignments |
+                Where-Object { $_.target.'@odata.type' -eq $ExclusionType } |
                 ForEach-Object { $_.target.groupId }
         )
 
-        # Determine expected include target types
-        $ExpectedIncludeTypes = switch ($ExpectedAssignTo) {
-            'allLicensedUsers'   { @('#microsoft.graph.allLicensedUsersAssignmentTarget') }
-            'AllDevices'         { @('#microsoft.graph.allDevicesAssignmentTarget') }
-            'AllDevicesAndUsers' { @('#microsoft.graph.allDevicesAssignmentTarget', '#microsoft.graph.allLicensedUsersAssignmentTarget') }
-            'customGroup'        { @('#microsoft.graph.groupAssignmentTarget') }
-            'On'                 { @() }
-            default              { @() }
+        # Read the broad targets through the same helper remediation writes them with, so a policy
+        # type that expresses one of them differently is expected the way it is actually applied.
+        $BroadTarget = Get-CIPPIntuneAssignmentTarget -AssignTo $Target.AssignTo -PolicyType $PolicyType
+        $ExpectedIncludeTypes = if ($Target.AssignTo -eq 'customGroup') {
+            @($GroupType)
+        } else {
+            @($BroadTarget.Targets | ForEach-Object { $_.'@odata.type' })
         }
+        # A broad target expressed as a group assignment (App Protection's "all users") is an
+        # expected group, not an unexpected extra one.
+        $BroadGroupIds = @($BroadTarget.Targets | Where-Object { $_.groupId } | ForEach-Object { $_.groupId })
 
-        # Compare include target types (ignore exclusion targets)
-        $ExistingIncludeTypes = @($ExistingTargetTypes | Where-Object { $_ -ne '#microsoft.graph.exclusionGroupAssignmentTarget' })
-        $TargetTypeMatch = $true
-        foreach ($t in $ExpectedIncludeTypes) {
-            if ($t -notin $ExistingIncludeTypes) { $TargetTypeMatch = $false; break }
-        }
-        if ($TargetTypeMatch) {
-            foreach ($t in $ExistingIncludeTypes) {
-                if ($t -notin $ExpectedIncludeTypes) { $TargetTypeMatch = $false; break }
-            }
-        }
-
-        # Lazy-load groups cache only if needed
+        # Groups are looked up once and reused for name->id resolution and for naming the ids that
+        # turn out to differ.
         $AllGroupsCache = $null
-
-        # For custom groups, resolve names to IDs and compare
-        $IncludeGroupMatch = $true
-        if ($ExpectedAssignTo -eq 'customGroup' -and $ExpectedCustomGroup) {
-            $AllGroupsCache = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/groups?$select=id,displayName&$top=999' -tenantid $TenantFilter
-            $ExpectedGroupIds = @(
-                $ExpectedCustomGroup.Split(',').Trim() | ForEach-Object {
-                    $name = $_
-                    $AllGroupsCache | Where-Object { $_.displayName -like ($name -replace '\[', '`[' -replace '\]', '`]') } | Select-Object -ExpandProperty id
-                } | Where-Object { $_ }
-            )
-            $MissingIds = @($ExpectedGroupIds | Where-Object { $_ -notin $ExistingIncludeGroupIds })
-            $ExtraIds   = @($ExistingIncludeGroupIds | Where-Object { $_ -notin $ExpectedGroupIds })
-            $IncludeGroupMatch = ($MissingIds.Count -eq 0 -and $ExtraIds.Count -eq 0)
-        }
-
-        # Compare exclusion groups
-        $ExcludeGroupMatch = $true
-        if ($ExpectedExcludeGroup) {
-            if (-not $AllGroupsCache) {
-                $AllGroupsCache = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/groups?$select=id,displayName&$top=999' -tenantid $TenantFilter
+        $ResolveGroupNames = {
+            param($NameList)
+            $Ids = [System.Collections.Generic.List[string]]::new()
+            $Unresolved = [System.Collections.Generic.List[string]]::new()
+            foreach ($Name in @($NameList.Split(',').Trim() | Where-Object { $_ })) {
+                # Square brackets are wildcard character classes to -like; group names containing
+                # them are literal. Matches the escaping Set-CIPPAssignedPolicy applies.
+                $Pattern = $Name -replace '\[', '`[' -replace '\]', '`]'
+                $Matched = @($AllGroupsCache | Where-Object { $_.displayName -like $Pattern } | Select-Object -ExpandProperty id)
+                if ($Matched.Count -eq 0) { $Unresolved.Add($Name) } else { $Ids.AddRange([string[]]$Matched) }
             }
-            $ExpectedExcludeIds = @(
-                $ExpectedExcludeGroup.Split(',').Trim() | ForEach-Object {
-                    $name = $_
-                    $AllGroupsCache | Where-Object { $_.displayName -like ($name -replace '\[', '`[' -replace '\]', '`]') } | Select-Object -ExpandProperty id
-                } | Where-Object { $_ }
-            )
-            $MissingExcludeIds = @($ExpectedExcludeIds | Where-Object { $_ -notin $ExistingExcludeGroupIds })
-            $ExtraExcludeIds   = @($ExistingExcludeGroupIds | Where-Object { $_ -notin $ExpectedExcludeIds })
-            $ExcludeGroupMatch = ($MissingExcludeIds.Count -eq 0 -and $ExtraExcludeIds.Count -eq 0)
-        } elseif ($ExistingExcludeGroupIds.Count -gt 0) {
-            # No exclusions expected but some exist
-            $ExcludeGroupMatch = $false
+            [PSCustomObject]@{ Ids = @($Ids); Unresolved = @($Unresolved) }
         }
 
-        # Compare assignment filter
+        # Exclusions are only resolved when remediation would apply them; otherwise an unresolvable
+        # name would be reported as a difference that nothing can act on.
+        $CheckExcludeGroups = [bool]($ExpectedExcludeGroup -and $Target.Applied)
+        $NeedsGroupLookup = ($Target.AssignTo -eq 'customGroup' -and $ExpectedCustomGroup) -or $CheckExcludeGroups
+        if ($NeedsGroupLookup) {
+            $AllGroupsCache = New-GraphGetRequest -uri $GroupUri -tenantid $TenantFilter
+        }
+
+        # -- include targets -------------------------------------------------------------------
+        # Group targets are reported by id below, so only the broad All Users / All Devices targets
+        # are compared at type level here.
+        $TargetTypeMatch = $true
+        if ($Target.Managed) {
+            $MissingTypes = @($ExpectedIncludeTypes | Where-Object { $_ -ne $GroupType -and $_ -notin $ExistingIncludeTypes })
+            $ExtraTypes = @($ExistingIncludeTypes | Where-Object { $_ -ne $GroupType -and $_ -notin $ExpectedIncludeTypes })
+            if ($MissingTypes.Count -gt 0) {
+                $TargetTypeMatch = $false
+                $Reasons.Add("Policy is not assigned to $(($MissingTypes -replace '#microsoft\.graph\.', '') -join ', ')")
+            }
+            if ($ExtraTypes.Count -gt 0) {
+                $TargetTypeMatch = $false
+                $Reasons.Add("Policy is assigned to $(($ExtraTypes -replace '#microsoft\.graph\.', '') -join ', '), which the standard does not expect")
+            }
+        }
+
+        # -- include groups --------------------------------------------------------------------
+        $ExpectedGroupIds = @()
+        $UnresolvedGroups = [System.Collections.Generic.List[string]]::new()
+        if ($Target.AssignTo -eq 'customGroup' -and $ExpectedCustomGroup) {
+            $Resolved = & $ResolveGroupNames $ExpectedCustomGroup
+            $ExpectedGroupIds = $Resolved.Ids
+            foreach ($Name in $Resolved.Unresolved) { $UnresolvedGroups.Add($Name) }
+        }
+        $ExpectedGroupIds = @($ExpectedGroupIds) + $BroadGroupIds
+        $MissingIncludeIds = @($ExpectedGroupIds | Where-Object { $_ -notin $ExistingIncludeGroupIds })
+        $ExtraIncludeIds = if ($Target.Managed) {
+            @($ExistingIncludeGroupIds | Where-Object { $_ -notin $ExpectedGroupIds })
+        } else { @() }
+
+        # -- exclusion groups ------------------------------------------------------------------
+        $ExpectedExcludeIds = @()
+        if ($CheckExcludeGroups) {
+            $Resolved = & $ResolveGroupNames $ExpectedExcludeGroup
+            $ExpectedExcludeIds = $Resolved.Ids
+            foreach ($Name in $Resolved.Unresolved) { $UnresolvedGroups.Add($Name) }
+        }
+        $MissingExcludeIds = @($ExpectedExcludeIds | Where-Object { $_ -notin $ExistingExcludeGroupIds })
+        $ExtraExcludeIds = if ($Target.Managed) {
+            @($ExistingExcludeGroupIds | Where-Object { $_ -notin $ExpectedExcludeIds })
+        } else { @() }
+
+        # -- assignment filter -----------------------------------------------------------------
+        $ExistingFilterIds = @(
+            $Assignments |
+                Where-Object { $_.target.deviceAndAppManagementAssignmentFilterId -and $_.target.deviceAndAppManagementAssignmentFilterId -ne $NoFilterId } |
+                ForEach-Object { $_.target.deviceAndAppManagementAssignmentFilterId }
+        )
         $FilterMatch = $true
-        if ($ExpectedAssignmentFilter) {
-            $ExistingFilterIds = @(
-                $ExistingAssignments |
-                    Where-Object { $_.target.deviceAndAppManagementAssignmentFilterId } |
-                    ForEach-Object { $_.target.deviceAndAppManagementAssignmentFilterId }
-            )
-            if ($ExistingFilterIds.Count -eq 0) {
+        if ($ExpectedAssignmentFilter -and $Target.Applied) {
+            $AllFilters = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/deviceManagement/assignmentFilters' -tenantid $TenantFilter
+            $ExpectedFilter = $AllFilters | Where-Object { $_.displayName -like $ExpectedAssignmentFilter } | Select-Object -First 1
+            if (-not $ExpectedFilter) {
                 $FilterMatch = $false
-            } else {
-                $AllFilters = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/deviceManagement/assignmentFilters' -tenantid $TenantFilter
-                $ExpectedFilter = $AllFilters | Where-Object { $_.displayName -like $ExpectedAssignmentFilter } | Select-Object -First 1
-                $FilterMatch = $ExpectedFilter -and ($ExpectedFilter.id -in $ExistingFilterIds)
+                $Reasons.Add("Assignment filter '$ExpectedAssignmentFilter' does not exist in this tenant")
+            } elseif ($ExistingIncludeAssignments.Count -gt 0) {
+                # Remediation stamps the filter onto every include target, so anything short of that
+                # is a difference. When there are no include targets at all the missing-assignment
+                # reasons above already say so; adding a filter complaint on top is just noise.
+                $ExpectedFilterType = if ($ExpectedAssignmentFilterType) { $ExpectedAssignmentFilterType } else { 'include' }
+                $Unfiltered = @($ExistingIncludeAssignments | Where-Object { $_.target.deviceAndAppManagementAssignmentFilterId -ne $ExpectedFilter.id })
+                $WrongMode = @($ExistingIncludeAssignments | Where-Object { $_.target.deviceAndAppManagementAssignmentFilterId -eq $ExpectedFilter.id -and $_.target.deviceAndAppManagementAssignmentFilterType -ne $ExpectedFilterType })
+                if ($Unfiltered.Count -gt 0) {
+                    $FilterMatch = $false
+                    $Reasons.Add("Assignment filter '$($ExpectedFilter.displayName)' is not applied to every assignment target")
+                }
+                if ($WrongMode.Count -gt 0) {
+                    $FilterMatch = $false
+                    $Reasons.Add("Assignment filter '$($ExpectedFilter.displayName)' should be in '$ExpectedFilterType' mode")
+                }
             }
+        } elseif ($Target.Managed -and -not $ExpectedAssignmentFilter -and $ExistingFilterIds.Count -gt 0) {
+            $FilterMatch = $false
+            $Reasons.Add('An assignment filter is applied to this policy but the standard does not specify one')
         }
 
-        return $TargetTypeMatch -and $IncludeGroupMatch -and $ExcludeGroupMatch -and $FilterMatch
+        # -- name the ids that differ ------------------------------------------------------------
+        $DifferingIds = @($MissingIncludeIds + $ExtraIncludeIds + $MissingExcludeIds + $ExtraExcludeIds | Where-Object { $_ } | Select-Object -Unique)
+        if ($DifferingIds.Count -gt 0 -and -not $AllGroupsCache) {
+            $AllGroupsCache = New-GraphGetRequest -uri $GroupUri -tenantid $TenantFilter
+        }
+        $GroupNameById = @{}
+        foreach ($Group in $AllGroupsCache) { $GroupNameById[$Group.id] = $Group.displayName }
+        # Virtual groups are not in the directory, so name them from the helper that produced them.
+        foreach ($Id in $BroadTarget.GroupNames.Keys) { $GroupNameById[$Id] = $BroadTarget.GroupNames[$Id] }
+        $Describe = { param($Ids) (@(foreach ($Id in $Ids) { if ($GroupNameById[$Id]) { $GroupNameById[$Id] } else { $Id } }) -join ', ') }
+
+        if ($MissingIncludeIds.Count -gt 0) { $Reasons.Add("Not assigned to expected group(s): $(& $Describe $MissingIncludeIds)") }
+        if ($ExtraIncludeIds.Count -gt 0) { $Reasons.Add("Assigned to unexpected group(s): $(& $Describe $ExtraIncludeIds)") }
+        if ($MissingExcludeIds.Count -gt 0) { $Reasons.Add("Missing exclusion for group(s): $(& $Describe $MissingExcludeIds)") }
+        if ($ExtraExcludeIds.Count -gt 0) { $Reasons.Add("Unexpected exclusion for group(s): $(& $Describe $ExtraExcludeIds)") }
+        foreach ($Name in $UnresolvedGroups) { $Reasons.Add("Group name '$Name' matches no group in this tenant") }
+
+        $IncludeGroupMatch = ($MissingIncludeIds.Count -eq 0 -and $ExtraIncludeIds.Count -eq 0)
+        $ExcludeGroupMatch = ($MissingExcludeIds.Count -eq 0 -and $ExtraExcludeIds.Count -eq 0)
+        # A group name that resolves to nothing is a broken expectation, not a match.
+        $GroupsResolved = ($UnresolvedGroups.Count -eq 0)
+
+        return [PSCustomObject]@{
+            Matched              = ($TargetTypeMatch -and $IncludeGroupMatch -and $ExcludeGroupMatch -and $FilterMatch -and $GroupsResolved)
+            Unknown              = $false
+            Managed              = $Target.Managed
+            Applied              = $Target.Applied
+            AssignTo             = $Target.AssignTo
+            MissingIncludeGroups = & $ToGroupRefs $MissingIncludeIds $GroupNameById
+            ExtraIncludeGroups   = & $ToGroupRefs $ExtraIncludeIds $GroupNameById
+            MissingExcludeGroups = & $ToGroupRefs $MissingExcludeIds $GroupNameById
+            ExtraExcludeGroups   = & $ToGroupRefs $ExtraExcludeIds $GroupNameById
+            UnresolvedGroups     = @($UnresolvedGroups)
+            Reasons              = @($Reasons)
+            Error                = $null
+        }
 
     } catch {
+        # Unknown, not a mismatch. The caller must not record this as a deviation - a transient
+        # Graph failure would otherwise write drift that no remediation run can clear.
         Write-Warning "Compare-CIPPIntuneAssignments failed for tenant $TenantFilter : $($_.Exception.Message)"
-        return $null  # null = unknown, don't treat as mismatch
+        return [PSCustomObject]@{
+            Matched              = $null
+            Unknown              = $true
+            Managed              = $Target.Managed
+            Applied              = $Target.Applied
+            AssignTo             = $Target.AssignTo
+            MissingIncludeGroups = @()
+            ExtraIncludeGroups   = @()
+            MissingExcludeGroups = @()
+            ExtraExcludeGroups   = @()
+            UnresolvedGroups     = @()
+            Reasons              = @()
+            Error                = $_.Exception.Message
+        }
     }
 }

--- a/backend/Modules/CIPPCore/Public/Get-CIPPAppProtectionPolicyUrl.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPAppProtectionPolicyUrl.ps1
@@ -1,0 +1,114 @@
+function Get-CIPPAppProtectionPolicyUrl {
+    <#
+    .SYNOPSIS
+        Resolves the deviceAppManagement collection an App Protection policy belongs to.
+
+    .DESCRIPTION
+        'AppProtection' is a single CIPP template type covering several concrete Graph types, each
+        of which lives in its own collection, so a template cannot be deployed until the concrete
+        type is known.
+
+        @odata.type answers that directly, but Graph only emits it when the policy was read through
+        the polymorphic managedAppPolicies collection. Read through its own collection - which is
+        how CIPP captures these once the type is known - Graph omits @odata.type and records the
+        type in @odata.context instead, so templates captured that way, and every copy synced from
+        them, carry only the context. Fall back to it, and then to settings that exist on only one
+        platform, before giving up.
+
+        Returns $null when the policy identifies no platform at all.
+
+    .PARAMETER Policy
+        The policy payload, either as an object or as its raw JSON.
+
+    .EXAMPLE
+        Get-CIPPAppProtectionPolicyUrl -Policy ($RawJSON | ConvertFrom-Json)
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Policy
+    )
+
+    if ($Policy -is [string]) {
+        try {
+            $Policy = $Policy | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            return $null
+        }
+    }
+    if (-not $Policy) { return $null }
+
+    # Graph's collection names are not a plain pluralisation of the type name, so map the types App
+    # Protection can hold and keep the -y/-ies rule only as a fallback for anything added later.
+    $CollectionByType = @{
+        'iosManagedAppProtection'               = 'iosManagedAppProtections'
+        'androidManagedAppProtection'           = 'androidManagedAppProtections'
+        'windowsManagedAppProtection'           = 'windowsManagedAppProtections'
+        'defaultManagedAppProtection'           = 'defaultManagedAppProtections'
+        'targetedManagedAppConfiguration'       = 'targetedManagedAppConfigurations'
+        'windowsInformationProtectionPolicy'    = 'windowsInformationProtectionPolicies'
+        'mdmWindowsInformationProtectionPolicy' = 'mdmWindowsInformationProtectionPolicies'
+    }
+
+    $ToCollection = {
+        param($Type)
+        $Type = "$Type" -replace '^#', '' -replace '^microsoft\.graph\.', ''
+        if ([string]::IsNullOrWhiteSpace($Type)) { return $null }
+        if ($CollectionByType.ContainsKey($Type)) { return $CollectionByType[$Type] }
+        if ($Type.EndsWith('y')) { return ($Type -replace 'y$', 'ies') }
+        return "$($Type)s"
+    }
+
+    $Collection = & $ToCollection $Policy.'@odata.type'
+    if ($Collection) { return $Collection }
+
+    # .../$metadata#deviceAppManagement/<collection>[/microsoft.graph.<type>]/$entity
+    if ("$($Policy.'@odata.context')" -match '#deviceAppManagement/(?<collection>[A-Za-z0-9]+)(/microsoft\.graph\.(?<type>[A-Za-z0-9]+))?') {
+        if ($Matches.type) {
+            return (& $ToCollection $Matches.type)
+        }
+        # managedAppPolicies is the polymorphic collection: it names no platform and cannot be
+        # posted to, so a context pointing at it says nothing about the type.
+        if ($Matches.collection -ne 'managedAppPolicies') {
+            return $Matches.collection
+        }
+    }
+
+    # Nothing authoritative left. Settings that exist on one platform only still identify the two
+    # types that make up nearly every App Protection policy. Require the match to be one-sided -
+    # deploying into the wrong collection is worse than reporting that the type is unknown.
+    $IosOnlySettings = @(
+        'faceIdBlocked'
+        'appDataEncryptionType'
+        'thirdPartyKeyboardsBlocked'
+        'filterOpenInToOnlyManagedApps'
+        'managedUniversalLinks'
+        'exemptedUniversalLinks'
+        'exemptedAppProtocols'
+        'allowedIosDeviceModels'
+        'appActionIfIosDeviceModelNotAllowed'
+        'protectInboundDataFromUnknownSources'
+    )
+    $AndroidOnlySettings = @(
+        'screenCaptureBlocked'
+        'encryptAppData'
+        'disableAppEncryptionIfDeviceEncryptionIsEnabled'
+        'exemptedAppPackages'
+        'approvedKeyboards'
+        'allowedAndroidDeviceManufacturers'
+        'appActionIfAndroidDeviceManufacturerNotAllowed'
+        'allowedAndroidDeviceModels'
+        'appActionIfAndroidDeviceModelNotAllowed'
+        'customBrowserPackageId'
+    )
+
+    $PropertyNames = @($Policy.PSObject.Properties.Name)
+    $IosMatches = @($IosOnlySettings | Where-Object { $PropertyNames -contains $_ }).Count
+    $AndroidMatches = @($AndroidOnlySettings | Where-Object { $PropertyNames -contains $_ }).Count
+
+    if ($IosMatches -gt 0 -and $AndroidMatches -eq 0) { return 'iosManagedAppProtections' }
+    if ($AndroidMatches -gt 0 -and $IosMatches -eq 0) { return 'androidManagedAppProtections' }
+
+    return $null
+}

--- a/backend/Modules/CIPPCore/Public/Get-CIPPIntuneAssignTarget.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPIntuneAssignTarget.ps1
@@ -1,0 +1,53 @@
+function Get-CIPPIntuneAssignTarget {
+    <#
+    .SYNOPSIS
+        Normalizes an Intune template's AssignTo setting and reports what remediation will do with it.
+    .DESCRIPTION
+        The assignment expectation and the assignment remediation have to agree, or drift can never
+        converge: a comparison that asserts something remediation does not do produces a deviation
+        no run can ever clear. Both sides read the setting through this function so they cannot
+        drift apart.
+
+        Two flags come out of it:
+
+        Applied - remediation calls Set-CIPPAssignedPolicy at all. Set-CIPPIntunePolicy skips the
+                  assignment step entirely when AssignTo is empty, so nothing about assignments
+                  (not even a missing exclusion or filter) is remediable in that case.
+        Managed - the standard names a concrete include target, which means it owns the policy's
+                  assignments outright and remediation replaces them. Only then can an unexpected
+                  extra group or filter actually be removed, so only then is it a real deviation.
+
+        'On' ("Do not assign") is Applied but not Managed: remediation still applies exclusions and
+        filters, but it adds no include target and cannot remove one that is already there.
+
+        Also unwraps the { label, value } shape. The radio control stores a plain string today, but
+        templates imported from older versions or from the community repo can carry the object.
+    .PARAMETER AssignTo
+        The raw AssignTo value from the standard's settings. String or { label, value } object.
+    .EXAMPLE
+        Get-CIPPIntuneAssignTarget -AssignTo $Settings.AssignTo
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        $AssignTo
+    )
+
+    $Value = $AssignTo
+    if ($null -ne $Value -and $Value -isnot [string] -and $Value.PSObject.Properties.Name -contains 'value') {
+        $Value = $Value.value
+    }
+    $Value = ([string]$Value).Trim()
+
+    # Match case-insensitively but return the canonical casing, so callers can compare with -eq
+    # without repeating the casing of every option.
+    $KnownTargets = @('allLicensedUsers', 'AllDevices', 'AllDevicesAndUsers', 'customGroup')
+    $Canonical = $KnownTargets | Where-Object { $_ -eq $Value } | Select-Object -First 1
+
+    [PSCustomObject]@{
+        AssignTo = if ($Canonical) { $Canonical } else { $Value }
+        Managed  = [bool]$Canonical
+        Applied  = -not [string]::IsNullOrWhiteSpace($Value)
+    }
+}

--- a/backend/Modules/CIPPCore/Public/Get-CIPPIntuneAssignmentTarget.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPIntuneAssignmentTarget.ps1
@@ -1,0 +1,113 @@
+function Get-CIPPIntuneAssignmentTarget {
+    <#
+    .SYNOPSIS
+        The include targets one of the broad AssignTo options produces for a given policy type.
+
+    .DESCRIPTION
+        Remediation (Set-CIPPAssignedPolicy) and the assignment comparison
+        (Compare-CIPPIntuneAssignments) both read the broad targets through this function, so what
+        the comparison asserts is what remediation writes. A comparison expecting a target
+        remediation never produces is a deviation no run can clear - the same invariant
+        Get-CIPPIntuneAssignTarget exists to protect, one level further down.
+
+        App Protection and managed app configuration are served by Intune's MAM service rather than
+        the device management service, and it accepts only groupAssignmentTarget and
+        exclusionGroupAssignmentTarget - an assign carrying allLicensedUsersAssignmentTarget or
+        allDevicesAssignmentTarget is rejected outright. "All users" is expressed there as a group
+        assignment against Intune's well-known All Users virtual group, which is what the portal's
+        "Add all users" writes. A MAM policy protects a user's apps and has no device audience at
+        all, so All Devices has no equivalent and is reported as unsupported rather than guessed at.
+
+        'customGroup' and 'On' produce no broad target: the caller resolves group names itself.
+
+    .PARAMETER AssignTo
+        The canonical AssignTo value from Get-CIPPIntuneAssignTarget.
+
+    .PARAMETER PolicyType
+        The policy's type. Accepts either the CIPP template type ('AppProtection') or the Graph
+        collection segment ('iosManagedAppProtections'), because the two callers speak in different
+        vocabularies.
+
+    .OUTPUTS
+        PSCustomObject with:
+            Targets     - the target objects to assign, in order
+            Unsupported - a message when the requested target cannot be expressed for this policy
+                          type, otherwise $null
+            Dropped     - targets that were requested but cannot be expressed, where the rest of
+                          the request still can
+            GroupNames  - display names for any virtual group a broad target resolved to, keyed by
+                          id, so the comparison can name it instead of printing a bare GUID
+
+    .EXAMPLE
+        Get-CIPPIntuneAssignmentTarget -AssignTo 'allLicensedUsers' -PolicyType 'iosManagedAppProtections'
+
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$AssignTo,
+        [string]$PolicyType
+    )
+
+    # Intune's well-known virtual group for "all users", the only way to express it on a MAM policy.
+    $MamAllUsersGroupId = 'acacacac-9df4-4c7d-9d50-4ef0226f57a9'
+
+    $MamPolicyTypes = @(
+        'AppProtection'
+        'managedAppPolicies'
+        'iosManagedAppProtections'
+        'androidManagedAppProtections'
+        'windowsManagedAppProtections'
+        'targetedManagedAppConfigurations'
+    )
+    $IsMam = $MamPolicyTypes -contains $PolicyType
+
+    $AllUsersTarget = if ($IsMam) {
+        @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $MamAllUsersGroupId }
+    } else {
+        @{ '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget' }
+    }
+    $AllDevicesTarget = @{ '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget' }
+
+    $Targets = [System.Collections.Generic.List[object]]::new()
+    $Dropped = [System.Collections.Generic.List[string]]::new()
+    $Unsupported = $null
+
+    switch ($AssignTo) {
+        'allLicensedUsers' {
+            $Targets.Add($AllUsersTarget)
+        }
+        'AllDevices' {
+            if ($IsMam) {
+                $Unsupported = "'$PolicyType' policies protect a user's apps and have no device audience, so they cannot be assigned to All Devices. Assign to all users or to a group instead."
+            } else {
+                $Targets.Add($AllDevicesTarget)
+            }
+        }
+        'AllDevicesAndUsers' {
+            if ($IsMam) {
+                # The users half is still expressible, so honour it rather than failing the whole
+                # assignment over a target this policy type has no concept of.
+                $Dropped.Add('All Devices')
+            } else {
+                $Targets.Add($AllDevicesTarget)
+            }
+            $Targets.Add($AllUsersTarget)
+        }
+    }
+
+    # Virtual groups are not in the directory, so a lookup by id finds nothing to name them with.
+    $GroupNames = @{}
+    if ($Targets.groupId -contains $MamAllUsersGroupId) {
+        $GroupNames[$MamAllUsersGroupId] = 'All Users'
+    }
+
+    [PSCustomObject]@{
+        Targets     = @($Targets)
+        Unsupported = $Unsupported
+        Dropped     = @($Dropped)
+        GroupNames  = $GroupNames
+        IsMam       = $IsMam
+    }
+}

--- a/backend/Modules/CIPPCore/Public/Get-CIPPIntuneCompareExclusions.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPIntuneCompareExclusions.ps1
@@ -13,9 +13,11 @@ function Get-CIPPIntuneCompareExclusions {
     #>
     [CmdletBinding()]
     param(
-        # App protection templates store apps[] and deployedAppCount, but deployment
-        # strips apps and the policy read-back never returns either. Scoped because
-        # Device configs carry legitimate nested 'apps' (e.g. kiosk profiles).
+        # App protection templates store apps[], deployedAppCount and isAssigned, but
+        # deployment strips all three and the policy read-back never reproduces them -
+        # isAssigned is server state set by assigning, which the assignment compare
+        # covers on its own. Scoped because Device configs carry legitimate nested
+        # 'apps' (e.g. kiosk profiles).
         [switch]$AppProtection
     )
 
@@ -46,7 +48,7 @@ function Get-CIPPIntuneCompareExclusions {
         'assignments'
     )
     if ($AppProtection) {
-        $Exclusions = $Exclusions + @('apps', 'deployedAppCount')
+        $Exclusions = $Exclusions + @('apps', 'deployedAppCount', 'isAssigned')
     }
     $Exclusions
 }

--- a/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicy.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicy.ps1
@@ -34,6 +34,17 @@ function Get-CIPPIntunePolicy {
                 $androidPolicies = ($BulkResults | Where-Object { $_.id -eq 'AndroidPolicies' }).body.value
                 $iOSPolicies = ($BulkResults | Where-Object { $_.id -eq 'iOSPolicies' }).body.value
 
+                # Reading a concrete collection makes Graph omit @odata.type from every item, but
+                # callers need the concrete type to address the policy - its assignments live under
+                # that collection. The collection a policy came from is the authoritative answer, so
+                # record it here rather than leaving each caller to infer it from the payload.
+                foreach ($Policy in $androidPolicies) {
+                    $null = $Policy | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value '#microsoft.graph.androidManagedAppProtection' -Force
+                }
+                foreach ($Policy in $iOSPolicies) {
+                    $null = $Policy | Add-Member -MemberType NoteProperty -Name '@odata.type' -Value '#microsoft.graph.iosManagedAppProtection' -Force
+                }
+
                 if ($DisplayName) {
                     $androidPolicy = $androidPolicies | Where-Object -Property displayName -EQ $DisplayName | Sort-Object -Property lastModifiedDateTime -Descending | Select-Object -First 1
                     $iOSPolicy = $iOSPolicies | Where-Object -Property displayName -EQ $DisplayName | Sort-Object -Property lastModifiedDateTime -Descending | Select-Object -First 1

--- a/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicyAssignments.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPIntunePolicyAssignments.ps1
@@ -44,9 +44,11 @@ function Get-CIPPIntunePolicyAssignments {
         }
         'AppProtection' {
             $PlatformType = 'deviceAppManagement'
-            $OdataType = if ($ExistingPolicy) { $ExistingPolicy.'@odata.type' -replace '#microsoft.graph.', '' } else { $null }
-            if (-not $OdataType) { return $null }
-            $TypeUrl = if ($OdataType -eq 'windowsInformationProtectionPolicy') { 'windowsInformationProtectionPolicies' } else { "${OdataType}s" }
+            # App Protection spans several collections and assignments live under the concrete one.
+            # A policy read from its own collection has no @odata.type - Graph only emits it for
+            # reads through managedAppPolicies - so resolve from whatever the payload does carry.
+            $TypeUrl = if ($ExistingPolicy) { Get-CIPPAppProtectionPolicyUrl -Policy $ExistingPolicy } else { $null }
+            if (-not $TypeUrl) { return $null }
         }
         'windowsDriverUpdateProfiles' {
             $PlatformType = 'deviceManagement'

--- a/backend/Modules/CIPPCore/Public/GraphHelper/Invoke-CIPPIntuneApprovalRetry.ps1
+++ b/backend/Modules/CIPPCore/Public/GraphHelper/Invoke-CIPPIntuneApprovalRetry.ps1
@@ -1,0 +1,128 @@
+function Invoke-CIPPIntuneApprovalRetry {
+    <#
+    .SYNOPSIS
+        Completes an Intune write that was deferred by multi-admin approval.
+    .DESCRIPTION
+        Intune multi-admin approval (MAA) never performs a protected write inline. The original
+        request registers an approval request and fails, returning its id in the
+        x-msft-approval-code response header. The change only happens when the request has been
+        approved by a second, interactive admin and the caller resubmits the original request with
+        the approval code in the x-msft-approval-code header.
+
+        This function is the second half of that handshake. It polls the approval request and, once
+        approved, resubmits the write. While the request is still open it reschedules itself as a
+        hidden one-off task, so a deferred change eventually completes without anyone in CIPP having
+        to come back to it. It stops on any terminal state and after MaxAttempts checks.
+    .PARAMETER TenantFilter
+        Tenant the approval request and the original write belong to.
+    .PARAMETER ApprovalCode
+        Approval request id from the x-msft-approval-code header of the original response.
+    .PARAMETER ResourcePath
+        Graph resource path of the original request, relative to the beta endpoint - for example
+        'deviceManagement/configurationPolicies/<id>'. Only a path is accepted, never a full URL:
+        this function runs from the scheduler, so it must not be usable to call arbitrary hosts.
+    .PARAMETER Type
+        HTTP method of the original request. Defaults to DELETE.
+    .PARAMETER Attempt
+        Current check number. Managed by the reschedule - callers should leave it at the default.
+    .PARAMETER MaxAttempts
+        Number of hourly checks before giving up. Defaults to 72 - Intune expires a request that has
+        not been processed within 3 days, so there is nothing left to complete after that.
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantFilter,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[0-9a-fA-F-]{36}$')]
+        [string]$ApprovalCode,
+
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern("^[A-Za-z0-9/_.\-'()]+$")]
+        [string]$ResourcePath,
+
+        [ValidateSet('DELETE', 'POST', 'PATCH', 'PUT')]
+        [string]$Type = 'DELETE',
+
+        [int]$Attempt = 1,
+
+        [int]$MaxAttempts = 72
+    )
+
+    $Uri = 'https://graph.microsoft.com/beta/{0}' -f $ResourcePath.TrimStart('/')
+
+    try {
+        # operationApprovalRequest has no requestId property - the approval code is the entity id.
+        # The collection is read rather than the single entity so a code that turns out to be a
+        # different identifier still resolves, and so a 404 on one id cannot mask a real failure.
+        $ApprovalRequest = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/deviceManagement/operationApprovalRequests' -tenantid $TenantFilter |
+            Where-Object { $_.id -eq $ApprovalCode -or $_.requestId -eq $ApprovalCode } | Select-Object -First 1
+    } catch {
+        # A lookup failure is transient as far as we know - fall through to the reschedule so a
+        # blip does not strand an approved change.
+        Write-Warning "Could not read approval request $ApprovalCode for $TenantFilter : $($_.Exception.Message)"
+        $ApprovalRequest = $null
+    }
+
+    $Status = $ApprovalRequest.status
+
+    if ($Status -eq 'completed') {
+        $Message = "Approval request $ApprovalCode is already completed. $Type $ResourcePath needs no further action."
+        Write-LogMessage -API 'IntuneApproval' -tenant $TenantFilter -message $Message -Sev 'Info'
+        return $Message
+    }
+
+    if ($Status -eq 'approved') {
+        try {
+            $null = New-GraphPOSTRequest -uri $Uri -tenantid $TenantFilter -type $Type -AddedHeaders @{ 'x-msft-approval-code' = $ApprovalCode }
+            $Message = "Approval request $ApprovalCode was approved. $Type $ResourcePath completed."
+            Write-LogMessage -API 'IntuneApproval' -tenant $TenantFilter -message $Message -Sev 'Info'
+            return $Message
+        } catch {
+            $ErrorMessage = Get-CippException -Exception $_
+            $Message = "Approval request $ApprovalCode was approved but $Type $ResourcePath still failed: $($ErrorMessage.NormalizedError)"
+            Write-LogMessage -API 'IntuneApproval' -tenant $TenantFilter -message $Message -Sev 'Error' -LogData $ErrorMessage
+            return $Message
+        }
+    }
+
+    # The API enum spells it 'cancelled'; the Intune console says 'Canceled'. Accept both.
+    if ($Status -in @('rejected', 'cancelled', 'canceled', 'expired')) {
+        $Message = "Approval request $ApprovalCode ended in state '$Status'. $Type $ResourcePath will not be performed."
+        Write-LogMessage -API 'IntuneApproval' -tenant $TenantFilter -message $Message -Sev 'Warning'
+        return $Message
+    }
+
+    # Still open (needsApproval), or the request could not be read this time round
+    if ($Attempt -ge $MaxAttempts) {
+        $Message = "Approval request $ApprovalCode was not approved within the 3 days Intune allows before a request expires. Giving up on $Type $ResourcePath - repeat the action in CIPP to raise a fresh request."
+        Write-LogMessage -API 'IntuneApproval' -tenant $TenantFilter -message $Message -Sev 'Warning'
+        return $Message
+    }
+
+    $TaskBody = @{
+        TenantFilter  = $TenantFilter
+        Name          = "Intune approval retry: $Type $ResourcePath"
+        Command       = @{ value = 'Invoke-CIPPIntuneApprovalRetry' }
+        Parameters    = [pscustomobject]@{
+            TenantFilter = $TenantFilter
+            ApprovalCode = $ApprovalCode
+            ResourcePath = $ResourcePath
+            Type         = $Type
+            Attempt      = $Attempt + 1
+            MaxAttempts  = $MaxAttempts
+        }
+        ScheduledTime = [int64](([datetime]::UtcNow.AddHours(1)) - (Get-Date '1/1/1970')).TotalSeconds
+        Recurrence    = '0'
+        PostExecution = @{}
+        Reference     = "IntuneApproval-$ApprovalCode"
+    }
+    $null = Add-CIPPScheduledTask -Task $TaskBody -Hidden $true
+
+    $Message = "Approval request $ApprovalCode is still awaiting approval (check $Attempt of $MaxAttempts). $Type $ResourcePath will be retried in an hour."
+    Write-Information $Message
+    return $Message
+}

--- a/backend/Modules/CIPPCore/Public/New-CIPPBackupTask.ps1
+++ b/backend/Modules/CIPPCore/Public/New-CIPPBackupTask.ps1
@@ -96,7 +96,9 @@ function New-CIPPBackupTask {
         'intuneprotection' {
             Measure-CippTask -TaskName 'IntuneProtection' -EventName 'CIPP.BackupCompleted' -Script {
                 New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/deviceAppManagement/managedAppPolicies?$top=999' -tenantid $TenantFilter | ForEach-Object {
-                    New-CIPPIntuneTemplate -TenantFilter $TenantFilter -URLName 'managedAppPolicies' -ID $_.ID
+                    # The listing is the only place the concrete type is visible; without it the
+                    # capture reads back a policy that does not say which platform it is for.
+                    New-CIPPIntuneTemplate -TenantFilter $TenantFilter -URLName 'managedAppPolicies' -ID $_.ID -ODataType $_.'@odata.type'
                 }
             }
         }

--- a/backend/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
+++ b/backend/Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1
@@ -53,39 +53,21 @@ function Set-CIPPAssignedPolicy {
 
         $assignmentsList = [System.Collections.Generic.List[object]]::new()
         switch ($GroupName) {
-            'allLicensedUsers' {
-                $assignmentsList.Add(
-                    @{
-                        target = @{
-                            '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget'
-                        }
-                    }
-                )
-            }
-            'AllDevices' {
-                $assignmentsList.Add(
-                    @{
-                        target = @{
-                            '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget'
-                        }
-                    }
-                )
-            }
-            'AllDevicesAndUsers' {
-                $assignmentsList.Add(
-                    @{
-                        target = @{
-                            '@odata.type' = '#microsoft.graph.allDevicesAssignmentTarget'
-                        }
-                    }
-                )
-                $assignmentsList.Add(
-                    @{
-                        target = @{
-                            '@odata.type' = '#microsoft.graph.allLicensedUsersAssignmentTarget'
-                        }
-                    }
-                )
+            { $_ -in 'allLicensedUsers', 'AllDevices', 'AllDevicesAndUsers' } {
+                # How a broad target is expressed depends on the policy type - the MAM service
+                # behind App Protection takes only group targets. Both this and the assignment
+                # comparison resolve it through the same helper so they cannot disagree.
+                $BroadTarget = Get-CIPPIntuneAssignmentTarget -AssignTo $GroupName -PolicyType $Type
+                if ($BroadTarget.Unsupported) {
+                    Write-LogMessage -headers $Headers -API $APIName -message $BroadTarget.Unsupported -sev 'Error' -tenant $TenantFilter
+                    throw $BroadTarget.Unsupported
+                }
+                foreach ($Dropped in $BroadTarget.Dropped) {
+                    Write-LogMessage -headers $Headers -API $APIName -message "Skipped the '$Dropped' target on policy $PolicyId : '$Type' policies cannot be assigned to it. The rest of the assignment was applied." -sev 'Warning' -tenant $TenantFilter
+                }
+                foreach ($BroadAssignment in $BroadTarget.Targets) {
+                    $assignmentsList.Add(@{ target = $BroadAssignment })
+                }
             }
             'On' {
                 # Do not assign to any group - used to turn on policy without assignments
@@ -278,6 +260,10 @@ function Set-CIPPAssignedPolicy {
     } catch {
         $ErrorMessage = Get-CippException -Exception $_
         Write-LogMessage -headers $Headers -API $APIName -message "Failed to assign $GroupName to Policy $PolicyId, using Platform $PlatformType and $Type. The error is:$($ErrorMessage.NormalizedError)" -Sev 'Error' -tenant $TenantFilter -LogData $ErrorMessage
-        return "Failed to assign $GroupName to Policy $PolicyId. Error: $ErrorMessage"
+        # Throw rather than return the message. A returned string is indistinguishable from success
+        # to any caller that only watches for an exception, which is how a policy whose assignment
+        # failed still got recorded as correctly assigned. Both callers already handle a throw:
+        # Invoke-ExecAssignPolicy turns it into a 500, Set-CIPPIntunePolicy rethrows it.
+        throw "Failed to assign $GroupName to Policy $PolicyId. Error: $($ErrorMessage.NormalizedError)"
     }
 }

--- a/backend/Modules/CIPPCore/Public/Set-CIPPIntunePolicy.ps1
+++ b/backend/Modules/CIPPCore/Public/Set-CIPPIntunePolicy.ps1
@@ -13,7 +13,12 @@ function Set-CIPPIntunePolicy {
         $AssignmentFilterName,
         $AssignmentFilterType = 'include',
         [array]$ReusableSettings,
-        [int]$LevenshteinDistance = 0
+        [int]$LevenshteinDistance = 0,
+        # 'append' (default) adds the requested assignments and leaves everything else in place.
+        # 'replace' makes the policy's assignments exactly what was requested - used by callers that
+        # own the assignment, so that a comparison demanding an exact set is actually satisfiable.
+        [ValidateSet('append', 'replace')]
+        [string]$AssignmentMode = 'append'
     )
 
     $RawJSON = Get-CIPPTextReplacement -TenantFilter $TenantFilter -Text $RawJSON -EscapeForJson
@@ -26,16 +31,17 @@ function Set-CIPPIntunePolicy {
         switch ($TemplateType) {
             'AppProtection' {
                 $PlatformType = 'deviceAppManagement'
-                $TemplateType = ($RawJSON | ConvertFrom-Json).'@odata.type' -replace '#microsoft.graph.', ''
-                if ([string]::IsNullOrWhiteSpace($TemplateType)) {
-                    throw "App Protection template '$DisplayName' does not contain @odata.type, so the policy type cannot be determined. Recreate the template or re-run the template sync to include @odata.type."
-                }
                 $PolicyFile = $RawJSON | ConvertFrom-Json
+                $TemplateTypeURL = Get-CIPPAppProtectionPolicyUrl -Policy $PolicyFile
+                if (-not $TemplateTypeURL) {
+                    throw "App Protection template '$DisplayName' identifies no platform - it carries no @odata.type, no @odata.context and no platform-specific settings - so the policy type cannot be determined. Recreate the template or re-run the template sync."
+                }
                 $Null = $PolicyFile | Add-Member -MemberType NoteProperty -Name 'description' -Value $Description -Force
                 $null = $PolicyFile | Add-Member -MemberType NoteProperty -Name 'displayName' -Value $DisplayName -Force
-                $PolicyFile = $PolicyFile | Select-Object * -ExcludeProperty 'apps'
+                # Read-only properties Graph echoes back on a GET. They are carried in the template
+                # because the capture keeps the payload whole, and Graph rejects them on the way in.
+                $PolicyFile = $PolicyFile | Select-Object * -ExcludeProperty 'apps', id, createdDateTime, lastModifiedDateTime, version, '@odata.context', isAssigned, deployedAppCount
                 $RawJSON = ConvertTo-Json -InputObject $PolicyFile -Depth 20
-                $TemplateTypeURL = if ($TemplateType -eq 'windowsInformationProtectionPolicy') { 'windowsInformationProtectionPolicies' } else { "$($TemplateType)s" }
                 $CheckExististing = New-GraphGETRequest -uri "https://graph.microsoft.com/beta/$PlatformType/$TemplateTypeURL" -tenantid $TenantFilter
                 $FuzzyResult = Find-CIPPFuzzyPolicyMatch -DisplayName $DisplayName -ExistingPolicies $CheckExististing -MaxDistance $LevenshteinDistance
                 if ($FuzzyResult) {
@@ -302,12 +308,13 @@ function Set-CIPPIntunePolicy {
             Write-Host "ID is $($CreateRequest.id)"
 
             $AssignParams = @{
-                GroupName    = $AssignTo
-                PolicyId     = $CreateRequest.id
-                PlatformType = $PlatformType
-                Type         = $TemplateTypeURL
-                TenantFilter = $tenantFilter
-                ExcludeGroup = $ExcludeGroup
+                GroupName      = $AssignTo
+                PolicyId       = $CreateRequest.id
+                PlatformType   = $PlatformType
+                Type           = $TemplateTypeURL
+                TenantFilter   = $tenantFilter
+                ExcludeGroup   = $ExcludeGroup
+                AssignmentMode = $AssignmentMode
             }
 
             if ($AssignmentFilterName) {

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListIntuneApprovalRequests.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Endpoint/MEM/Invoke-ListIntuneApprovalRequests.ps1
@@ -1,0 +1,74 @@
+function Invoke-ListIntuneApprovalRequests {
+    <#
+    .FUNCTIONALITY
+        Entrypoint
+    .ROLE
+        Endpoint.MEM.Read
+    .SYNOPSIS
+        List Intune multi-admin approval requests
+    .DESCRIPTION
+        Lists the multi-admin approval (MAA) requests raised in a tenant. When an access policy protects
+        a resource type, Intune defers the change and records it here until a second administrator
+        approves it, so this is where a change made from CIPP that appears to have done nothing ends up.
+    #>
+    [CmdletBinding()]
+    param($Request, $TriggerMetadata)
+
+    $APIName = $Request.Params.CIPPEndpoint
+    $Headers = $Request.Headers
+
+    $TenantFilter = $Request.Query.tenantFilter
+    # Only return requests still waiting on a decision. Off by default so the table shows history too.
+    $PendingOnly = $Request.Query.PendingOnly -eq $true
+
+    if (-not $TenantFilter) {
+        return ([HttpResponseContext]@{
+                StatusCode = [System.Net.HttpStatusCode]::BadRequest
+                Body       = @{ Results = 'tenantFilter is required' }
+            })
+    }
+
+    try {
+        $Uri = 'https://graph.microsoft.com/beta/deviceManagement/operationApprovalRequests'
+        if ($PendingOnly) {
+            $Uri = "$($Uri)?`$filter=status eq 'needsApproval'"
+        }
+        $ApprovalRequests = New-GraphGetRequest -uri $Uri -tenantid $TenantFilter
+
+        $Results = foreach ($ApprovalRequest in $ApprovalRequests) {
+            # payloadOperation, payloadName and payload are absent from the published schema but are
+            # returned by the service, and they are the only description of what is actually held -
+            # without them a row says a change is pending but not which one.
+            #
+            # requestor/approver are identitySets that the service leaves null in practice, including
+            # for requests raised through Graph. They are projected anyway rather than dropped, so
+            # they populate on their own if Microsoft starts filling them in.
+            [PSCustomObject]@{
+                id                    = $ApprovalRequest.id
+                status                = $ApprovalRequest.status
+                operation             = $ApprovalRequest.payloadOperation
+                target                = $ApprovalRequest.payloadName
+                operationTypes        = @($ApprovalRequest.requiredOperationApprovalPolicyTypes) -join ', '
+                requestJustification  = $ApprovalRequest.requestJustification
+                approvalJustification = $ApprovalRequest.approvalJustification
+                requestedBy           = $ApprovalRequest.requestor.user.displayName ?? $ApprovalRequest.requestor.application.displayName
+                approvedBy            = $ApprovalRequest.approver.user.displayName ?? $ApprovalRequest.approver.application.displayName
+                requestDateTime       = $ApprovalRequest.requestDateTime
+                expirationDateTime    = $ApprovalRequest.expirationDateTime
+                lastModifiedDateTime  = $ApprovalRequest.lastModifiedDateTime
+                payload               = $ApprovalRequest.payload
+            }
+        }
+        $StatusCode = [System.Net.HttpStatusCode]::OK
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to list Intune approval requests: $($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $ErrorMessage
+        $Results = $ErrorMessage.NormalizedError
+        $StatusCode = [System.Net.HttpStatusCode]::InternalServerError
+    }
+
+    return ([HttpResponseContext]@{
+            StatusCode = $StatusCode
+            Body       = @($Results)
+        })
+}

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecUpdateDriftDeviation.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Standards/Invoke-ExecUpdateDriftDeviation.ps1
@@ -73,6 +73,14 @@ function Invoke-ExecUpdateDriftDeviation {
             $Deviations = $Request.Body.deviations
             $Reason = $Request.Body.reason
             $PersistentDeny = [bool]($Request.Body.persistentDeny)
+            # Intune multi-admin approval rejects any write that carries no justification header
+            # ("Header 'x-msft-approval-justification' is required to request approval"). The header is
+            # ignored on tenants and resources that do not require approval, so send it on every delete.
+            # The value must be base64 of the UTF-8 text - Intune rejects plain text outright.
+            $Justification = [string]$Reason
+            if ([string]::IsNullOrWhiteSpace($Justification)) { $Justification = 'Denied and deleted from CIPP drift review' }
+            if ($Justification.Length -gt 1024) { $Justification = $Justification.Substring(0, 1024) }
+            $Justification = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Justification))
             $Results = foreach ($Deviation in $Deviations) {
                 try {
                     $user = $request.headers.'x-ms-client-principal'
@@ -240,9 +248,47 @@ function Invoke-ExecUpdateDriftDeviation {
                         $ID = $Policy.ID
                         if ($Policy -and $URLName) {
                             Write-Host "Going to delete Policy with ID $($Policy.ID) Deviation Name is $($Deviation.standardName)"
-                            $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/$($URLName)/$($ID)" -type DELETE -tenant $TenantFilter
-                            "Deleted Policy $($ID)"
-                            Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Deleted Policy with ID $($ID)" -Sev 'Info'
+                            try {
+                                $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/$($URLName)/$($ID)" -type DELETE -tenantid $TenantFilter -AddedHeaders @{ 'x-msft-approval-justification' = $Justification }
+                                "Deleted Policy $($ID)"
+                                Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Deleted Policy with ID $($ID)" -Sev 'Info'
+                            } catch {
+                                # Multi-admin approval never deletes inline. The first call registers an approval
+                                # request, fails, and returns its id in the x-msft-approval-code header (echoed
+                                # into the error body); repeat calls while that request is open fail with "An
+                                # active Approval Request already exists" and no header. Both are pending changes
+                                # rather than failures - report them so the deletion can be tracked in Intune.
+                                $RawError = $_.Exception.Data['RawErrorBody'] ?? $_.Exception.Message
+                                $ApprovalCode = if ($RawError -match 'x-msft-approval-code["'':\\\s]*([0-9a-fA-F-]{36})') { $Matches[1] } else { $null }
+                                $ApprovalExists = $RawError -match 'active Approval Request already exists'
+                                if ($ApprovalCode) {
+                                    # Approval alone does not perform the delete - the request has to be
+                                    # resubmitted with the approval code once a second admin approves it.
+                                    # Hand that off so the deletion completes without anyone returning here.
+                                    try {
+                                        $null = Invoke-CIPPIntuneApprovalRetry -TenantFilter $TenantFilter -ApprovalCode $ApprovalCode -ResourcePath "$($URLName)/$($ID)" -Type 'DELETE'
+                                        $ApprovalText = "Approval request $ApprovalCode has been raised - CIPP will complete the deletion once another administrator approves it in Intune"
+                                    } catch {
+                                        $ApprovalText = "Approval request $ApprovalCode has been raised, but the follow-up could not be scheduled ($($_.Exception.Message)). Approve the request in Intune and repeat this action"
+                                    }
+                                    [PSCustomObject]@{
+                                        resultText = "Policy $($ID) was not deleted: this tenant requires multi-admin approval in Intune. $ApprovalText."
+                                        state      = 'warning'
+                                        copyField  = $ApprovalCode
+                                    }
+                                    Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Deletion of policy $($ID) requires multi-admin approval. $ApprovalText." -Sev 'Warning'
+                                } elseif ($ApprovalExists) {
+                                    # A request raised earlier is still open, and Intune returns no code for it,
+                                    # so there is nothing to poll against - the admin has to drive this one.
+                                    [PSCustomObject]@{
+                                        resultText = "Policy $($ID) was not deleted: an Intune multi-admin approval request for it is already open. Approve or reject it in Intune, then repeat this action."
+                                        state      = 'warning'
+                                    }
+                                    Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Deletion of policy $($ID) is already awaiting multi-admin approval in Intune." -Sev 'Warning'
+                                } else {
+                                    throw
+                                }
+                            }
                         } else {
                             "could not find policy with ID $($ID)"
                             Write-LogMessage -tenant $TenantFilter -Headers $Request.Headers -API $APINAME -message "Could not find Policy with ID $($ID) to delete for remediation" -sev 'Warning'

--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneTemplate.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardIntuneTemplate.ps1
@@ -95,7 +95,11 @@ function Invoke-CIPPStandardIntuneTemplate {
     # rather than the template's Displayname, so find them under the name they were created with.
     $PolicyName = Get-CIPPIntunePolicyName -TemplateType $TemplateType -RawJSON $RawJSON -DisplayName $displayname
 
+    # Read the assignment intent once and share it between the check and the remediation, so the two
+    # cannot disagree about what this standard manages. See Get-CIPPIntuneAssignTarget.
+    $AssignmentTarget = Get-CIPPIntuneAssignTarget -AssignTo $Settings.AssignTo
     $AssignmentsMatch = $null
+    $AssignmentDetail = $null
     try {
         $ExistingPolicy = Get-CIPPIntunePolicy -tenantFilter $Tenant -DisplayName $PolicyName -TemplateType $TemplateType -APIName 'IntuneTemplate'
     } catch {
@@ -111,14 +115,17 @@ function Invoke-CIPPStandardIntuneTemplate {
         try {
             Write-Information "Verifying assignments for tenant $Tenant"
             $ExistingAssignments = Get-CIPPIntunePolicyAssignments -PolicyId $ExistingPolicy.id -TemplateType $TemplateType -TenantFilter $Tenant -ExistingPolicy $ExistingPolicy
-            $AssignmentsMatch = Compare-CIPPIntuneAssignments -ExistingAssignments $ExistingAssignments -ExpectedAssignTo $Settings.AssignTo -ExpectedCustomGroup $Settings.customGroup -ExpectedExcludeGroup $Settings.excludeGroup -ExpectedAssignmentFilter $Settings.assignmentFilter -ExpectedAssignmentFilterType $Settings.assignmentFilterType -TenantFilter $Tenant
+            $AssignmentDetail = Compare-CIPPIntuneAssignments -ExistingAssignments $ExistingAssignments -ExpectedAssignTo $Settings.AssignTo -ExpectedCustomGroup $Settings.customGroup -ExpectedExcludeGroup $Settings.excludeGroup -ExpectedAssignmentFilter $Settings.assignmentFilter -ExpectedAssignmentFilterType $Settings.assignmentFilterType -PolicyType $TemplateType -TenantFilter $Tenant
+            # Unknown stays $null all the way through to the report; it is not a deviation.
+            $AssignmentsMatch = if ($AssignmentDetail.Unknown) { $null } else { $AssignmentDetail.Matched }
 
-            Write-Information "AssignmentsMatch for tenant $($Tenant): $AssignmentsMatch"
+            Write-Information "AssignmentsMatch for tenant $($Tenant): $AssignmentsMatch $(if ($AssignmentDetail.Reasons) { "($($AssignmentDetail.Reasons -join '; '))" })"
         } catch {
             # The policy itself read back fine, so still report on its configuration rather than
             # discarding the whole check because the assignment lookup failed.
             Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not verify assignments for Intune policy '$PolicyName'. Error: $($_.Exception.Message)" -sev 'Error'
             $AssignmentsMatch = $null
+            $AssignmentDetail = $null
         }
     }
     Write-Information "[IntuneTemplate][$Tenant] GetPolicy '$PolicyName' ($TemplateType): $([int]($sw.Elapsed - $lap).TotalMilliseconds)ms"
@@ -182,6 +189,7 @@ function Invoke-CIPPStandardIntuneTemplate {
         assignmentFilter     = $Settings.assignmentFilter
         assignmentFilterType = $Settings.assignmentFilterType
         AssignmentsMatch     = $AssignmentsMatch
+        AssignmentDetail     = $AssignmentDetail
     }
 
     if ($Settings.remediate) {
@@ -204,14 +212,49 @@ function Invoke-CIPPStandardIntuneTemplate {
                 $PolicyParams.AssignmentFilterType = $CompareResult.assignmentFilterType ?? 'include'
             }
 
+            # When the standard names an assignment target it owns the policy's assignments, and the
+            # check demands an exact set. Appending can never remove a target the template does not
+            # define, so an exact-set check against an append-only remediation is a deviation that no
+            # run can clear. Replace instead, so what is checked is what remediation delivers.
+            if ($AssignmentTarget.Managed) {
+                $PolicyParams.AssignmentMode = 'replace'
+            }
+
             # Pass fuzzy-match threshold (0 = exact only, which preserves previous behaviour)
             $PolicyParams.LevenshteinDistance = [int]($Settings.levenshteinDistance ?? 0)
 
             Set-CIPPIntunePolicy @PolicyParams
-            # Remediation succeeded — accept Graph return and update state so report reflects it
+            # The policy body is safe to accept: Set-CIPPIntunePolicy throws when Graph rejects the
+            # write, so reaching this line means the write succeeded.
             $CompareResult.compare = $null
             $CompareResult.MatchFailed = $false
-            $CompareResult.AssignmentsMatch = $true
+
+            # Assignments are not. Asserting them writes a compliant result that the skip cache in
+            # Push-CIPPStandardsList then keeps for as long as nothing else in the tenant changes, so
+            # a policy whose assignment does not actually match the standard reads as green for days
+            # and the deviation reappears out of nowhere. Read them back instead.
+            if ($Settings.verifyAssignments -eq $true -and $AssignmentTarget.Applied) {
+                $CompareResult.AssignmentsMatch = $null
+                $CompareResult.AssignmentDetail = $null
+                try {
+                    $RemediatedPolicy = Get-CIPPIntunePolicy -tenantFilter $Tenant -DisplayName $PolicyName -TemplateType $TemplateType -APIName 'IntuneTemplate'
+                    if ($RemediatedPolicy.id) {
+                        $RemediatedAssignments = Get-CIPPIntunePolicyAssignments -PolicyId $RemediatedPolicy.id -TemplateType $TemplateType -TenantFilter $Tenant -ExistingPolicy $RemediatedPolicy
+                        $CompareResult.AssignmentDetail = Compare-CIPPIntuneAssignments -ExistingAssignments $RemediatedAssignments -ExpectedAssignTo $Settings.AssignTo -ExpectedCustomGroup $Settings.customGroup -ExpectedExcludeGroup $Settings.excludeGroup -ExpectedAssignmentFilter $Settings.assignmentFilter -ExpectedAssignmentFilterType $Settings.assignmentFilterType -PolicyType $TemplateType -TenantFilter $Tenant
+                        $CompareResult.AssignmentsMatch = if ($CompareResult.AssignmentDetail.Unknown) { $null } else { $CompareResult.AssignmentDetail.Matched }
+
+                        if ($CompareResult.AssignmentsMatch -eq $false) {
+                            # Graph accepted the assign call and the result still does not match, so
+                            # the standard is asking for something deployment does not produce. Name
+                            # it: this is the only place that difference is visible.
+                            Write-LogMessage -API 'Standards' -tenant $Tenant -message "Assignments for Intune policy '$PolicyName' still do not match after remediation: $(@($CompareResult.AssignmentDetail.Reasons) -join '; ')" -sev 'Warning'
+                        }
+                    }
+                } catch {
+                    # Leave it unknown. The next report run reads the assignments again.
+                    Write-LogMessage -API 'Standards' -tenant $Tenant -message "Could not re-check assignments for Intune policy '$PolicyName' after remediation. Error: $($_.Exception.Message)" -sev 'Error'
+                }
+            }
         } catch {
             $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
             Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to create or update Intune Template $($CompareResult.displayname), Error: $ErrorMessage" -sev 'Error'
@@ -222,14 +265,21 @@ function Invoke-CIPPStandardIntuneTemplate {
     }
 
     if ($Settings.alert) {
-        $AlertObj = $CompareResult | Select-Object -Property displayname, description, compare, assignTo, excludeGroup, existingPolicyId, AssignmentsMatch
+        $AlertObj = $CompareResult | Select-Object -Property displayname, description, compare, assignTo, excludeGroup, existingPolicyId, AssignmentsMatch, AssignmentDetail
         $AssignmentsDiffer = $Settings.verifyAssignments -and ($null -ne $CompareResult.AssignmentsMatch -and -not $CompareResult.AssignmentsMatch)
         $HasDifference = $CompareResult.compare -or $AssignmentsDiffer
         if ($HasDifference) {
             $Message = if ($CompareResult.compare) {
                 "Template $($CompareResult.displayname) does not match the expected configuration."
             } elseif ($AssignmentsDiffer) {
-                "Template $($CompareResult.displayname) has incorrect assignments."
+                # Name what differs. "Incorrect assignments" against a policy whose assignment looks
+                # right in the portal is not something an operator can act on.
+                $AssignmentReason = @($CompareResult.AssignmentDetail.Reasons) -join '; '
+                if ($AssignmentReason) {
+                    "Template $($CompareResult.displayname) has incorrect assignments: $AssignmentReason"
+                } else {
+                    "Template $($CompareResult.displayname) has incorrect assignments."
+                }
             } else {
                 "Template $($CompareResult.displayname) does not match the expected configuration."
             }
@@ -259,9 +309,19 @@ function Invoke-CIPPStandardIntuneTemplate {
             isCompliant = $true
         }
 
-        if ($Settings.verifyAssignments) {
-            $CurrentValue['isAssigned'] = if ($null -ne $CompareResult.AssignmentsMatch) { $CompareResult.AssignmentsMatch } else { $false }
+        # A failed assignment lookup is unknown, not a deviation. Recording it as $false writes drift
+        # that survives every later run until the lookup next succeeds, and points the operator at a
+        # policy that was never wrong. Leave the dimension out of the comparison until it can be read.
+        if ($Settings.verifyAssignments -and $null -ne $CompareResult.AssignmentsMatch) {
+            $CurrentValue['isAssigned'] = $CompareResult.AssignmentsMatch
             $ExpectedValue['isAssigned'] = $true
+
+            # Carry the actual delta into the report. Without it the drift UI can only say the
+            # assignments differ, which is unactionable when the portal looks correct.
+            $AssignmentReason = @($CompareResult.AssignmentDetail.Reasons) -join '; '
+            if (-not $CompareResult.AssignmentsMatch -and $AssignmentReason) {
+                $CurrentValue['assignmentDifferences'] = $AssignmentReason
+            }
         }
         Set-CIPPStandardsCompareField -FieldName "standards.IntuneTemplate.$id" -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -TenantFilter $Tenant
         #Add-CIPPBPAField -FieldName "policy-$id" -FieldValue $Compare -StoreAs bool -Tenant $tenant

--- a/backend/Tests/Private/Compare-CIPPIntuneAssignments.Tests.ps1
+++ b/backend/Tests/Private/Compare-CIPPIntuneAssignments.Tests.ps1
@@ -1,0 +1,397 @@
+# Pester tests for Compare-CIPPIntuneAssignments
+#
+# The failure this guards is a drift deviation that never clears: the check asserted an exact set of
+# assignments while remediation only ever appended to them, and asserted "no include targets" for
+# every AssignTo value it did not recognise (including unset and 'Do not assign'). Both produce a
+# policy that is correctly assigned in the portal and permanently non-compliant in CIPP.
+#
+# So the rule these tests encode is: the verdict may only assert what remediation manages. Anything
+# else belongs in the reported detail, not in the boolean.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    # Minimal stub so Mock has a command to replace
+    function New-GraphGetRequest { param($uri, $tenantid, $AsApp, $ComplexFilter) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntuneAssignTarget.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntuneAssignmentTarget.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Compare-CIPPIntuneAssignments.ps1')
+
+    $script:Tenant = 'contoso.onmicrosoft.com'
+    $script:SalesId = '11111111-1111-1111-1111-111111111111'
+    $script:PilotId = '22222222-2222-2222-2222-222222222222'
+    $script:ContractorsId = '33333333-3333-3333-3333-333333333333'
+    $script:FilterId = '44444444-4444-4444-4444-444444444444'
+
+    function New-GroupAssignment {
+        param($GroupId, $FilterId, $FilterType)
+        $Target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $GroupId }
+        if ($FilterId) {
+            $Target['deviceAndAppManagementAssignmentFilterId'] = $FilterId
+            $Target['deviceAndAppManagementAssignmentFilterType'] = $FilterType
+        }
+        [PSCustomObject]@{ target = [PSCustomObject]$Target }
+    }
+
+    function New-ExclusionAssignment {
+        param($GroupId)
+        [PSCustomObject]@{
+            target = [PSCustomObject]@{
+                '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                groupId       = $GroupId
+            }
+        }
+    }
+
+    function New-BroadAssignment {
+        param($ODataType, $FilterId, $FilterType)
+        $Target = @{ '@odata.type' = $ODataType }
+        if ($FilterId) {
+            $Target['deviceAndAppManagementAssignmentFilterId'] = $FilterId
+            $Target['deviceAndAppManagementAssignmentFilterType'] = $FilterType
+        }
+        [PSCustomObject]@{ target = [PSCustomObject]$Target }
+    }
+}
+
+Describe 'Compare-CIPPIntuneAssignments' {
+    BeforeEach {
+        Mock -CommandName New-GraphGetRequest -ParameterFilter { $uri -like '*/groups?*' } -MockWith {
+            @(
+                [PSCustomObject]@{ id = $script:SalesId; displayName = 'Sales Users' }
+                [PSCustomObject]@{ id = $script:PilotId; displayName = 'Pilot Users' }
+                [PSCustomObject]@{ id = $script:ContractorsId; displayName = 'Contractors' }
+            )
+        }
+        Mock -CommandName New-GraphGetRequest -ParameterFilter { $uri -like '*assignmentFilters*' } -MockWith {
+            @([PSCustomObject]@{ id = $script:FilterId; displayName = 'Corporate iOS' })
+        }
+    }
+
+    Context 'when the standard names no assignment target' {
+        It 'does not assert anything about a policy that is assigned (<Case>)' -ForEach @(
+            @{ Case = 'AssignTo unset'; AssignTo = $null }
+            @{ Case = 'AssignTo empty'; AssignTo = '' }
+            @{ Case = "AssignTo 'Do not assign'"; AssignTo = 'On' }
+        ) {
+            # Remediation adds no include target for these, so a mismatch here is a deviation that
+            # can never be cleared. This is the regression: it used to return $false.
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId
+                New-BroadAssignment -ODataType '#microsoft.graph.allLicensedUsersAssignmentTarget'
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo $AssignTo -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeTrue
+            $Result.Reasons | Should -BeNullOrEmpty
+        }
+
+        It 'ignores exclusions in the tenant when none are configured' {
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId
+                New-ExclusionAssignment -GroupId $script:ContractorsId
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'On' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeTrue
+        }
+
+        It "still requires configured exclusions under 'Do not assign', which remediation does apply" {
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'On' -ExpectedExcludeGroup 'Contractors' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.MissingExcludeGroups.id | Should -Be $script:ContractorsId
+            $Result.Reasons -join '; ' | Should -BeLike '*Contractors*'
+        }
+
+        It 'does not assert exclusions when AssignTo is unset, because remediation never runs' {
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo '' -ExpectedExcludeGroup 'Contractors' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeTrue
+        }
+    }
+
+    Context 'custom group assignment' {
+        It 'matches when the policy is assigned to exactly the configured group' {
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeTrue
+            $Result.Reasons | Should -BeNullOrEmpty
+            $Result.Unknown | Should -BeFalse
+        }
+
+        It 'resolves comma-separated names and wildcards the same way Set-CIPPAssignedPolicy does' {
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId
+                New-GroupAssignment -GroupId $script:PilotId
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users, Pilot*' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeTrue
+        }
+
+        It 'names the group that is missing rather than just failing' {
+            $Existing = @(New-GroupAssignment -GroupId $script:PilotId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.MissingIncludeGroups.displayName | Should -Be 'Sales Users'
+            $Result.ExtraIncludeGroups.displayName | Should -Be 'Pilot Users'
+            $Result.Reasons -join '; ' | Should -BeLike '*Sales Users*'
+        }
+
+        It 'reports a configured group name that matches nothing in the tenant' {
+            # A renamed or deleted group is a common cause of a policy that looks correctly assigned
+            # but no longer matches the standard. Silently resolving to no ids made it match.
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Group That Was Renamed' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.UnresolvedGroups | Should -Be 'Group That Was Renamed'
+            $Result.Reasons -join '; ' | Should -BeLike '*matches no group*'
+        }
+
+        It 'accepts the { label, value } AssignTo shape from older templates' {
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId)
+            $AssignTo = [PSCustomObject]@{ label = 'Assign to Custom Group'; value = 'customGroup' }
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo $AssignTo -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant
+
+            $Result.Managed | Should -BeTrue
+            $Result.Matched | Should -BeTrue
+        }
+    }
+
+    Context 'broad targets' {
+        It 'matches All Users' {
+            $Existing = @(New-BroadAssignment -ODataType '#microsoft.graph.allLicensedUsersAssignmentTarget')
+
+            (Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'allLicensedUsers' -TenantFilter $script:Tenant).Matched |
+                Should -BeTrue
+        }
+
+        It 'requires both targets for AllDevicesAndUsers' {
+            $Existing = @(New-BroadAssignment -ODataType '#microsoft.graph.allDevicesAssignmentTarget')
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'AllDevicesAndUsers' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.Reasons -join '; ' | Should -BeLike '*allLicensedUsersAssignmentTarget*'
+        }
+
+        It 'matches when both targets are present' {
+            $Existing = @(
+                New-BroadAssignment -ODataType '#microsoft.graph.allDevicesAssignmentTarget'
+                New-BroadAssignment -ODataType '#microsoft.graph.allLicensedUsersAssignmentTarget'
+            )
+
+            (Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'AllDevicesAndUsers' -TenantFilter $script:Tenant).Matched |
+                Should -BeTrue
+        }
+
+        It 'reports a group assignment that the standard does not expect' {
+            $Existing = @(
+                New-BroadAssignment -ODataType '#microsoft.graph.allLicensedUsersAssignmentTarget'
+                New-GroupAssignment -GroupId $script:PilotId
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'allLicensedUsers' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.ExtraIncludeGroups.displayName | Should -Be 'Pilot Users'
+        }
+
+        It 'reports an unexpected broad target' {
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId
+                New-BroadAssignment -ODataType '#microsoft.graph.allDevicesAssignmentTarget'
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.Reasons -join '; ' | Should -BeLike '*allDevicesAssignmentTarget*'
+        }
+    }
+
+    Context 'broad targets on an App Protection policy' {
+        # Remediation cannot write an allLicensedUsers target here - the MAM service rejects it -
+        # so expecting one would be a deviation no run could ever clear.
+        BeforeAll {
+            $script:AllUsersGroupId = 'acacacac-9df4-4c7d-9d50-4ef0226f57a9'
+        }
+
+        It 'matches the group assignment remediation actually writes for all users' {
+            $Existing = @(New-GroupAssignment -GroupId $script:AllUsersGroupId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'allLicensedUsers' -PolicyType 'AppProtection' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeTrue
+            $Result.ExtraIncludeGroups | Should -BeNullOrEmpty
+        }
+
+        It 'reports the virtual group by name when it is missing' {
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments @() -ExpectedAssignTo 'allLicensedUsers' -PolicyType 'AppProtection' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.MissingIncludeGroups.displayName | Should -Be 'All Users'
+            $Result.Reasons -join '; ' | Should -Not -BeLike "*$script:AllUsersGroupId*"
+        }
+
+        It 'does not demand an allLicensedUsers target that cannot be written' {
+            $Existing = @(New-GroupAssignment -GroupId $script:AllUsersGroupId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'allLicensedUsers' -PolicyType 'iosManagedAppProtections' -TenantFilter $script:Tenant
+
+            $Result.Reasons -join '; ' | Should -Not -BeLike '*allLicensedUsersAssignmentTarget*'
+        }
+
+        It 'expects only the users half of AllDevicesAndUsers, matching what remediation applies' {
+            $Existing = @(New-GroupAssignment -GroupId $script:AllUsersGroupId)
+
+            (Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'AllDevicesAndUsers' -PolicyType 'AppProtection' -TenantFilter $script:Tenant).Matched |
+                Should -BeTrue
+        }
+
+        It 'still reports a group the standard does not expect' {
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:AllUsersGroupId
+                New-GroupAssignment -GroupId $script:PilotId
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'allLicensedUsers' -PolicyType 'AppProtection' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.ExtraIncludeGroups.displayName | Should -Be 'Pilot Users'
+        }
+    }
+
+    Context 'exclusion groups' {
+        It 'matches when the configured exclusion is present' {
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId
+                New-ExclusionAssignment -GroupId $script:ContractorsId
+            )
+
+            (Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -ExpectedExcludeGroup 'Contractors' -TenantFilter $script:Tenant).Matched |
+                Should -BeTrue
+        }
+
+        It 'reports an exclusion the standard does not define when it owns the assignment' {
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId
+                New-ExclusionAssignment -GroupId $script:PilotId
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.ExtraExcludeGroups.displayName | Should -Be 'Pilot Users'
+        }
+    }
+
+    Context 'assignment filters' {
+        It 'matches when the filter is on every include target in the expected mode' {
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId -FilterId $script:FilterId -FilterType 'include'
+                New-ExclusionAssignment -GroupId $script:ContractorsId
+            )
+
+            (Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -ExpectedExcludeGroup 'Contractors' -ExpectedAssignmentFilter 'Corporate iOS' -ExpectedAssignmentFilterType 'include' -TenantFilter $script:Tenant).Matched |
+                Should -BeTrue
+        }
+
+        It 'reports a filter applied to only some of the include targets' {
+            # Remediation stamps the filter onto every include target, so a partial application is a
+            # real difference rather than a pass.
+            $Existing = @(
+                New-GroupAssignment -GroupId $script:SalesId -FilterId $script:FilterId -FilterType 'include'
+                New-GroupAssignment -GroupId $script:PilotId
+            )
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users, Pilot Users' -ExpectedAssignmentFilter 'Corporate iOS' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.Reasons -join '; ' | Should -BeLike '*not applied to every assignment target*'
+        }
+
+        It 'reports the wrong filter mode' {
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId -FilterId $script:FilterId -FilterType 'include')
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -ExpectedAssignmentFilter 'Corporate iOS' -ExpectedAssignmentFilterType 'exclude' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.Reasons -join '; ' | Should -BeLike "*'exclude' mode*"
+        }
+
+        It 'reports a filter that does not exist in the tenant' {
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -ExpectedAssignmentFilter 'No Such Filter' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.Reasons -join '; ' | Should -BeLike '*does not exist in this tenant*'
+        }
+
+        It 'reports a filter present in the tenant that the standard does not specify' {
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId -FilterId $script:FilterId -FilterType 'include')
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.Reasons -join '; ' | Should -BeLike '*does not specify one*'
+        }
+
+        It 'treats the empty GUID as no filter' {
+            # Graph returns all-zeros rather than null on some assignment shapes; reading that as a
+            # filter would fail every unfiltered policy.
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId -FilterId '00000000-0000-0000-0000-000000000000' -FilterType 'none')
+
+            (Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant).Matched |
+                Should -BeTrue
+        }
+    }
+
+    Context 'unreadable assignments' {
+        It 'returns unknown rather than a mismatch when Graph fails' {
+            # $false here would write a drift entry that survives every later run and points at a
+            # policy that was never wrong.
+            Mock -CommandName New-GraphGetRequest -ParameterFilter { $uri -like '*/groups?*' } -MockWith {
+                throw 'Request throttled'
+            }
+            $Existing = @(New-GroupAssignment -GroupId $script:SalesId)
+
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments $Existing -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant -WarningAction SilentlyContinue
+
+            $Result.Unknown | Should -BeTrue
+            $Result.Matched | Should -BeNullOrEmpty
+            $Result.Error | Should -Be 'Request throttled'
+        }
+    }
+
+    Context 'policy with no assignments at all' {
+        It 'reports the expected group as missing' {
+            $Result = Compare-CIPPIntuneAssignments -ExistingAssignments @() -ExpectedAssignTo 'customGroup' -ExpectedCustomGroup 'Sales Users' -TenantFilter $script:Tenant
+
+            $Result.Matched | Should -BeFalse
+            $Result.MissingIncludeGroups.displayName | Should -Be 'Sales Users'
+        }
+
+        It 'matches when the standard names no target' {
+            (Compare-CIPPIntuneAssignments -ExistingAssignments @() -ExpectedAssignTo $null -TenantFilter $script:Tenant).Matched |
+                Should -BeTrue
+        }
+    }
+}

--- a/backend/Tests/Private/Get-CIPPAppProtectionPolicyUrl.Tests.ps1
+++ b/backend/Tests/Private/Get-CIPPAppProtectionPolicyUrl.Tests.ps1
@@ -1,0 +1,125 @@
+# Pester tests for Get-CIPPAppProtectionPolicyUrl.
+#
+# App Protection templates captured through a concrete Graph collection carry no @odata.type -
+# Graph only emits it for reads through the polymorphic managedAppPolicies collection - so
+# deployment used to reject them outright. These cover the order the type is resolved in.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPAppProtectionPolicyUrl.ps1')
+}
+
+Describe 'Get-CIPPAppProtectionPolicyUrl' {
+
+    Context 'from @odata.type' {
+        It 'maps <Type> to <Expected>' -ForEach @(
+            @{ Type = '#microsoft.graph.iosManagedAppProtection'; Expected = 'iosManagedAppProtections' }
+            @{ Type = '#microsoft.graph.androidManagedAppProtection'; Expected = 'androidManagedAppProtections' }
+            @{ Type = '#microsoft.graph.windowsManagedAppProtection'; Expected = 'windowsManagedAppProtections' }
+            @{ Type = '#microsoft.graph.targetedManagedAppConfiguration'; Expected = 'targetedManagedAppConfigurations' }
+            @{ Type = 'microsoft.graph.iosManagedAppProtection'; Expected = 'iosManagedAppProtections' }
+            @{ Type = 'iosManagedAppProtection'; Expected = 'iosManagedAppProtections' }
+        ) {
+            Get-CIPPAppProtectionPolicyUrl -Policy ([PSCustomObject]@{ '@odata.type' = $Type }) |
+                Should -Be $Expected
+        }
+
+        It 'pluralises <Type> correctly rather than appending an s' -ForEach @(
+            @{ Type = '#microsoft.graph.windowsInformationProtectionPolicy'; Expected = 'windowsInformationProtectionPolicies' }
+            @{ Type = '#microsoft.graph.mdmWindowsInformationProtectionPolicy'; Expected = 'mdmWindowsInformationProtectionPolicies' }
+        ) {
+            Get-CIPPAppProtectionPolicyUrl -Policy ([PSCustomObject]@{ '@odata.type' = $Type }) |
+                Should -Be $Expected
+        }
+    }
+
+    Context 'from @odata.context' {
+        It 'reads the collection out of the context of a concrete-type read' {
+            # This is the shape every template captured by CIPP through its own collection has.
+            $Policy = [PSCustomObject]@{
+                '@odata.context' = 'https://graph.microsoft.com/beta/$metadata#deviceAppManagement/iosManagedAppProtections/$entity'
+                displayName      = 'App Protection - iOS'
+            }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -Be 'iosManagedAppProtections'
+        }
+
+        It 'reads the type cast out of a polymorphic context' {
+            $Policy = [PSCustomObject]@{
+                '@odata.context' = 'https://graph.microsoft.com/beta/$metadata#deviceAppManagement/managedAppPolicies/microsoft.graph.androidManagedAppProtection/$entity'
+            }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -Be 'androidManagedAppProtections'
+        }
+
+        It 'prefers @odata.type when both are present' {
+            $Policy = [PSCustomObject]@{
+                '@odata.type'    = '#microsoft.graph.androidManagedAppProtection'
+                '@odata.context' = 'https://graph.microsoft.com/beta/$metadata#deviceAppManagement/iosManagedAppProtections/$entity'
+            }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -Be 'androidManagedAppProtections'
+        }
+
+        It 'ignores a bare managedAppPolicies context, which names no platform' {
+            $Policy = [PSCustomObject]@{
+                '@odata.context' = 'https://graph.microsoft.com/beta/$metadata#deviceAppManagement/managedAppPolicies/$entity'
+                pinRequired      = $true
+            }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'from platform-specific settings' {
+        It 'recognises an iOS policy by settings that exist nowhere else' {
+            $Policy = [PSCustomObject]@{
+                displayName          = 'App Protection - iOS'
+                pinRequired          = $true
+                faceIdBlocked        = $false
+                managedUniversalLinks = @('https://*.sharepoint.com/*')
+            }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -Be 'iosManagedAppProtections'
+        }
+
+        It 'recognises an Android policy by settings that exist nowhere else' {
+            $Policy = [PSCustomObject]@{
+                displayName         = 'App Protection - Android'
+                pinRequired         = $true
+                screenCaptureBlocked = $true
+                encryptAppData      = $true
+            }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -Be 'androidManagedAppProtections'
+        }
+
+        It 'refuses to guess when both platforms are indicated' {
+            # Deploying into the wrong collection is worse than reporting an unknown type.
+            $Policy = [PSCustomObject]@{
+                faceIdBlocked        = $false
+                screenCaptureBlocked = $true
+            }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'input handling' {
+        It 'accepts raw JSON as well as an object' {
+            $RawJSON = '{"@odata.context":"https://graph.microsoft.com/beta/$metadata#deviceAppManagement/iosManagedAppProtections/$entity","displayName":"x"}'
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $RawJSON | Should -Be 'iosManagedAppProtections'
+        }
+
+        It 'returns nothing for unparseable JSON' {
+            Get-CIPPAppProtectionPolicyUrl -Policy 'not json at all' | Should -BeNullOrEmpty
+        }
+
+        It 'returns nothing for a policy that identifies no platform' {
+            $Policy = [PSCustomObject]@{ displayName = 'Nameless'; pinRequired = $true }
+
+            Get-CIPPAppProtectionPolicyUrl -Policy $Policy | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/backend/Tests/Private/Get-CIPPIntuneAssignTarget.Tests.ps1
+++ b/backend/Tests/Private/Get-CIPPIntuneAssignTarget.Tests.ps1
@@ -1,0 +1,84 @@
+# Pester tests for Get-CIPPIntuneAssignTarget
+# This function exists to keep the assignment check and the assignment remediation reading the same
+# setting the same way. The two flags it returns decide whether a difference is assertable at all,
+# so getting them wrong reintroduces exactly the bug it was added for: a deviation that no
+# remediation run can clear.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntuneAssignTarget.ps1')
+}
+
+Describe 'Get-CIPPIntuneAssignTarget' {
+
+    Context 'targets the standard owns' {
+        It 'reports <Value> as managed and applied' -ForEach @(
+            @{ Value = 'allLicensedUsers' }
+            @{ Value = 'AllDevices' }
+            @{ Value = 'AllDevicesAndUsers' }
+            @{ Value = 'customGroup' }
+        ) {
+            $Result = Get-CIPPIntuneAssignTarget -AssignTo $Value
+
+            $Result.AssignTo | Should -Be $Value
+            $Result.Managed | Should -BeTrue
+            $Result.Applied | Should -BeTrue
+        }
+
+        It 'returns the canonical casing so callers can compare with -eq' {
+            (Get-CIPPIntuneAssignTarget -AssignTo 'alldevices').AssignTo | Should -BeExactly 'AllDevices'
+            (Get-CIPPIntuneAssignTarget -AssignTo 'CUSTOMGROUP').AssignTo | Should -BeExactly 'customGroup'
+        }
+    }
+
+    Context "'Do not assign'" {
+        It 'is applied but not managed' {
+            # Remediation still runs Set-CIPPAssignedPolicy (so exclusions and filters land) but adds
+            # no include target, and cannot remove one that is already there.
+            $Result = Get-CIPPIntuneAssignTarget -AssignTo 'On'
+
+            $Result.Managed | Should -BeFalse
+            $Result.Applied | Should -BeTrue
+        }
+    }
+
+    Context 'no target configured' {
+        It 'reports <Case> as neither applied nor managed' -ForEach @(
+            @{ Case = 'null'; Value = $null }
+            @{ Case = 'empty string'; Value = '' }
+            @{ Case = 'whitespace'; Value = '   ' }
+        ) {
+            # Set-CIPPIntunePolicy skips the assignment step entirely for these, so nothing about
+            # assignments is remediable and nothing may be asserted.
+            $Result = Get-CIPPIntuneAssignTarget -AssignTo $Value
+
+            $Result.Managed | Should -BeFalse
+            $Result.Applied | Should -BeFalse
+        }
+    }
+
+    Context 'legacy value shapes' {
+        It 'unwraps the { label, value } object older templates carry' {
+            $Result = Get-CIPPIntuneAssignTarget -AssignTo ([PSCustomObject]@{
+                    label = 'Assign to Custom Group'
+                    value = 'customGroup'
+                })
+
+            $Result.AssignTo | Should -Be 'customGroup'
+            $Result.Managed | Should -BeTrue
+        }
+
+        It 'trims surrounding whitespace' {
+            (Get-CIPPIntuneAssignTarget -AssignTo ' AllDevices ').Managed | Should -BeTrue
+        }
+
+        It 'treats an unrecognised value as applied but not managed' {
+            # Unknown means "we do not know what set of targets to expect", which must never become
+            # "expect no targets".
+            $Result = Get-CIPPIntuneAssignTarget -AssignTo 'somethingElse'
+
+            $Result.Managed | Should -BeFalse
+            $Result.Applied | Should -BeTrue
+        }
+    }
+}

--- a/backend/Tests/Private/Get-CIPPIntuneAssignmentTarget.Tests.ps1
+++ b/backend/Tests/Private/Get-CIPPIntuneAssignmentTarget.Tests.ps1
@@ -1,0 +1,102 @@
+# Pester tests for Get-CIPPIntuneAssignmentTarget.
+#
+# Intune's MAM service, which serves App Protection and managed app configuration, accepts only
+# group targets - an assign carrying allLicensedUsersAssignmentTarget or allDevicesAssignmentTarget
+# is rejected outright. This is the one place that difference is expressed, because both the
+# assignment write and the assignment comparison read it from here.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntuneAssignmentTarget.ps1')
+
+    $script:AllUsersGroupId = 'acacacac-9df4-4c7d-9d50-4ef0226f57a9'
+}
+
+Describe 'Get-CIPPIntuneAssignmentTarget' {
+
+    Context 'device management policy types' {
+        It 'uses the broad targets for <AssignTo>' -ForEach @(
+            @{ AssignTo = 'allLicensedUsers'; Expected = @('#microsoft.graph.allLicensedUsersAssignmentTarget') }
+            @{ AssignTo = 'AllDevices'; Expected = @('#microsoft.graph.allDevicesAssignmentTarget') }
+            @{ AssignTo = 'AllDevicesAndUsers'; Expected = @('#microsoft.graph.allDevicesAssignmentTarget', '#microsoft.graph.allLicensedUsersAssignmentTarget') }
+        ) {
+            $Result = Get-CIPPIntuneAssignmentTarget -AssignTo $AssignTo -PolicyType 'deviceConfigurations'
+
+            @($Result.Targets | ForEach-Object { $_.'@odata.type' }) | Should -Be $Expected
+            $Result.Unsupported | Should -BeNullOrEmpty
+            $Result.Dropped | Should -BeNullOrEmpty
+        }
+
+        It 'produces no broad target for <AssignTo>, which the caller resolves itself' -ForEach @(
+            @{ AssignTo = 'customGroup' }
+            @{ AssignTo = 'On' }
+            @{ AssignTo = '' }
+        ) {
+            $Result = Get-CIPPIntuneAssignmentTarget -AssignTo $AssignTo -PolicyType 'deviceConfigurations'
+
+            $Result.Targets | Should -BeNullOrEmpty
+            $Result.Unsupported | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'MAM policy types' {
+        It 'recognises <PolicyType> as MAM' -ForEach @(
+            @{ PolicyType = 'AppProtection' }
+            @{ PolicyType = 'managedAppPolicies' }
+            @{ PolicyType = 'iosManagedAppProtections' }
+            @{ PolicyType = 'androidManagedAppProtections' }
+            @{ PolicyType = 'windowsManagedAppProtections' }
+            @{ PolicyType = 'targetedManagedAppConfigurations' }
+        ) {
+            (Get-CIPPIntuneAssignmentTarget -AssignTo 'allLicensedUsers' -PolicyType $PolicyType).IsMam |
+                Should -BeTrue
+        }
+
+        It 'does not treat device-side app configuration as MAM' {
+            # mobileAppConfigurations targets enrolled devices and goes through device management.
+            (Get-CIPPIntuneAssignmentTarget -AssignTo 'allLicensedUsers' -PolicyType 'mobileAppConfigurations').IsMam |
+                Should -BeFalse
+        }
+
+        It 'expresses all users as a group assignment on the All Users virtual group' {
+            $Result = Get-CIPPIntuneAssignmentTarget -AssignTo 'allLicensedUsers' -PolicyType 'iosManagedAppProtections'
+
+            @($Result.Targets).Count | Should -Be 1
+            $Result.Targets[0].'@odata.type' | Should -Be '#microsoft.graph.groupAssignmentTarget'
+            $Result.Targets[0].groupId | Should -Be $script:AllUsersGroupId
+            $Result.Unsupported | Should -BeNullOrEmpty
+        }
+
+        It 'names the virtual group so it is not reported as a bare GUID' {
+            $Result = Get-CIPPIntuneAssignmentTarget -AssignTo 'allLicensedUsers' -PolicyType 'iosManagedAppProtections'
+
+            $Result.GroupNames[$script:AllUsersGroupId] | Should -Be 'All Users'
+        }
+
+        It 'reports All Devices as unsupported rather than guessing an audience' {
+            $Result = Get-CIPPIntuneAssignmentTarget -AssignTo 'AllDevices' -PolicyType 'iosManagedAppProtections'
+
+            $Result.Targets | Should -BeNullOrEmpty
+            $Result.Unsupported | Should -BeLike '*cannot be assigned to All Devices*'
+        }
+
+        It 'keeps the users half of AllDevicesAndUsers and reports the dropped half' {
+            $Result = Get-CIPPIntuneAssignmentTarget -AssignTo 'AllDevicesAndUsers' -PolicyType 'androidManagedAppProtections'
+
+            @($Result.Targets).Count | Should -Be 1
+            $Result.Targets[0].groupId | Should -Be $script:AllUsersGroupId
+            $Result.Unsupported | Should -BeNullOrEmpty
+            $Result.Dropped | Should -Be @('All Devices')
+        }
+
+        It 'emits no allLicensedUsers or allDevices target for any option' {
+            foreach ($AssignTo in 'allLicensedUsers', 'AllDevices', 'AllDevicesAndUsers') {
+                $Result = Get-CIPPIntuneAssignmentTarget -AssignTo $AssignTo -PolicyType 'iosManagedAppProtections'
+                @($Result.Targets | ForEach-Object { $_.'@odata.type' }) |
+                    Should -Not -Contain '#microsoft.graph.allLicensedUsersAssignmentTarget'
+                @($Result.Targets | ForEach-Object { $_.'@odata.type' }) |
+                    Should -Not -Contain '#microsoft.graph.allDevicesAssignmentTarget'
+            }
+        }
+    }
+}

--- a/backend/Tests/Private/Set-CIPPAssignedPolicy.Tests.ps1
+++ b/backend/Tests/Private/Set-CIPPAssignedPolicy.Tests.ps1
@@ -1,0 +1,165 @@
+# Pester tests for Set-CIPPAssignedPolicy error signalling.
+#
+# This function used to swallow every failure and return the error as a string. To a caller that
+# only watches for an exception that is indistinguishable from success, which is how a policy whose
+# assignment call failed still got recorded as correctly assigned by the Intune Template standard.
+# A failure has to reach the caller as a failure.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    # Stubs mirror the real signatures so signature drift fails loudly here.
+    function New-GraphGetRequest { [CmdletBinding()] param($uri, $tenantid, $AsApp, $ComplexFilter) }
+    function New-GraphPOSTRequest { [CmdletBinding()] param($uri, $tenantid, $type, $body) }
+    function Write-LogMessage { [CmdletBinding()] param($message, $tenant, $API, $tenantId, $headers, $user, $sev, $Sev2, $LogData) }
+    function Get-CippException { [CmdletBinding()] param($Exception) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntuneAssignmentTarget.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Set-CIPPAssignedPolicy.ps1')
+
+    $script:Tenant = 'contoso.onmicrosoft.com'
+    $script:SalesId = '11111111-1111-1111-1111-111111111111'
+    $script:AllUsersGroupId = 'acacacac-9df4-4c7d-9d50-4ef0226f57a9'
+}
+
+Describe 'Set-CIPPAssignedPolicy' {
+    BeforeEach {
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Get-CippException -MockWith {
+            [PSCustomObject]@{ NormalizedError = 'Graph said no' }
+        }
+        Mock -CommandName New-GraphGetRequest -ParameterFilter { $uri -like '*/groups?*' } -MockWith {
+            @([PSCustomObject]@{ id = $script:SalesId; displayName = 'Sales Users' })
+        }
+        Mock -CommandName New-GraphGetRequest -ParameterFilter { $uri -like '*/assignments' } -MockWith { @() }
+        Mock -CommandName New-GraphPOSTRequest -MockWith { @{} }
+    }
+
+    Context 'when the assignment succeeds' {
+        It 'returns a result message and does not throw' {
+            $Result = Set-CIPPAssignedPolicy -GroupName 'Sales Users' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant
+
+            $Result | Should -BeLike '*Successfully assigned*'
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly
+        }
+    }
+
+    Context 'when Graph rejects the assign call' {
+        It 'throws instead of returning the error as a value' {
+            Mock -CommandName New-GraphPOSTRequest -MockWith { throw 'Forbidden' }
+
+            { Set-CIPPAssignedPolicy -GroupName 'Sales Users' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant } |
+                Should -Throw -ExpectedMessage '*Failed to assign*'
+        }
+
+        It 'still writes the failure to the audit log' {
+            Mock -CommandName New-GraphPOSTRequest -MockWith { throw 'Forbidden' }
+
+            { Set-CIPPAssignedPolicy -GroupName 'Sales Users' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant } | Should -Throw
+
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $Sev -eq 'Error' }
+        }
+
+        It 'surfaces the normalized error rather than the exception object' {
+            Mock -CommandName New-GraphPOSTRequest -MockWith { throw 'Forbidden' }
+
+            { Set-CIPPAssignedPolicy -GroupName 'Sales Users' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant } |
+                Should -Throw -ExpectedMessage '*Graph said no*'
+        }
+    }
+
+    Context 'when the requested group does not exist' {
+        It 'throws rather than reporting a successful no-op' {
+            { Set-CIPPAssignedPolicy -GroupName 'Group That Was Renamed' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant } |
+                Should -Throw
+
+            Should -Invoke New-GraphPOSTRequest -Times 0 -Exactly
+        }
+    }
+
+    Context 'when existing assignments cannot be read in append mode' {
+        It 'throws rather than posting a set that would drop them' {
+            Mock -CommandName New-GraphGetRequest -ParameterFilter { $uri -like '*/assignments' } -MockWith {
+                throw 'Throttled'
+            }
+
+            { Set-CIPPAssignedPolicy -GroupName 'Sales Users' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant -AssignmentMode 'append' } |
+                Should -Throw
+
+            Should -Invoke New-GraphPOSTRequest -Times 0 -Exactly
+        }
+    }
+
+    Context 'broad targets on a device management policy' {
+        It 'sends the allLicensedUsers target' {
+            $null = Set-CIPPAssignedPolicy -GroupName 'allLicensedUsers' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                ($body | ConvertFrom-Json).assignments.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget'
+            }
+        }
+    }
+
+    Context 'broad targets on an App Protection policy' {
+        # The MAM service rejects any assign carrying a target class other than group/exclusion, so
+        # the whole assignment fails - which is how a remediated policy ended up with none at all.
+        It 'assigns all users as a group target on the All Users virtual group' {
+            $null = Set-CIPPAssignedPolicy -GroupName 'allLicensedUsers' -PolicyId 'policy-1' -Type 'iosManagedAppProtections' -PlatformType 'deviceAppManagement' -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                $Sent = ($body | ConvertFrom-Json).assignments
+                @($Sent).Count -eq 1 -and
+                $Sent.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
+                $Sent.target.groupId -eq $script:AllUsersGroupId
+            }
+        }
+
+        It 'accepts the singular type name the policy lists expose' {
+            $null = Set-CIPPAssignedPolicy -GroupName 'allLicensedUsers' -PolicyId 'policy-1' -Type 'androidManagedAppProtection' -PlatformType 'deviceAppManagement' -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                ($body | ConvertFrom-Json).assignments.target.groupId -eq $script:AllUsersGroupId
+            }
+        }
+
+        It 'refuses All Devices instead of sending a target Graph will reject' {
+            # Echo the real message rather than this file's fixed stand-in: the point of the guard
+            # is that the operator is told why, not just that something failed.
+            Mock -CommandName Get-CippException -MockWith { [PSCustomObject]@{ NormalizedError = $Exception.Exception.Message } }
+
+            { Set-CIPPAssignedPolicy -GroupName 'AllDevices' -PolicyId 'policy-1' -Type 'iosManagedAppProtections' -PlatformType 'deviceAppManagement' -TenantFilter $script:Tenant } |
+                Should -Throw -ExpectedMessage '*cannot be assigned to All Devices*'
+
+            Should -Invoke New-GraphPOSTRequest -Times 0 -Exactly
+        }
+
+        It 'applies the users half of AllDevicesAndUsers rather than failing outright' {
+            $null = Set-CIPPAssignedPolicy -GroupName 'AllDevicesAndUsers' -PolicyId 'policy-1' -Type 'iosManagedAppProtections' -PlatformType 'deviceAppManagement' -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                $Sent = ($body | ConvertFrom-Json).assignments
+                @($Sent).Count -eq 1 -and $Sent.target.groupId -eq $script:AllUsersGroupId
+            }
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $sev -eq 'Warning' -and $message -like "*'All Devices'*" }
+        }
+
+        It 'still applies exclusions alongside the translated include target' {
+            $null = Set-CIPPAssignedPolicy -GroupName 'allLicensedUsers' -ExcludeGroup 'Sales Users' -PolicyId 'policy-1' -Type 'iosManagedAppProtections' -PlatformType 'deviceAppManagement' -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                $Types = @(($body | ConvertFrom-Json).assignments.target.'@odata.type')
+                $Types -contains '#microsoft.graph.groupAssignmentTarget' -and
+                $Types -contains '#microsoft.graph.exclusionGroupAssignmentTarget'
+            }
+        }
+    }
+
+    Context 'WhatIf' {
+        It 'does not post and does not throw' {
+            $Result = Set-CIPPAssignedPolicy -GroupName 'Sales Users' -PolicyId 'policy-1' -Type 'deviceConfigurations' -TenantFilter $script:Tenant -WhatIf
+
+            $Result | Should -BeNullOrEmpty
+            Should -Invoke New-GraphPOSTRequest -Times 0 -Exactly
+        }
+    }
+}

--- a/backend/Tests/Private/Set-CIPPIntunePolicy.AppProtection.Tests.ps1
+++ b/backend/Tests/Private/Set-CIPPIntunePolicy.AppProtection.Tests.ps1
@@ -1,0 +1,121 @@
+# Pester tests for the App Protection branch of Set-CIPPIntunePolicy.
+#
+# App Protection is one CIPP template type spanning several Graph collections, so the deploy URL is
+# derived from the payload. Templates captured through a concrete collection carry no @odata.type -
+# Graph omits it there - and deployment used to reject them before it reached Graph at all.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    # Stubs mirror the real signatures so signature drift fails loudly here.
+    function New-GraphGETRequest { [CmdletBinding()] param($uri, $tenantid, $AsApp, $ComplexFilter) }
+    function New-GraphPOSTRequest { [CmdletBinding()] param($uri, $tenantid, $type, $body) }
+    function Write-LogMessage { [CmdletBinding()] param($message, $tenant, $API, $tenantId, $headers, $user, $sev, $Sev2, $LogData) }
+    function Get-CippException { [CmdletBinding()] param($Exception) }
+    function Get-CIPPTextReplacement { [CmdletBinding()] param([string]$TenantFilter, $Text, [switch]$EscapeForJson) }
+    function Set-CIPPAssignedPolicy { [CmdletBinding()] param($GroupName, $PolicyId, $PlatformType, $Type, $TenantFilter, $ExcludeGroup, $AssignmentMode, $AssignmentFilterName, $AssignmentFilterType) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPAppProtectionPolicyUrl.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Tools/Find-CIPPFuzzyPolicyMatch.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Set-CIPPIntunePolicy.ps1')
+
+    $script:Tenant = 'contoso.onmicrosoft.com'
+
+    # The shape a template captured from iosManagedAppProtections has: no @odata.type, the type
+    # recorded in @odata.context, and the read-only properties Graph echoed back on the capture.
+    $script:IosTemplate = [ordered]@{
+        '@odata.context'    = 'https://graph.microsoft.com/beta/$metadata#deviceAppManagement/iosManagedAppProtections/$entity'
+        id                  = 'T_b3ed3c06-8c16-441d-976f-537352285d50'
+        version             = '"871c2313-0000-0d00-0000-69dcdd6d0000"'
+        createdDateTime     = '2026-04-10T12:15:06.8880574Z'
+        lastModifiedDateTime = '2026-04-13T12:11:25Z'
+        isAssigned          = $true
+        deployedAppCount    = 11
+        displayName         = 'App Protection - iOS'
+        pinRequired         = $true
+        faceIdBlocked       = $false
+    } | ConvertTo-Json -Depth 10
+}
+
+Describe 'Set-CIPPIntunePolicy -TemplateType AppProtection' {
+    BeforeEach {
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Get-CIPPTextReplacement -MockWith { $Text }
+        # Mirrors the real helper: a plain throw normalises to its own message, which is how the
+        # reason reaches the standards run.
+        Mock -CommandName Get-CippException -MockWith { [PSCustomObject]@{ NormalizedError = $Exception.Exception.Message } }
+        Mock -CommandName New-GraphGETRequest -MockWith { @() }
+        Mock -CommandName New-GraphPOSTRequest -MockWith { [PSCustomObject]@{ id = 'new-policy-id' } }
+        Mock -CommandName Set-CIPPAssignedPolicy -MockWith { }
+    }
+
+    Context 'a template that records its type only in @odata.context' {
+        It 'deploys to the collection named in the context instead of throwing' {
+            $Result = Set-CIPPIntunePolicy -TemplateType 'AppProtection' -DisplayName 'App Protection - iOS' `
+                -Description 'desc' -RawJSON $script:IosTemplate -TenantFilter $script:Tenant
+
+            $Result | Should -BeLike '*Successfully added policy*'
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                $uri -eq 'https://graph.microsoft.com/beta/deviceAppManagement/iosManagedAppProtections' -and $type -eq 'POST'
+            }
+        }
+
+        It 'looks for an existing policy in the same collection' {
+            $null = Set-CIPPIntunePolicy -TemplateType 'AppProtection' -DisplayName 'App Protection - iOS' `
+                -Description 'desc' -RawJSON $script:IosTemplate -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphGETRequest -Times 1 -Exactly -ParameterFilter {
+                $uri -eq 'https://graph.microsoft.com/beta/deviceAppManagement/iosManagedAppProtections'
+            }
+        }
+
+        It 'strips the read-only properties Graph will not accept back' {
+            $null = Set-CIPPIntunePolicy -TemplateType 'AppProtection' -DisplayName 'App Protection - iOS' `
+                -Description 'desc' -RawJSON $script:IosTemplate -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                $Sent = $body | ConvertFrom-Json
+                $Names = @($Sent.PSObject.Properties.Name)
+                $Names -notcontains 'id' -and
+                $Names -notcontains 'version' -and
+                $Names -notcontains 'createdDateTime' -and
+                $Names -notcontains 'lastModifiedDateTime' -and
+                $Names -notcontains 'isAssigned' -and
+                $Names -notcontains 'deployedAppCount' -and
+                $Names -notcontains '@odata.context' -and
+                $Sent.pinRequired -eq $true -and
+                $Sent.displayName -eq 'App Protection - iOS'
+            }
+        }
+    }
+
+    Context 'a template that does carry @odata.type' {
+        It 'still uses it, and uses it in preference to the context' {
+            $RawJSON = [ordered]@{
+                '@odata.type'    = '#microsoft.graph.androidManagedAppProtection'
+                '@odata.context' = 'https://graph.microsoft.com/beta/$metadata#deviceAppManagement/managedAppPolicies/$entity'
+                displayName      = 'App Protection - Android'
+                pinRequired      = $true
+            } | ConvertTo-Json -Depth 10
+
+            $null = Set-CIPPIntunePolicy -TemplateType 'AppProtection' -DisplayName 'App Protection - Android' `
+                -Description 'desc' -RawJSON $RawJSON -TenantFilter $script:Tenant
+
+            Should -Invoke New-GraphPOSTRequest -Times 1 -Exactly -ParameterFilter {
+                $uri -eq 'https://graph.microsoft.com/beta/deviceAppManagement/androidManagedAppProtections'
+            }
+        }
+    }
+
+    Context 'a template that identifies no platform' {
+        It 'throws without calling Graph' {
+            $RawJSON = '{"displayName":"Nameless","pinRequired":true}'
+
+            { Set-CIPPIntunePolicy -TemplateType 'AppProtection' -DisplayName 'Nameless' `
+                    -Description 'desc' -RawJSON $RawJSON -TenantFilter $script:Tenant } |
+                Should -Throw -ExpectedMessage '*identifies no platform*'
+
+            Should -Invoke New-GraphPOSTRequest -Times 0 -Exactly
+        }
+    }
+}

--- a/backend/Tests/Standards/Invoke-CIPPStandardIntuneTemplate.Assignments.Tests.ps1
+++ b/backend/Tests/Standards/Invoke-CIPPStandardIntuneTemplate.Assignments.Tests.ps1
@@ -1,0 +1,201 @@
+# Pester tests for the assignment half of Invoke-CIPPStandardIntuneTemplate's remediation.
+#
+# Remediation used to stamp AssignmentsMatch = $true without reading anything back. Combined with
+# the compliant-template skip in Push-CIPPStandardsList, which drops a standard from later runs
+# while its cached result says compliant, that turned an assignment that never matched into a green
+# tick lasting until something unrelated changed in the tenant - and a deviation that then
+# reappeared for no visible reason. The remediation result has to come from a re-read.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $StandardPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-CIPPStandardIntuneTemplate.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $StandardPath) { throw 'Could not locate Invoke-CIPPStandardIntuneTemplate.ps1 under Modules/' }
+
+    # Stubs mirror the real signatures and are advanced functions on purpose: strict parameter
+    # binding makes signature drift in the standard fail loudly here.
+    function Get-CippTable { [CmdletBinding()] param($tablename) }
+    function Get-CIPPAzDataTableEntity { [CmdletBinding()] param($Table, $Filter) }
+    function Repair-CIPPIntuneTemplateNesting { [CmdletBinding()] param($Template, $Table) }
+    function Sync-CIPPReusablePolicySettings { [CmdletBinding()] param($TemplateInfo, $Tenant) }
+    function Get-CIPPTextReplacement { [CmdletBinding()] param($Text, $TenantFilter, [switch]$EscapeForJson) }
+    function Get-CIPPIntunePolicyName { [CmdletBinding()] param($TemplateType, $RawJSON, $DisplayName) }
+    function Get-CIPPIntunePolicy { [CmdletBinding()] param($TemplateType, $DisplayName, $PolicyId, $Headers, $APINAME, $tenantFilter) }
+    function Get-CIPPIntunePolicyAssignments { [CmdletBinding()] param($PolicyId, $TemplateType, $TenantFilter, $ExistingPolicy) }
+    function Compare-CIPPIntuneAssignments { [CmdletBinding()] param($ExistingAssignments, $ExpectedAssignTo, $ExpectedCustomGroup, $ExpectedExcludeGroup, $ExpectedAssignmentFilter, $ExpectedAssignmentFilterType, $PolicyType, $TenantFilter) }
+    function Merge-CIPPIntuneTemplateIdentity { [CmdletBinding()] param($Policy, $TemplateType, $DisplayName, $Description) }
+    function Select-CIPPIntuneAvailableSetting { [CmdletBinding()] param($Policy, $TenantFilter) }
+    function Compare-CIPPIntuneObject { [CmdletBinding()] param($ReferenceObject, $DifferenceObject, $compareType) }
+    function Set-CIPPIntunePolicy { [CmdletBinding()] param($TemplateType, $Description, $DisplayName, $RawJSON, $AssignTo, $ExcludeGroup, $Headers, $APIName, $TenantFilter, $AssignmentFilterName, $AssignmentFilterType, [array]$ReusableSettings, [int]$LevenshteinDistance, [string]$AssignmentMode) }
+    function Set-CIPPStandardsCompareField { [CmdletBinding()] param($FieldName, $FieldValue, $CurrentValue, $ExpectedValue, $TenantFilter, [bool]$LicenseAvailable = $true, [array]$BulkFields) }
+    function Write-LogMessage { [CmdletBinding()] param($message, $tenant, $API, $tenantId, $headers, $user, $sev, $LogData) }
+    function Write-StandardsAlert { [CmdletBinding()] param($message, $object, $tenant, $standardName, $standardId) }
+    function Get-NormalizedError { [CmdletBinding()] param($Message) $Message }
+
+    # The assignment intent helper is pure, so use the real one - its Applied/Managed semantics are
+    # exactly what decides whether the standard re-reads at all.
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPIntuneAssignTarget.ps1')
+    . $StandardPath
+
+    $script:Tenant = 'contoso.onmicrosoft.com'
+
+    function New-TemplateSettings {
+        param($AssignTo = 'customGroup', $CustomGroup = 'Sales Users', $VerifyAssignments = $true)
+        [PSCustomObject]@{
+            TemplateList      = [PSCustomObject]@{ value = 'tpl-1' }
+            AssignTo          = $AssignTo
+            customGroup       = $CustomGroup
+            verifyAssignments = $VerifyAssignments
+            remediate         = $true
+            report            = $true
+            alert             = $false
+            templateId        = 'tpl-1'
+        }
+    }
+
+    function New-AssignmentVerdict {
+        param([bool]$Matched, [bool]$Unknown, $Reasons = @())
+        [PSCustomObject]@{
+            Matched = if ($Unknown) { $null } else { $Matched }
+            Unknown = $Unknown
+            Reasons = @($Reasons)
+        }
+    }
+}
+
+Describe 'Invoke-CIPPStandardIntuneTemplate assignment remediation' {
+    BeforeEach {
+        $script:CompareFields = @()
+        $script:AssignmentReads = 0
+
+        Mock -CommandName Get-CippTable -MockWith { @{ Table = 'templates' } }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @([PSCustomObject]@{
+                    RowKey = 'tpl-1'
+                    JSON   = '{"Displayname":"iOS Restrictions","Description":"","Type":"Device","RAWJson":"{\"@odata.type\":\"#microsoft.graph.iosGeneralDeviceConfiguration\"}"}'
+                })
+        }
+        Mock -CommandName Repair-CIPPIntuneTemplateNesting -MockWith { $Template }
+        Mock -CommandName Sync-CIPPReusablePolicySettings -MockWith { [PSCustomObject]@{} }
+        Mock -CommandName Get-CIPPTextReplacement -MockWith { $Text }
+        Mock -CommandName Get-CIPPIntunePolicyName -MockWith { 'iOS Restrictions' }
+        Mock -CommandName Get-CIPPIntunePolicy -MockWith {
+            [PSCustomObject]@{ id = 'policy-1'; cippconfiguration = '{"displayName":"iOS Restrictions"}' }
+        }
+        Mock -CommandName Get-CIPPIntunePolicyAssignments -MockWith {
+            $script:AssignmentReads++
+            @()
+        }
+        Mock -CommandName Merge-CIPPIntuneTemplateIdentity -MockWith { $Policy }
+        # No difference in the policy body, so isCompliant isolates from isAssigned.
+        Mock -CommandName Compare-CIPPIntuneObject -MockWith { $null }
+        Mock -CommandName Set-CIPPIntunePolicy -MockWith { 'Successfully edited policy' }
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Write-StandardsAlert -MockWith { }
+        Mock -CommandName Set-CIPPStandardsCompareField -MockWith {
+            $script:CompareFields += @{ Current = $CurrentValue; Expected = $ExpectedValue }
+        }
+    }
+
+    Context 'when remediation manages the assignment' {
+        It 'reads the assignments back instead of asserting they are correct' {
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $false -Reasons @('Not assigned to expected group(s): Sales Users') }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings)
+
+            # Once before remediation, once after. Asserting would have read only once.
+            $script:AssignmentReads | Should -Be 2
+            Should -Invoke Compare-CIPPIntuneAssignments -Times 2 -Exactly
+        }
+
+        It 'reports the policy as unassigned when the re-read still does not match' {
+            # This is the regression: the old code recorded isAssigned = $true here.
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $false -Reasons @('Not assigned to expected group(s): Sales Users') }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings)
+
+            $script:CompareFields[0].Current.isAssigned | Should -BeFalse
+            $script:CompareFields[0].Expected.isAssigned | Should -BeTrue
+            $script:CompareFields[0].Current.assignmentDifferences | Should -BeLike '*Sales Users*'
+        }
+
+        It 'reports the policy as assigned when the re-read matches' {
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $true }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings)
+
+            $script:CompareFields[0].Current.isAssigned | Should -BeTrue
+            $script:CompareFields[0].Current.Keys | Should -Not -Contain 'assignmentDifferences'
+        }
+
+        It 'leaves the assignment unjudged when the re-read cannot be completed' {
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Unknown $true }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings)
+
+            # Neither compliant nor a deviation: the next report run reads them again.
+            $script:CompareFields[0].Current.Keys | Should -Not -Contain 'isAssigned'
+            $script:CompareFields[0].Expected.Keys | Should -Not -Contain 'isAssigned'
+        }
+
+        It 'passes replace mode so the exact-set check is satisfiable' {
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $true }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings)
+
+            Should -Invoke Set-CIPPIntunePolicy -Times 1 -Exactly -ParameterFilter { $AssignmentMode -eq 'replace' }
+        }
+    }
+
+    Context 'when the assignment call fails' {
+        It 'does not record the policy as assigned' {
+            # Set-CIPPAssignedPolicy now throws, so Set-CIPPIntunePolicy rethrows and the standard's
+            # catch runs. The pre-remediation verdict has to survive rather than becoming $true.
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $false -Reasons @('Not assigned to expected group(s): Sales Users') }
+            Mock -CommandName Set-CIPPIntunePolicy -MockWith { throw 'Failed to assign Sales Users to Policy policy-1' }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings)
+
+            $script:CompareFields[0].Current.isAssigned | Should -BeFalse
+            # The failed run must not re-read either; there is nothing new to read.
+            $script:AssignmentReads | Should -Be 1
+        }
+
+        It 'logs the failure' {
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $false }
+            Mock -CommandName Set-CIPPIntunePolicy -MockWith { throw 'Failed to assign Sales Users to Policy policy-1' }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings)
+
+            Should -Invoke Write-LogMessage -ParameterFilter { $sev -eq 'Error' -and $message -like '*Failed to create or update Intune Template*' }
+        }
+    }
+
+    Context 'when the standard names no assignment target' {
+        It 'does not re-read, because remediation never touched the assignments' {
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $true }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings -AssignTo $null -CustomGroup $null)
+
+            $script:AssignmentReads | Should -Be 1
+            $script:CompareFields[0].Current.isAssigned | Should -BeTrue
+        }
+
+        It 'does not ask for replace mode, which would wipe assignments it does not own' {
+            Mock -CommandName Compare-CIPPIntuneAssignments -MockWith { New-AssignmentVerdict -Matched $true }
+
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings -AssignTo 'On' -CustomGroup $null)
+
+            Should -Invoke Set-CIPPIntunePolicy -Times 1 -Exactly -ParameterFilter { $AssignmentMode -ne 'replace' }
+        }
+    }
+
+    Context 'when assignment verification is switched off' {
+        It 'does not read assignments and does not report on them' {
+            Invoke-CIPPStandardIntuneTemplate -Tenant $script:Tenant -Settings (New-TemplateSettings -VerifyAssignments $false)
+
+            $script:AssignmentReads | Should -Be 0
+            $script:CompareFields[0].Current.Keys | Should -Not -Contain 'isAssigned'
+        }
+    }
+}

--- a/frontend/src/data/alerts.json
+++ b/frontend/src/data/alerts.json
@@ -433,6 +433,12 @@
     "recommendedRunInterval": "1d"
   },
   {
+    "name": "IntuneApprovalRequests",
+    "label": "Alert on Intune changes waiting for multi-admin approval",
+    "recommendedRunInterval": "1d",
+    "description": "Multi-admin approval holds a protected Intune change until a second administrator approves it, and nothing notifies the requestor. This reports requests still sitting in needsApproval."
+  },
+  {
     "name": "SoftDeletedMailboxes",
     "label": "Alert on soft deleted mailboxes",
     "recommendedRunInterval": "1d"

--- a/frontend/src/layouts/config.js
+++ b/frontend/src/layouts/config.js
@@ -662,6 +662,11 @@ export const nativeMenuItems = [
             path: '/endpoint/MEM/list-scripts',
             permissions: ['Endpoint.MEM.*'],
           },
+          {
+            title: 'MAA Requests',
+            path: '/endpoint/MEM/approval-requests',
+            permissions: ['Endpoint.MEM.*'],
+          },
         ],
       },
       {

--- a/frontend/src/pages/endpoint/MEM/approval-requests/index.js
+++ b/frontend/src/pages/endpoint/MEM/approval-requests/index.js
@@ -1,0 +1,135 @@
+import { OpenInNew } from '@mui/icons-material'
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { useSettings } from '../../../../hooks/use-settings'
+import { useDialog } from '../../../../hooks/use-dialog'
+
+const Page = () => {
+  const pageTitle = 'MAA Requests'
+  const tenantFilter = useSettings().currentTenant
+  const handoffDialog = useDialog()
+
+  // This page deliberately has no row actions. Intune answers approve and reject with "Valid user
+  // identity required while Multi Admin Approval is enabled" for the delegated partner identity and
+  // for the application identity alike, and a requestor may never approve its own request - which
+  // CIPP always is. Delete is not offered either: the request is the tenant's record of a pending
+  // decision, and removing it neither applies nor cancels the change behind it. The decision has to
+  // be made by an account inside the tenant, so all this page offers is a handoff to Intune.
+  const offCanvas = {
+    extendedInfoFields: [
+      'id',
+      'status',
+      'operation',
+      'target',
+      'operationTypes',
+      'requestJustification',
+      'approvalJustification',
+      'requestedBy',
+      'approvedBy',
+      'requestDateTime',
+      'expirationDateTime',
+      'lastModifiedDateTime',
+    ],
+  }
+
+  // requestedBy and approvedBy are kept out of the table: Intune leaves the requestor and approver
+  // identity sets null, so as columns they would be dead space on every row.
+  const simpleColumns = [
+    'status',
+    'operation',
+    'target',
+    'operationTypes',
+    'requestJustification',
+    'requestDateTime',
+    'expirationDateTime',
+  ]
+
+  return (
+    <>
+      <CippTablePage
+        title={pageTitle}
+        cardButton={
+          <Button
+            startIcon={<OpenInNew />}
+            onClick={() => handoffDialog.handleOpen()}
+          >
+            Action in Intune
+          </Button>
+        }
+        tableFilter={
+          <Alert severity="info">
+            Multi-admin approval holds these changes until a second
+            administrator approves them, and the decision cannot be made from
+            CIPP. Once a request is approved, anything CIPP raised is reapplied
+            automatically. Requests expire after 3 days.
+          </Alert>
+        }
+        apiUrl="/api/ListIntuneApprovalRequests"
+        queryKey="ListIntuneApprovalRequests"
+        offCanvas={offCanvas}
+        simpleColumns={simpleColumns}
+      />
+      <Dialog
+        open={handoffDialog.open}
+        onClose={handoffDialog.handleClose}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Approvals cannot be made through CIPP</DialogTitle>
+        <DialogContent>
+          <DialogContentText component="div">
+            <p>
+              Intune rejects a multi-admin approval decision from a GDAP
+              delegated identity and from an application identity alike, so
+              neither CIPP nor any other partner tooling can approve or reject
+              these requests.
+            </p>
+            <p>
+              The decision has to come from an account signed in to the customer
+              tenant that is a member of the approver group on the access
+              policy, and it cannot be the account that raised the request.
+              Approve or reject under{' '}
+              <strong>
+                Tenant administration &gt; Multi Admin Approval &gt; Received
+                requests
+              </strong>
+              .
+            </p>
+            <p>
+              A JIT admin account may be able to fill this role, provided it is
+              added to the approver security group and that group is directly
+              assigned to an Intune RBAC role. This is untested.
+            </p>
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handoffDialog.handleClose}>Cancel</Button>
+          <Button
+            component="a"
+            href={`https://intune.microsoft.com/${tenantFilter}`}
+            target="_blank"
+            rel="noreferrer"
+            variant="contained"
+            startIcon={<OpenInNew />}
+            onClick={handoffDialog.handleClose}
+          >
+            Open Intune
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
+
+export default Page


### PR DESCRIPTION
Add end-to-end Intune multi-admin approval support: new approval-requests API and UI page, a scheduled alert for pending approvals, and retry orchestration that resubmits protected writes after approval.

Refactor Intune assignment handling to keep checks and remediation aligned by introducing shared assignment-target helpers, richer assignment comparison output, App Protection URL/type resolution, and stricter error propagation in policy assignment. Standards now re-check assignments after remediation and report actionable mismatch reasons. Includes broad new Pester coverage for assignment logic, App Protection resolution, and standards/remediation behavior.