### PR TITLE
test: add require-context polyfill to jsdom env, add breadcrumb test

### DIFF
--- a/frontend/tests/components/CippComponents/CippBreadcrumbNav.test.jsx
+++ b/frontend/tests/components/CippComponents/CippBreadcrumbNav.test.jsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../test-utils'
+import { CippBreadcrumbNav } from '../../../src/components/CippComponents/CippBreadcrumbNav'
+
+// second require.context consumer, this one globs every pages/**/tabOptions.json. covers the
+// subdirectory + regex arms of the polyfill that the tutorial glob (flat, no subdirs) doesn't.
+// 'Groups' only reaches the trail through src/pages/tenant/administration/tenants/tabOptions.json
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/tenant/administration/tenants/groups',
+    asPath: '/tenant/administration/tenants/groups',
+    query: {},
+    isReady: true,
+    push: () => Promise.resolve(),
+    replace: () => Promise.resolve(),
+    events: { on: () => {}, off: () => {}, emit: () => {} },
+  }),
+}))
+
+describe('CippBreadcrumbNav', () => {
+  it('labels the tab crumb from the tabOptions require.context', () => {
+    renderWithProviders(<CippBreadcrumbNav />)
+
+    expect(screen.getByLabelText('page hierarchy')).toBeInTheDocument()
+    expect(screen.getByText('Groups')).toBeInTheDocument()
+  })
+})

--- a/frontend/tests/contexts/tutorial-context.test.jsx
+++ b/frontend/tests/contexts/tutorial-context.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { TutorialProvider, useTutorials } from '../../src/contexts/tutorial-context'
+
+// TutorialProvider loads its tours through webpack's require.context, which vite has no
+// equivalent for. tests/mocks/require-context.js maps it onto import.meta.glob, so this
+// render is what proves the polyfill actually reaches a src module.
+const TutorialProbe = () => {
+  const { tutorials, getTutorialsForPage } = useTutorials()
+  return (
+    <>
+      <div data-testid="ids">{tutorials.map((t) => t.id).join(',')}</div>
+      <div data-testid="home">{getTutorialsForPage('/').map((t) => t.id).join(',')}</div>
+    </>
+  )
+}
+
+describe('TutorialProvider', () => {
+  it('loads the tutorial json off require.context', () => {
+    render(
+      <TutorialProvider>
+        <TutorialProbe />
+      </TutorialProvider>
+    )
+
+    const ids = screen.getByTestId('ids').textContent.split(',')
+    expect(ids).toEqual(
+      expect.arrayContaining(['getting-started', 'dashboard-overview', 'tenant-management'])
+    )
+  })
+
+  it('scopes tutorials to the page they declare', () => {
+    render(
+      <TutorialProvider>
+        <TutorialProbe />
+      </TutorialProvider>
+    )
+
+    // getting-started declares pages: ['/'], the other two declare other routes
+    expect(screen.getByTestId('home').textContent).toBe('getting-started')
+  })
+})

--- a/frontend/vitest.config.mjs
+++ b/frontend/vitest.config.mjs
@@ -17,6 +17,23 @@ const nextAliases = {
   'next/link': path.resolve(dirname, 'tests/mocks/next-link.js'),
 }
 
+// vitest gives every module its own cjs `require`, which shadows the globalThis polyfill in
+// tests/mocks/require-context.js. jsdom only - the browser project has no local require
+const requireContextPlugin = {
+  name: 'cipp-require-context',
+  enforce: 'pre',
+  transform(code, id) {
+    if (id.includes('/node_modules/') || !code.includes('require.context(')) {
+      return null
+    }
+    // lookbehind so an already-prefixed call isn't rewritten to globalThis.globalThis.require
+    return {
+      code: code.replace(/(?<![.\w$])require\.context\(/g, 'globalThis.require.context('),
+      map: null,
+    }
+  },
+}
+
 export default defineConfig({
   esbuild: {
     jsx: 'automatic',
@@ -38,6 +55,7 @@ export default defineConfig({
     },
     projects: [
       {
+        plugins: [requireContextPlugin],
         resolve: { alias: nextAliases },
         define: { 'process.env': '{}' },
         esbuild: {


### PR DESCRIPTION
jsdom test env doesn't have `require.context`, add polyfill and tests demonstrating it

related #187 and #189 