### PR TITLE
fix(frontend): fix side-nav SwipeableDrawer bugs on mobile

### DIFF
--- a/frontend/src/components/CippComponents/CippBottomSheet.jsx
+++ b/frontend/src/components/CippComponents/CippBottomSheet.jsx
@@ -1,4 +1,5 @@
 import { Box, SwipeableDrawer, Typography } from "@mui/material";
+import { useSwipeCloseTransition } from "../../hooks/use-swipe-close-transition";
 
 // SwipeableDrawer requires onOpen; these sheets are only ever opened programmatically.
 const noop = () => {};
@@ -8,18 +9,19 @@ const noop = () => {};
 export const CippBottomSheet = (props) => {
   const { open, onClose, title, children, footer, onExited, SlideProps, ModalProps, ...other } =
     props;
+  const swipeClose = useSwipeCloseTransition(open, onClose);
   return (
     <SwipeableDrawer
       anchor="bottom"
       open={open}
-      onClose={onClose}
+      onClose={swipeClose.onClose}
       onOpen={noop}
       disableSwipeToOpen
       ModalProps={{
         keepMounted: false,
         ...ModalProps,
       }}
-      SlideProps={{ ...SlideProps, onExited }}
+      SlideProps={{ ...SlideProps, ...swipeClose.transitionProps, onExited }}
       sx={{ zIndex: (theme) => theme.zIndex.modal + 1 }}
       PaperProps={{
         sx: {

--- a/frontend/src/hooks/use-swipe-close-transition.js
+++ b/frontend/src/hooks/use-swipe-close-transition.js
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef } from "react";
+
+// Slide probes the paper's untranslated position when the exit starts (Slide.js
+// getTranslateValue), so a paper carrying a drag transform snaps wide open and animates the
+// full width out. Re-seed the start position with where the finger let go.
+export const useSwipeCloseTransition = (open, onClose) => {
+  const paperRef = useRef(null);
+  const dragFrom = useRef(null);
+
+  // fires as the open transition starts, so a drag that begins mid-animation still has the node
+  const handleEnter = useCallback((node) => {
+    paperRef.current = node;
+  }, []);
+
+  const handleClose = useCallback(
+    (...args) => {
+      const transform = paperRef.current?.style.transform;
+      dragFrom.current = transform && transform !== "none" ? transform : null;
+      onClose?.(...args);
+    },
+    [onClose]
+  );
+
+  // Effects flush child-first, so this lands after Slide's own exit effect, which runs the same
+  // probe again. Repairing from the transition's onExit callback gets overwritten by it.
+  useEffect(() => {
+    const node = paperRef.current;
+    const from = dragFrom.current;
+    dragFrom.current = null;
+    if (open || !node || !from) {
+      return;
+    }
+    const target = node.style.transform;
+    const transition = node.style.transition;
+    node.style.transition = "none";
+    node.style.transform = from;
+    node.getBoundingClientRect();
+    node.style.transition = transition;
+    node.style.transform = target;
+  }, [open]);
+
+  return {
+    onClose: handleClose,
+    transitionProps: { onEnter: handleEnter },
+  };
+};

--- a/frontend/src/layouts/mobile-nav.js
+++ b/frontend/src/layouts/mobile-nav.js
@@ -11,6 +11,7 @@ import { paths } from "../paths";
 import { MobileNavItem } from "./mobile-nav-item";
 import { SideNavBookmarks } from "./side-nav-bookmarks";
 import { useSettings } from "../hooks/use-settings";
+import { useSwipeCloseTransition } from "../hooks/use-swipe-close-transition";
 
 // 80% of the viewport truncated third-level labels at 320px (256px) and was absurd at
 // 899px (719px). Cap it like a real nav drawer.
@@ -111,6 +112,7 @@ export const MobileNav = (props) => {
   const { open, onClose, onOpen, items } = props;
   const pathname = usePathname();
   const settings = useSettings();
+  const swipeClose = useSwipeCloseTransition(open, onClose);
   const [search, setSearch] = useState("");
   const showSidebarBookmarks = settings.bookmarkSidebar !== false;
 
@@ -123,9 +125,15 @@ export const MobileNav = (props) => {
   return (
     <SwipeableDrawer
       anchor="left"
-      onClose={onClose}
+      // MUI's default is `iOS`, so everywhere else a 20px fixed strip covers the left edge.
+      // A touch on it flips maybeSwiping (modal opens), and with no touchmove the end handler
+      // bails before onOpen/onClose, so the drawer animates in and back out. Swipe-to-close on
+      // the open drawer is a separate path and still works.
+      disableSwipeToOpen
+      onClose={swipeClose.onClose}
       onOpen={onOpen ?? (() => {})}
       open={open}
+      slotProps={{ transition: swipeClose.transitionProps }}
       PaperProps={{
         sx: {
           width: MOBILE_NAV_WIDTH,

--- a/frontend/tests/components/CippComponents/CippBottomSheet.stories.jsx
+++ b/frontend/tests/components/CippComponents/CippBottomSheet.stories.jsx
@@ -185,7 +185,22 @@ export const DragHandleDismisses = {
       fire('touchmove', from + dy)
       await tick()
     }
+    const draggedTo = new DOMMatrixReadOnly(getComputedStyle(paper).transform).m42
+    expect(draggedTo).toBeGreaterThan(100)
     fire('touchend', from + 260)
+
+    // The exit has to continue from where the finger let go. Slide probes the paper's
+    // untranslated position when the exit starts (Slide.js getTranslateValue), and the browser
+    // takes that probe as the transition's start, which puts the sheet back at full height for
+    // the length of the close.
+    const firstExitFrame = await new Promise((resolve) => {
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() =>
+          resolve(new DOMMatrixReadOnly(getComputedStyle(paper).transform).m42)
+        )
+      )
+    })
+    expect(firstExitFrame).toBeGreaterThan(draggedTo * 0.6)
 
     await waitFor(() => expect(body.queryByText('Reset password')).not.toBeInTheDocument())
   },

--- a/frontend/tests/layouts/MobileNav.stories.jsx
+++ b/frontend/tests/layouts/MobileNav.stories.jsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react'
+import { within, expect, userEvent, waitFor } from 'storybook/test'
+import { Box, Button } from '@mui/material'
+import { MobileNav } from '../../src/layouts/mobile-nav'
+import { shrinkToPhoneViewport } from '../viewport'
+
+const items = [
+  { title: 'Dashboard', path: '/' },
+  {
+    title: 'Identity Management',
+    path: '/identity',
+    items: [
+      { title: 'Users', path: '/identity/administration/users' },
+      { title: 'Groups', path: '/identity/administration/groups' },
+      { title: 'Devices', path: '/identity/administration/devices' },
+    ],
+  },
+  {
+    title: 'Tenant Administration',
+    path: '/tenant',
+    items: [
+      { title: 'Tenants', path: '/tenant/administration/tenants' },
+      { title: 'Alerts', path: '/tenant/administration/alert-configuration' },
+    ],
+  },
+  { title: 'Tools', path: '/tools' },
+  { title: 'Settings', path: '/cipp/settings' },
+]
+
+// Mirrors the open/close state Layout owns (layouts/index.js useMobileNav), so the drawer
+// behaves here exactly as it does in the app.
+const Harness = (props) => {
+  const [open, setOpen] = useState(false)
+  return (
+    <Box sx={{ p: 2 }}>
+      <Button variant="contained" data-testid="open-nav" onClick={() => setOpen(true)}>
+        Open nav
+      </Button>
+      <MobileNav
+        items={items}
+        open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
+        {...props}
+      />
+    </Box>
+  )
+}
+
+export default {
+  title: 'Layouts/MobileNav',
+  component: MobileNav,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export const Default = {
+  render: () => <Harness />,
+}
+
+// Only a real browser can settle this: jsdom runs no transitions, so the frame the close
+// animation starts from does not exist there.
+export const DragClosesFromWhereItWasLeft = {
+  render: () => <Harness />,
+  play: async ({ canvasElement }) => {
+    const onAPhone = await shrinkToPhoneViewport()
+    const canvas = within(canvasElement)
+
+    await userEvent.click(canvas.getByTestId('open-nav'))
+    const paper = await waitFor(() => {
+      const node = document.querySelector('.MuiDrawer-paper')
+      expect(node).not.toBeNull()
+      return node
+    })
+    if (!onAPhone) {
+      return
+    }
+    await waitFor(() =>
+      expect(new DOMMatrixReadOnly(getComputedStyle(paper).transform).m41).toBe(0)
+    )
+
+    // Dispatched on a node inside the paper and left to bubble: MUI reads event.target to
+    // decide the gesture started in the drawer, so firing at the document bails immediately.
+    const target = paper.querySelector('nav') ?? paper
+    const at = (clientX) =>
+      new Touch({ identifier: 1, target, clientX, clientY: 400, pageX: clientX, pageY: 400 })
+    const fire = (type, clientX) =>
+      target.dispatchEvent(
+        new TouchEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          touches: type === 'touchend' ? [] : [at(clientX)],
+          changedTouches: [at(clientX)],
+        })
+      )
+
+    // MUI flags "maybe swiping" in React state on touchstart and ignores moves until that has
+    // been applied, so the gesture has to be spread across ticks like a real one.
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 30))
+    fire('touchstart', 300)
+    await tick()
+    for (const x of [285, 230, 160, 80, 40]) {
+      fire('touchmove', x)
+      await tick()
+    }
+
+    const draggedTo = new DOMMatrixReadOnly(getComputedStyle(paper).transform).m41
+    expect(draggedTo).toBeLessThan(-100)
+    fire('touchend', 40)
+
+    // The exit has to continue from where the finger let go. Slide probes the paper's
+    // untranslated position when the exit starts (Slide.js getTranslateValue), and the browser
+    // takes that probe as the transition's start, which snaps the drawer wide open first.
+    const firstExitFrame = await new Promise((resolve) => {
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() =>
+          resolve(new DOMMatrixReadOnly(getComputedStyle(paper).transform).m41)
+        )
+      )
+    })
+    expect(firstExitFrame).toBeLessThan(draggedTo * 0.6)
+
+    await waitFor(() =>
+      expect(document.querySelector('.MuiDrawer-root').getAttribute('aria-hidden')).toBe('true')
+    )
+  },
+}

--- a/frontend/tests/layouts/MobileNav.test.jsx
+++ b/frontend/tests/layouts/MobileNav.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { act } from '@testing-library/react'
+import { renderWithProviders, settingsWith } from '../test-utils'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}))
+
+const idle = vi.hoisted(() => ({
+  isSuccess: false,
+  isFetching: false,
+  isPending: false,
+  isError: false,
+  data: undefined,
+  mutate: () => {},
+  reset: () => {},
+  refetch: () => {},
+}))
+vi.mock('../../src/api/ApiCall', () => ({
+  ApiGetCall: () => idle,
+  ApiPostCall: () => idle,
+  ApiGetCallWithPagination: () => ({ ...idle, fetchNextPage: () => {} }),
+}))
+
+import { MobileNav } from '../../src/layouts/mobile-nav'
+
+const items = [{ title: 'Dashboard', path: '/' }]
+
+// MUI binds touchstart/touchmove/touchend on the document, so the swipe lifecycle is driven
+// with native events; userEvent emits pointer/mouse, which SwipeableDrawer ignores.
+const touch = (el, type, x = 5, y = 200) => {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  const point = { pageX: x, pageY: y, clientX: x, clientY: y }
+  Object.defineProperty(event, 'touches', { value: type === 'touchend' ? [] : [point] })
+  Object.defineProperty(event, 'changedTouches', { value: [point] })
+  act(() => {
+    el.dispatchEvent(event)
+  })
+}
+
+const renderNav = (props = {}) => {
+  const onOpen = vi.fn()
+  const onClose = vi.fn()
+  renderWithProviders(
+    <MobileNav items={items} open={false} onOpen={onOpen} onClose={onClose} {...props} />,
+    { settings: settingsWith({ bookmarkSidebar: false }) }
+  )
+  return { onOpen, onClose }
+}
+
+describe('MobileNav', () => {
+  it('renders no edge swipe area', () => {
+    renderNav()
+    expect(document.querySelector('.PrivateSwipeArea-root')).toBeNull()
+  })
+
+  // MUI forces the modal open while a swipe is in progress (maybeSwiping), and a touch with no
+  // movement never sets isSwiping, so handleBodyTouchEnd bails before onOpen/onClose. The drawer
+  // animates in and straight back out with the app's open state untouched.
+  it('leaves the drawer closed on a left-edge tap', () => {
+    const { onOpen, onClose } = renderNav()
+    const target = document.querySelector('.PrivateSwipeArea-root') ?? document.body
+    const drawer = document.querySelector('.MuiDrawer-root')
+    expect(drawer.getAttribute('aria-hidden')).toBe('true')
+
+    touch(target, 'touchstart')
+    expect(drawer.getAttribute('aria-hidden')).toBe('true')
+
+    touch(target, 'touchend')
+    expect(drawer.getAttribute('aria-hidden')).toBe('true')
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Two issues:
1) tap on left screen edge flashes the nav open then closed
2) dragging the drawer closed snaps it fully open then closed
<img width="1000" height="1092" alt="side-nav-drag" src="https://github.com/user-attachments/assets/6e57280a-97a0-4ea5-aa2d-6166c93333df" />

fixes:
the issue is upstream in mui's v7 Slide
add `use-swipe-close-transition` shared hook that snapshots the drag transform from `onClose` and resets it when the transition starts
added tests pinning the fixed behavior