### PR TITLE
fix(auth): derive MCP resource URIs from the app's public hostname

### DIFF
--- a/backend/Modules/CIPPCore/Public/Authentication/Set-CIPPMCPClientApp.ps1
+++ b/backend/Modules/CIPPCore/Public/Authentication/Set-CIPPMCPClientApp.ps1
@@ -20,12 +20,26 @@ function Set-CIPPMCPClientApp {
         $Headers
     )
 
-    $Hostname = $env:WEBSITE_HOSTNAME
-    if ([string]::IsNullOrWhiteSpace($Hostname)) {
-        throw 'WEBSITE_HOSTNAME is not set; cannot determine the MCP resource URL.'
+    # Register the MCP resource for every hostname bound to this instance, not just
+    # WEBSITE_HOSTNAME. WEBSITE_HOSTNAME is the platform default and, per Microsoft's docs,
+    # 'doesn't account for custom host names' - a client reaching CIPP on a custom domain derives
+    # its OAuth resource from that host, so the resource must be registered for it too or Entra
+    # rejects the token with AADSTS9010010. Get-CIPPSiteHostname is the sanctioned source (ARM
+    # properties.hostNames: the default *.azurewebsites.net name plus every bound custom domain).
+    $Hostnames = @(Get-CIPPSiteHostname)
+    if ($Hostnames.Count -eq 0) {
+        # ARM was unreachable with no usable fallback (e.g. local dev). Preserve the previous
+        # behaviour: the platform hostname, or a hard failure if even that is unavailable.
+        if ([string]::IsNullOrWhiteSpace($env:WEBSITE_HOSTNAME)) {
+            throw 'Could not resolve any hostname for this instance (WEBSITE_HOSTNAME is unset and ARM discovery returned nothing); cannot determine the MCP resource URL.'
+        }
+        $Hostnames = @($env:WEBSITE_HOSTNAME)
     }
 
-    $McpUris = @("https://$Hostname", "https://$Hostname/api/ExecMcp")
+    $McpUris = foreach ($Hostname in $Hostnames) {
+        "https://$Hostname"
+        "https://$Hostname/api/ExecMcp"
+    }
 
     $App = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/applications(appId='$AppId')" -NoAuthCheck $true -AsApp $true
     if (-not $App) {

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecApiClient.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ExecApiClient.ps1
@@ -221,13 +221,23 @@ function Invoke-ExecApiClient {
                 Set-CippApiAuth -RGName $RGName -FunctionAppName $FunctionAppName -TenantId $TenantId -ClientIds $ClientIds -McpClientIds $McpClientIds
 
                 if ($McpClientIds.Count -gt 0 -and $env:WEBSITE_HOSTNAME) {
+                    # Advertise the MCP resource scope for every hostname bound to this instance,
+                    # not just WEBSITE_HOSTNAME. WEBSITE_HOSTNAME is the platform default and does
+                    # not account for custom domains; a client reaching CIPP on a custom domain
+                    # derives its OAuth resource from that host, so advertising only the default
+                    # host's scope makes Entra reject with AADSTS9010010 on custom domains.
+                    # WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES accepts a comma-separated scope list
+                    # (per Microsoft's App Service MCP-auth docs), so list every bound hostname.
+                    $McpHostnames = @(Get-CIPPSiteHostname)
+                    if ($McpHostnames.Count -eq 0) { $McpHostnames = @($env:WEBSITE_HOSTNAME) }
+                    $McpScopes = @($McpHostnames | ForEach-Object { "https://$_/user_impersonation" })
+                    $McpScopeSetting = $McpScopes -join ','
                     if ($env:CIPPNG) {
                         $TenantedLogin = "https://login.microsoftonline.com/$($env:TenantID)"
-                        $McpScope = "https://$($env:WEBSITE_HOSTNAME)/user_impersonation"
                         $PrmDocument = [ordered]@{
                             resource                 = '{origin}/api/ExecMcp'
                             authorization_servers    = @('{origin}')
-                            scopes_supported         = @($McpScope)
+                            scopes_supported         = $McpScopes
                             bearer_methods_supported = @('header')
                         } | ConvertTo-Json -Compress
                         $AsDocument = [ordered]@{
@@ -241,11 +251,11 @@ function Invoke-ExecApiClient {
                             grant_types_supported                 = @('authorization_code', 'refresh_token')
                             code_challenge_methods_supported      = @('S256')
                             token_endpoint_auth_methods_supported = @('none', 'client_secret_post', 'client_secret_basic')
-                            scopes_supported                      = @('openid', 'profile', 'offline_access', $McpScope)
+                            scopes_supported                      = @('openid', 'profile', 'offline_access') + $McpScopes
                         } | ConvertTo-Json -Compress
-                        $null = Update-CIPPAzFunctionAppSetting -Name $FunctionAppName -ResourceGroupName $RGName -AppSetting @{ 'CRAFT_PRM' = "$PrmDocument"; 'CRAFT_PRM_AS' = "$AsDocument"; 'WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES' = $McpScope }
+                        $null = Update-CIPPAzFunctionAppSetting -Name $FunctionAppName -ResourceGroupName $RGName -AppSetting @{ 'CRAFT_PRM' = "$PrmDocument"; 'CRAFT_PRM_AS' = "$AsDocument"; 'WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES' = $McpScopeSetting }
                     } else {
-                        $null = Update-CIPPAzFunctionAppSetting -Name $FunctionAppName -ResourceGroupName $RGName -AppSetting @{ 'WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES' = "https://$($env:WEBSITE_HOSTNAME)/user_impersonation" }
+                        $null = Update-CIPPAzFunctionAppSetting -Name $FunctionAppName -ResourceGroupName $RGName -AppSetting @{ 'WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES' = $McpScopeSetting }
                     }
                 } else {
                     $null = Update-CIPPAzFunctionAppSetting -Name $FunctionAppName -ResourceGroupName $RGName -AppSetting @{} -RemoveKeys @('WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES', 'CRAFT_PRM', 'CRAFT_PRM_AS')

--- a/backend/Tests/Private/Set-CIPPMCPClientApp.Tests.ps1
+++ b/backend/Tests/Private/Set-CIPPMCPClientApp.Tests.ps1
@@ -1,0 +1,73 @@
+# Pester tests for Set-CIPPMCPClientApp
+# Verifies that the MCP resource is registered for every hostname bound to the instance (default
+# *.azurewebsites.net plus custom domains, sourced from Get-CIPPSiteHostname), that existing
+# identifier URIs are preserved (additive - no working connector breaks on upgrade), and that the
+# previous WEBSITE_HOSTNAME behaviour is kept as a fallback when ARM discovery returns nothing.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Authentication/Set-CIPPMCPClientApp.ps1'
+
+    # Minimal stubs so Mock has commands to replace during tests
+    function Get-CIPPSiteHostname { }
+    function New-GraphGetRequest { param($uri, $NoAuthCheck, $AsApp) }
+    function New-GraphPOSTRequest { param($uri, $type, $body, $NoAuthCheck, $asapp) }
+    function Get-CippMcpKnownClients { }
+    function Write-LogMessage { param($headers, $API, $message, $Sev) }
+
+    . $FunctionPath
+}
+
+Describe 'Set-CIPPMCPClientApp' {
+    BeforeEach {
+        $script:PatchBody = $null
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Get-CippMcpKnownClients -MockWith {
+            [PSCustomObject]@{
+                PreAuthorizedClientIds   = @()
+                PublicClientRedirectUris = @()
+                ConfidentialRedirectUris = @()
+            }
+        }
+        Mock -CommandName New-GraphGetRequest -MockWith {
+            [PSCustomObject]@{
+                id             = 'object-1'
+                identifierUris = @('api://app-1')
+                api            = $null
+                web            = [PSCustomObject]@{ redirectUris = @('https://inst.azurewebsites.net/.auth/login/aad/callback') }
+                spa            = [PSCustomObject]@{ redirectUris = @() }
+                publicClient   = [PSCustomObject]@{ redirectUris = @() }
+            }
+        }
+        # Capture the PATCH body the function would send to Graph
+        Mock -CommandName New-GraphPOSTRequest -MockWith { $script:PatchBody = $body }
+    }
+
+    It 'registers MCP identifier URIs for every bound hostname, preserving existing ones' {
+        Mock -CommandName Get-CIPPSiteHostname -MockWith { @('inst.azurewebsites.net', 'cipp.example.com') }
+
+        Set-CIPPMCPClientApp -AppId 'app-1' -Confirm:$false
+
+        $Uris = @(($script:PatchBody | ConvertFrom-Json).identifierUris)
+        $Uris | Should -Contain 'api://app-1'                                  # existing preserved (additive)
+        $Uris | Should -Contain 'https://inst.azurewebsites.net'               # default host
+        $Uris | Should -Contain 'https://inst.azurewebsites.net/api/ExecMcp'
+        $Uris | Should -Contain 'https://cipp.example.com'                     # custom domain
+        $Uris | Should -Contain 'https://cipp.example.com/api/ExecMcp'
+    }
+
+    It 'falls back to WEBSITE_HOSTNAME when ARM discovery returns nothing' {
+        Mock -CommandName Get-CIPPSiteHostname -MockWith { @() }
+        $OldHost = $env:WEBSITE_HOSTNAME
+        $env:WEBSITE_HOSTNAME = 'fallback.azurewebsites.net'
+        try {
+            Set-CIPPMCPClientApp -AppId 'app-1' -Confirm:$false
+
+            $Uris = @(($script:PatchBody | ConvertFrom-Json).identifierUris)
+            $Uris | Should -Contain 'https://fallback.azurewebsites.net'
+            $Uris | Should -Contain 'https://fallback.azurewebsites.net/api/ExecMcp'
+        } finally {
+            $env:WEBSITE_HOSTNAME = $OldHost
+        }
+    }
+}


### PR DESCRIPTION
> **Draft** — opening this to ask a question as much as to propose a patch (see *Questions for maintainers* below).

## Problem

CIPP derives the MCP OAuth resource from `$env:WEBSITE_HOSTNAME` in two places — the identifier URIs on the API-client app registration (`Set-CIPPMCPClientApp`) and the PRM scope app setting (`Invoke-ExecApiClient`, the `SaveToAzure` branch). Microsoft documents `WEBSITE_HOSTNAME` as: *"Read-only. Primary host name for the app. This setting doesn't account for custom host names."* ([app-settings reference](https://learn.microsoft.com/azure/app-service/reference-app-settings#app-environment)).

The OAuth `resource` an MCP client requests is derived from the **request Host header**. On a deployment reached via a custom domain, that host never equals `WEBSITE_HOSTNAME`, so the advertised resource/scope never matches what the client requests, and Entra rejects the token exchange with **AADSTS9010010** (*"The resource parameter provided in the request doesn't match with the requested scopes"*) — the exact error the code comment on that line says it exists to clear. Connecting via `<instance>.azurewebsites.net` works; connecting via the custom domain fails.

## Approach — reuse the existing resolver, additive

The repo already has `Get-CIPPSiteHostname`, which queries ARM `properties.hostNames` (the default `*.azurewebsites.net` name **plus every bound custom domain**), falls back to `WEBSITE_HOSTNAME` when ARM is unreachable, and returns empty in local dev so callers no-op. Its own docstring says *"Anything that writes redirectUris should source them from here rather than from a single 'current' URL."* This change sources the MCP resource hostnames from it too, rather than adding a new resolver.

- **`Set-CIPPMCPClientApp`** — build identifier URIs for **every** bound hostname (`https://<host>` and `https://<host>/api/ExecMcp`). The function already merges identifier URIs, so this is **additive**: existing URIs (including `api://<appId>` and the current default-host URIs) are preserved, so no already-working connector breaks on upgrade. Falls back to `WEBSITE_HOSTNAME` if the resolver returns nothing.
- **`Invoke-ExecApiClient` (`SaveToAzure`)** — set `WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES` to the **comma-separated** list of `https://<host>/user_impersonation` for every bound hostname, and list them all in the PRM/AS `scopes_supported`. Microsoft's [App Service MCP-auth doc](https://learn.microsoft.com/azure/app-service/configure-authentication-mcp) confirms this setting takes *"a comma-separated list of scopes,"* so advertising every hostname's scope resolves the mismatch regardless of which domain the client arrives on. (The PRM `resource`/`authorization_servers` already use `{origin}` placeholders, so they were already domain-correct.)

**Behaviour is unchanged for deployments with no custom domain** — `Get-CIPPSiteHostname` returns just the default host, producing the same URIs/scope as today.

## Known gap the maintainers should weigh in on

Even with the resource/scope fixed, the Function App's EasyAuth `allowedAudiences` are also built from `WEBSITE_HOSTNAME` (in `Set-CippApiAuth`/`Initialize-CIPPAuth`), so a token whose audience is the custom-domain resource would still fail validation. I deliberately left that out to keep this PR small and reviewable — see the questions below.

## Questions for maintainers

1. **Is this auth path stable enough to patch, or is it being replaced in the Web Apps migration?** The v10.7.0 notes describe moving onto Azure Web Apps with a "next generation" in progress. Happy to rework, expand, or close if it's being rewritten.
2. Should the `allowedAudiences` derivation (`Set-CippApiAuth`) move onto `Get-CIPPSiteHostname` in this PR, or land separately?
3. Which MCP client was the PRM flow verified against, and was it tested on a custom domain?

## Tests

`backend/Tests/Private/Set-CIPPMCPClientApp.Tests.ps1` (Pester 5): asserts identifier URIs are registered for every bound hostname and existing URIs are preserved (additive), plus the `WEBSITE_HOSTNAME` fallback path.

## Testing scope

Verified by static reading, the unit test above (PowerShell 7), and confirmation of the `WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES` format from Microsoft's docs. **Not** verified end-to-end against a live custom-domain deployment with a real OAuth round-trip — I don't have one. `Invoke-ExecApiClient` (an HTTP entrypoint) is not unit-tested here; only `Set-CIPPMCPClientApp` is.
