### PR TITLE
fix(auth): resolve empty API client IP range to Any

### DIFF
--- a/backend/Modules/CIPPCore/Public/Authentication/Get-CippApiClient.ps1
+++ b/backend/Modules/CIPPCore/Public/Authentication/Get-CippApiClient.ps1
@@ -29,7 +29,7 @@ function Get-CippApiClient {
         if ($Client.IPRange) {
             try {
                 $IPRange = @($Client.IPRange | ConvertFrom-Json -ErrorAction Stop)
-                if (($IPRange | Measure-Object).Count -eq 0) { @('Any') }
+                if (($IPRange | Measure-Object).Count -eq 0) { $IPRange = @('Any') }
                 $Client.IPRange = $IPRange
             } catch {
                 $Client.IPRange = @('Any')

--- a/backend/Tests/Private/Get-CippApiClient.Tests.ps1
+++ b/backend/Tests/Private/Get-CippApiClient.Tests.ps1
@@ -1,0 +1,70 @@
+# Pester tests for Get-CippApiClient
+# Verifies IPRange normalisation. A stored empty range ("[]") must resolve to @('Any') so the
+# client is not created dead; a populated range is preserved verbatim; and both the absent-property
+# and malformed-JSON cases fall back to @('Any'). The empty case must also not leak a bare 'Any'
+# string into the function's output stream alongside the returned client objects.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Authentication/Get-CippApiClient.ps1'
+
+    # Minimal stubs so Mock has commands to replace during tests
+    function Get-CIPPTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter) }
+
+    . $FunctionPath
+}
+
+Describe 'Get-CippApiClient' {
+    BeforeEach {
+        Mock -CommandName Get-CIPPTable -MockWith { @{} }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { $script:StoredClient }
+    }
+
+    Context 'IPRange normalisation' {
+        It 'resolves a stored empty range "[]" to Any so the client is not created dead' {
+            $script:StoredClient = [PSCustomObject]@{ RowKey = 'client-1'; AppName = 'demo'; Role = $null; IPRange = '[]'; Enabled = $true; MCPAllowed = $false }
+
+            $Client = Get-CippApiClient | Where-Object { $_.ClientId -eq 'client-1' }
+
+            @($Client.IPRange).Count | Should -Be 1
+            @($Client.IPRange)[0] | Should -Be 'Any'
+        }
+
+        It 'preserves a populated range verbatim' {
+            $script:StoredClient = [PSCustomObject]@{ RowKey = 'client-1'; AppName = 'demo'; Role = $null; IPRange = '["10.0.0.0/8"]'; Enabled = $true; MCPAllowed = $false }
+
+            $Client = Get-CippApiClient | Where-Object { $_.ClientId -eq 'client-1' }
+
+            @($Client.IPRange).Count | Should -Be 1
+            @($Client.IPRange)[0] | Should -Be '10.0.0.0/8'
+        }
+
+        It 'falls back to Any when the IPRange property is absent (legacy client)' {
+            $script:StoredClient = [PSCustomObject]@{ RowKey = 'client-1'; AppName = 'demo'; Role = $null; Enabled = $true; MCPAllowed = $false }
+
+            $Client = Get-CippApiClient | Where-Object { $_.ClientId -eq 'client-1' }
+
+            @($Client.IPRange)[0] | Should -Be 'Any'
+        }
+
+        It 'falls back to Any when the stored IPRange is malformed JSON' {
+            $script:StoredClient = [PSCustomObject]@{ RowKey = 'client-1'; AppName = 'demo'; Role = $null; IPRange = '{ not valid json'; Enabled = $true; MCPAllowed = $false }
+
+            $Client = Get-CippApiClient | Where-Object { $_.ClientId -eq 'client-1' }
+
+            @($Client.IPRange)[0] | Should -Be 'Any'
+        }
+    }
+
+    Context 'Output stream integrity' {
+        It 'returns only client objects - no bare Any string leaks into the collection' {
+            $script:StoredClient = [PSCustomObject]@{ RowKey = 'client-1'; AppName = 'demo'; Role = $null; IPRange = '[]'; Enabled = $true; MCPAllowed = $false }
+
+            $Result = @(Get-CippApiClient)
+
+            $Result.Count | Should -Be 1
+            ($Result | Where-Object { $_ -is [string] }) | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
`Get-CippApiClient` means to treat an empty stored `IPRange` as unrestricted (`@('Any')`), but the guard never assigns — `@('Any')` is emitted into the enclosing `foreach` output stream, and the next line overwrites `$Client.IPRange` with the empty array the guard was meant to replace.

## Two consequences

1. **The client is denied every request.** In `Test-CIPPAccess`, an empty list satisfies `-notcontains 'Any'`, the `foreach ($Range in $Client.IPRange)` loop runs zero times, `$IPMatched` stays `$false`, and access is refused — with no distinguishing error, so it is indistinguishable from a bad secret.
2. **A phantom entry in the client list.** The function builds its result as `$Apps = foreach ($Client in $Apps) { …; $Client }`, so the dangling `@('Any')` unrolls a bare `'Any'` string into that same output stream, and the returned collection contains a stray `'Any'` element alongside the client objects (surfaced via the `List` action in `Invoke-ExecApiClient`).

## Why it survived

Any API client saved through the current form with the default `Any` chip is stored as `"[]"` — the form validates entries against a CIDR regex and `Any` is not a CIDR, so it is rejected and the field is persisted as an empty array. So **every new client saved this way is created dead**, including clients created for the MCP feature. Clients stored before this validation existed have no `IPRange` property, take the `else` branch, and are unaffected — which is why this has gone unnoticed.

## The fix

Assign the fallback instead of emitting it:

```powershell
if (($IPRange | Measure-Object).Count -eq 0) { $IPRange = @('Any') }
```

## Tests

New `backend/Tests/Private/Get-CippApiClient.Tests.ps1` (Pester 5), covering:

- stored `IPRange` of `"[]"` → `@('Any')`
- stored `IPRange` of `'["10.0.0.0/8"]'` → preserved verbatim
- `IPRange` property absent → `@('Any')` (guards the `else` branch)
- malformed JSON → `@('Any')` (guards the `catch`)
- the returned collection contains only client objects — no bare string element

Both failing cases (1 and 5 above) were reproduced against the unmodified function before the fix, then confirmed passing after.

## Testing scope

Verified by static reading and the unit tests above, run on PowerShell 7. **Not** verified against a live CIPP deployment or a real API-client authentication round-trip. The phantom-`'Any'` symptom was confirmed by running the current function with a mocked empty range, not merely inferred.
