### PR TITLE
feat(mobile): session toggle between card view and the full table

### DIFF
--- a/frontend/src/components/CippComponents/CippSettingsSideBar.jsx
+++ b/frontend/src/components/CippComponents/CippSettingsSideBar.jsx
@@ -60,6 +60,7 @@ export const CippSettingsSideBar = (props) => {
       // General Settings
       usageLocation: formValues.usageLocation,
       tablePageSize: formValues.tablePageSize,
+      tableViewMode: formValues.tableViewMode,
       defaultTestSuite: formValues.defaultTestSuite,
       userAttributes: formValues.userAttributes,
 

--- a/frontend/src/components/CippTable/CIPPTableToptoolbar.js
+++ b/frontend/src/components/CippTable/CIPPTableToptoolbar.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import {
+  Badge,
   Box,
   Button,
   Menu,
@@ -11,8 +13,6 @@ import {
   IconButton,
   Tooltip,
   Typography,
-  InputBase,
-  Paper,
   Checkbox,
   SvgIcon,
   Dialog,
@@ -33,12 +33,12 @@ import {
   Check as CheckIcon,
   MoreVert as MoreVertIcon,
   Fullscreen as FullscreenIcon,
+  ViewAgenda,
 } from '@mui/icons-material'
 import {
   ExclamationCircleIcon,
   ChevronDownIcon,
 } from '@heroicons/react/24/outline'
-import { styled, alpha } from '@mui/material/styles'
 import { PDFExportButton, exportRowsToPdf } from '../pdfExportButton'
 import { CSVExportButton, exportRowsToCsv } from '../csvExportButton'
 import { getCippTranslation } from '../../utils/get-cipp-translation'
@@ -57,91 +57,15 @@ import GraphExplorerPresets from '../../data/GraphExplorerPresets.json'
 import CippGraphExplorerFilter from './CippGraphExplorerFilter'
 import { Stack } from '@mui/system'
 import { CippMobileTableControls } from './CippMobileTableControls'
+import { CippTableFilterSheet } from './CippTableFilterSheet'
+import { useSheetHandoff } from '../../hooks/use-sheet-handoff'
 
-// Styled components for modern design
-const ModernSearchContainer = styled(Paper)(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  width: '100%',
-  maxWidth: '300px',
-  minWidth: '200px',
-  height: '40px',
-  backgroundColor: theme.palette.mode === 'dark' ? '#2A2D3A' : '#F8F9FA',
-  border: `1px solid ${theme.palette.mode === 'dark' ? '#404040' : '#E0E0E0'}`,
-  borderRadius: '8px',
-  padding: '0 12px',
-  '&:hover': {
-    borderColor: theme.palette.primary.main,
-  },
-  '&:focus-within': {
-    borderColor: theme.palette.primary.main,
-    boxShadow: `0 0 0 2px ${alpha(theme.palette.primary.main, 0.2)}`,
-  },
-  [theme.breakpoints.down('md')]: {
-    minWidth: '0',
-    maxWidth: 'none',
-    flex: 1,
-  },
-}))
-
-const ModernSearchInput = styled(InputBase)(({ theme }) => ({
-  marginLeft: theme.spacing(1),
-  flex: 1,
-  fontSize: '14px',
-  '& .MuiInputBase-input': {
-    padding: '8px 0',
-    '&::placeholder': {
-      color: theme.palette.text.secondary,
-      opacity: 0.7,
-    },
-  },
-}))
-
-const ModernButton = styled(Button)(({ theme }) => ({
-  height: '40px',
-  borderRadius: '8px',
-  textTransform: 'none',
-  fontWeight: 500,
-  fontSize: '14px',
-  padding: '8px 16px',
-  backgroundColor: theme.palette.mode === 'dark' ? '#2A2D3A' : '#F8F9FA',
-  border: `1px solid ${theme.palette.mode === 'dark' ? '#404040' : '#E0E0E0'}`,
-  color: theme.palette.text.primary,
-  minWidth: 'auto',
-  whiteSpace: 'nowrap',
-  '&:hover': {
-    backgroundColor: theme.palette.mode === 'dark' ? '#363A4A' : '#F0F0F0',
-    borderColor: theme.palette.primary.main,
-  },
-  '& .MuiButton-startIcon': {
-    marginRight: '8px',
-  },
-  '& .MuiButton-endIcon': {
-    marginLeft: '8px',
-  },
-  [theme.breakpoints.down('md')]: {
-    padding: '8px 12px',
-    fontSize: '13px',
-    '& .MuiButton-startIcon': {
-      marginRight: '6px',
-    },
-    '& .MuiButton-endIcon': {
-      marginLeft: '6px',
-    },
-  },
-  [theme.breakpoints.down('sm')]: {
-    padding: '8px 10px',
-    fontSize: '12px',
-    '& .MuiButton-startIcon': {
-      marginRight: '4px',
-    },
-    '& .MuiButton-endIcon': {
-      marginLeft: '4px',
-    },
-  },
-}))
-
-const RefreshButton = styled(IconButton)(({ theme }) => ({}))
+import {
+  ModernSearchContainer,
+  ModernSearchInput,
+  ModernButton,
+  RefreshButton,
+} from './toolbar-primitives'
 
 export const CIPPTableToptoolbar = React.memo(
   ({
@@ -173,13 +97,31 @@ export const CIPPTableToptoolbar = React.memo(
     selectMode = false,
     onSelectModeChange,
     selectModeLocked = false,
+    onViewToggle,
+    tableViewActive = false,
+    showReturnToCards = false,
+    // when set, the selection count + Bulk Actions button portal into this node
+    // (the Card header's slot) rather than rendering inline in the toolbar
+    bulkActionsSlot = null,
+    // Live/Cached data-source controls, rendered in the mobile Table options sheet
+    dataSourceControls,
+    // Owned by CippDataTable: this toolbar mounts as two alternating instances (the cards
+    // branch and the renderTopToolbar branch), so state that must survive the cards<->table
+    // flip is passed down as props rather than kept in local useState/useRef here.
+    activeFilters = { graph: null, table: null },
+    setActiveFilters,
+    searchValue = '',
+    setSearchValue,
+    restoredFiltersRef,
   }) => {
     const popover = usePopover()
     const [filtersAnchor, setFiltersAnchor] = useState(null)
     const [columnsAnchor, setColumnsAnchor] = useState(null)
     const [exportAnchor, setExportAnchor] = useState(null)
     const [actionMenuAnchor, setActionMenuAnchor] = useState(null)
-    const [searchValue, setSearchValue] = useState('')
+    const [mobileFilterSheetOpen, setMobileFilterSheetOpen] = useState(false)
+    // table branch's own handoff instance — the cards branch (CippMobileTableControls) owns a separate one
+    const mobileFilterSheet = useSheetHandoff(() => setMobileFilterSheetOpen(false))
 
     const mdDown = useMediaQuery((theme) => theme.breakpoints.down('md'))
     const settings = useSettings()
@@ -200,13 +142,8 @@ export const CIPPTableToptoolbar = React.memo(
     const [originalSimpleColumns, setOriginalSimpleColumns] =
       useState(simpleColumns)
     const [filterCanvasVisible, setFilterCanvasVisible] = useState(false)
-    const [activeFilters, setActiveFilters] = useState({
-      graph: null,
-      table: null,
-    })
     const presetKey = (filter) => filter?.id ?? filter?.filterName
     const pageName = router.pathname.split('/').slice(1).join('/')
-    const currentTenant = settings?.currentTenant
     const [useCompactMode, setUseCompactMode] = useState(false)
     const toolbarRef = useRef(null)
     const leftContainerRef = useRef(null)
@@ -321,42 +258,11 @@ export const CIPPTableToptoolbar = React.memo(
       closeMenu()
     }
 
-    // Track if we've restored filters for this page to prevent infinite loops
-    const restoredFiltersRef = useRef(new Set())
-
-    useEffect(() => {
-      //if usedData changes, deselect all rows
-      table.toggleAllRowsSelected(false)
-    }, [usedData])
-
-    // Sync currentEffectiveQueryKey with queryKey prop changes (e.g., tenant changes)
+    // Sync currentEffectiveQueryKey with queryKey prop changes (e.g., tenant changes) — a
+    // plain re-derivation from the same props this instance was given, harmless on remount
     useEffect(() => {
       setCurrentEffectiveQueryKey(queryKey || title)
-      // Clear active filter name when query key changes (page load, tenant change, etc.)
-      setActiveFilters({ graph: null, table: null })
     }, [queryKey, title])
-
-    //if the currentTenant Switches, remove Graph filters
-    useEffect(() => {
-      if (currentTenant) {
-        setGraphFilterData({})
-        // Clear active filter name when tenant changes
-        setActiveFilters({ graph: null, table: null })
-        // Clear restoration tracking so saved filters can be re-applied
-        const restorationKey = `${pageName}-graph`
-        restoredFiltersRef.current.delete(restorationKey)
-      }
-    }, [currentTenant, pageName])
-
-    //useEffect to set the column visibility to the preferred columns if they exist
-    useEffect(() => {
-      if (
-        settings?.columnDefaults?.[pageName] &&
-        Object.keys(settings?.columnDefaults?.[pageName]).length > 0
-      ) {
-        setColumnVisibility(settings?.columnDefaults?.[pageName])
-      }
-    }, [settings?.columnDefaults?.[pageName], router, usedColumns])
 
     useEffect(() => {
       setOriginalSimpleColumns(simpleColumns)
@@ -435,11 +341,6 @@ export const CIPPTableToptoolbar = React.memo(
       queryKey,
       title,
     ])
-
-    // Clear restoration tracking when page changes
-    useEffect(() => {
-      restoredFiltersRef.current.clear()
-    }, [pageName])
 
     // Detect overflow and switch to compact mode
     useEffect(() => {
@@ -990,6 +891,72 @@ export const CIPPTableToptoolbar = React.memo(
       </MenuItem>
     )
 
+    // count + button share this gate whether rendered inline or portaled into the header
+    const bulkActionsContent = (
+      <>
+        {(table.getIsAllRowsSelected() || table.getIsSomeRowsSelected()) && (
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+              fontSize: { xs: '12px', md: '14px' },
+              whiteSpace: 'nowrap',
+              mr: 1,
+            }}
+          >
+            {table.getSelectedRowModel().rows.length} rows selected
+          </Typography>
+        )}
+
+        {showBulkActionsButton && (
+          <Button
+            onClick={popover.handleOpen}
+            ref={popover.anchorRef}
+            startIcon={
+              <SvgIcon fontSize="small">
+                <ChevronDownIcon />
+              </SvgIcon>
+            }
+            variant="outlined"
+            size="small"
+            sx={{
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
+              minWidth: 'auto',
+              height: '32px',
+              fontSize: { xs: '12px', md: '14px' },
+              mr: 1,
+            }}
+          >
+            Bulk Actions
+          </Button>
+        )}
+      </>
+    )
+
+    // feeds both CippMobileTableControls (cards) and CippTableFilterSheet (table branch)
+    const mobileColumnItems = table
+      .getAllColumns()
+      .filter((column) => !column.id.startsWith('mrt-'))
+      .map((column) => ({
+        id: column.id,
+        visible: Boolean(column.getIsVisible()),
+      }))
+    const handleToggleColumn = (columnId, visible) =>
+      setColumnVisibility({ ...columnVisibility, [columnId]: !visible })
+    const handleExportCsvClick = () =>
+      document.querySelector(`[data-csv-export="${title}"]`)?.click()
+    const handleExportPdfClick = () =>
+      document.querySelector(`[data-pdf-export="${title}"]`)?.click()
+    const handleViewApiResponse = () =>
+      isInDialog ? setJsonDialogOpen(true) : setOffcanvasVisible(true)
+    const handleEditGraphFilters =
+      api?.url === '/api/ListGraphRequest' ? () => setFilterCanvasVisible(true) : undefined
+    const handleResetFilters = () => setTableFilter('', 'reset', '')
+    const mobileIsRefreshing = Boolean(
+      getRequestData?.isFetching || refreshFunction?.isFetching
+    )
+
     return (
       <>
         {viewMode === 'cards' ? (
@@ -998,13 +965,12 @@ export const CIPPTableToptoolbar = React.memo(
             searchValue={searchValue}
             onSearchChange={handleSearchChange}
             onRefresh={handleRefresh}
-            isRefreshing={Boolean(
-              getRequestData?.isFetching || refreshFunction?.isFetching
-            )}
+            isRefreshing={mobileIsRefreshing}
             selectionEnabled={Boolean(table.options.enableRowSelection)}
             selectMode={selectMode}
             onSelectModeChange={onSelectModeChange}
             selectModeLocked={selectModeLocked}
+            onViewToggle={onViewToggle}
             customBulkActions={customBulkActions}
             onBulkAction={handleBulkAction}
             graphPresetItems={graphPresetItems}
@@ -1013,32 +979,14 @@ export const CIPPTableToptoolbar = React.memo(
             activeSlotCount={activeSlotCount}
             presetKey={presetKey}
             onPresetClick={handlePresetClick}
-            onResetFilters={() => setTableFilter('', 'reset', '')}
-            onEditGraphFilters={
-              api?.url === '/api/ListGraphRequest'
-                ? () => setFilterCanvasVisible(true)
-                : undefined
-            }
-            columnItems={table
-              .getAllColumns()
-              .filter((column) => !column.id.startsWith('mrt-'))
-              .map((column) => ({
-                id: column.id,
-                visible: Boolean(column.getIsVisible()),
-              }))}
-            onToggleColumn={(columnId, visible) =>
-              setColumnVisibility({ ...columnVisibility, [columnId]: !visible })
-            }
+            onResetFilters={handleResetFilters}
+            onEditGraphFilters={handleEditGraphFilters}
+            columnItems={mobileColumnItems}
+            onToggleColumn={handleToggleColumn}
             exportEnabled={exportEnabled}
-            onExportCsv={() =>
-              document.querySelector(`[data-csv-export="${title}"]`)?.click()
-            }
-            onExportPdf={() =>
-              document.querySelector(`[data-pdf-export="${title}"]`)?.click()
-            }
-            onViewApiResponse={() =>
-              isInDialog ? setJsonDialogOpen(true) : setOffcanvasVisible(true)
-            }
+            onExportCsv={handleExportCsvClick}
+            onExportPdf={handleExportPdfClick}
+            onViewApiResponse={handleViewApiResponse}
             fixedChrome={!isInDialog}
             queueTracker={
               queueMetadata?.QueueId ? (
@@ -1049,8 +997,10 @@ export const CIPPTableToptoolbar = React.memo(
                 />
               ) : undefined
             }
+            dataSourceControls={dataSourceControls}
           />
         ) : (
+        <>
         <Box
           ref={toolbarRef}
           sx={{
@@ -1076,48 +1026,50 @@ export const CIPPTableToptoolbar = React.memo(
               minWidth: 0,
             }}
           >
-            {/* Refresh Button */}
-            <Tooltip
-              title={
-                getRequestData?.isFetchNextPageError
-                  ? 'Could not retrieve all data. Click to try again.'
-                  : getRequestData?.isFetching
-                    ? 'Retrieving more data...'
-                    : 'Refresh data'
-              }
-            >
-              <span>
-                <RefreshButton
-                  onClick={handleRefresh}
-                  disabled={
-                    getRequestData?.isLoading ||
-                    getRequestData?.isFetching ||
-                    refreshFunction?.isFetching
-                  }
-                >
-                  <SvgIcon
-                    fontSize="small"
-                    sx={{
-                      animation:
-                        getRequestData?.isFetching ||
-                        refreshFunction?.isFetching
-                          ? 'spin 1s linear infinite'
-                          : 'none',
-                      '@keyframes spin': {
-                        '0%': { transform: 'rotate(0deg)' },
-                        '100%': { transform: 'rotate(-360deg)' },
-                      },
-                    }}
+            {/* phones refresh from the options sheet instead */}
+            {!mdDown && (
+              <Tooltip
+                title={
+                  getRequestData?.isFetchNextPageError
+                    ? 'Could not retrieve all data. Click to try again.'
+                    : getRequestData?.isFetching
+                      ? 'Retrieving more data...'
+                      : 'Refresh data'
+                }
+              >
+                <span>
+                  <RefreshButton
+                    onClick={handleRefresh}
+                    disabled={
+                      getRequestData?.isLoading ||
+                      getRequestData?.isFetching ||
+                      refreshFunction?.isFetching
+                    }
                   >
-                    {getRequestData?.isFetchNextPageError ? (
-                      <ExclamationCircleIcon color="red" />
-                    ) : (
-                      <Sync />
-                    )}
-                  </SvgIcon>
-                </RefreshButton>
-              </span>
-            </Tooltip>
+                    <SvgIcon
+                      fontSize="small"
+                      sx={{
+                        animation:
+                          getRequestData?.isFetching ||
+                          refreshFunction?.isFetching
+                            ? 'spin 1s linear infinite'
+                            : 'none',
+                        '@keyframes spin': {
+                          '0%': { transform: 'rotate(0deg)' },
+                          '100%': { transform: 'rotate(-360deg)' },
+                        },
+                      }}
+                    >
+                      {getRequestData?.isFetchNextPageError ? (
+                        <ExclamationCircleIcon color="red" />
+                      ) : (
+                        <Sync />
+                      )}
+                    </SvgIcon>
+                  </RefreshButton>
+                </span>
+              </Tooltip>
+            )}
 
             {/* Search Input */}
             <ModernSearchContainer elevation={0}>
@@ -1228,8 +1180,8 @@ export const CIPPTableToptoolbar = React.memo(
               </Box>
             )}
 
-            {/* Mobile/Compact Action Button */}
-            {(mdDown || useCompactMode) && !hasSelection && (
+            {/* Compact Action Button — desktop compact mode only, the phone table uses the filter sheet */}
+            {!mdDown && useCompactMode && !hasSelection && (
               <IconButton
                 onClick={(event) => setActionMenuAnchor(event.currentTarget)}
                 sx={{ flexShrink: 0 }}
@@ -1238,7 +1190,50 @@ export const CIPPTableToptoolbar = React.memo(
               </IconButton>
             )}
 
-            {/* Mobile Action Menu */}
+            {/* phones keep the kebab open regardless of selection, the only route to the
+                sheet (refresh, export, rows-per-page) down there, not just filters */}
+            {(mdDown || (useCompactMode && !hasSelection)) && (
+              <IconButton
+                aria-label={mdDown ? 'Table options' : 'Filters'}
+                onClick={(event) => {
+                  if (mdDown) {
+                    setMobileFilterSheetOpen(true)
+                    return
+                  }
+                  setFiltersAnchor(event.currentTarget)
+                }}
+                sx={{
+                  flexShrink: 0,
+                  ...(mdDown && activeSlotCount > 0 && { color: 'primary.main' }),
+                }}
+              >
+                {mdDown ? (
+                  <Badge badgeContent={activeSlotCount} color="primary">
+                    <MoreVertIcon />
+                  </Badge>
+                ) : (
+                  <FilterListIcon />
+                )}
+              </IconButton>
+            )}
+
+            {/* way back to cards, far right to match the card bar's toggle position */}
+            {tableViewActive && showReturnToCards && (
+              <Tooltip title="Return to card view">
+                <RefreshButton
+                  onClick={onViewToggle}
+                  aria-label="Toggle table view"
+                  aria-pressed={true}
+                >
+                  <SvgIcon fontSize="small">
+                    {/* destination icon: tapping here returns to cards */}
+                    <ViewAgenda />
+                  </SvgIcon>
+                </RefreshButton>
+              </Tooltip>
+            )}
+
+            {/* Compact Action Menu — desktop compact mode only */}
             <Menu
               anchorEl={actionMenuAnchor}
               open={Boolean(actionMenuAnchor)}
@@ -1254,17 +1249,6 @@ export const CIPPTableToptoolbar = React.memo(
               {/* Anchor the nested menus to the stable overflow IconButton — anchoring to
                   event.currentTarget here targets a MenuItem inside a menu that closes in
                   the same tick, which positions the next popover unpredictably. */}
-              <MenuItem
-                onClick={() => {
-                  setFiltersAnchor(actionMenuAnchor)
-                  setActionMenuAnchor(null)
-                }}
-              >
-                <ListItemIcon>
-                  <FilterListIcon />
-                </ListItemIcon>
-                <ListItemText>Filters</ListItemText>
-              </MenuItem>
               <MenuItem
                 onClick={() => {
                   setColumnsAnchor(actionMenuAnchor)
@@ -1515,46 +1499,8 @@ export const CIPPTableToptoolbar = React.memo(
               mt: { xs: 1, md: 0 },
             }}
           >
-            {/* Selected rows indicator */}
-            {(table.getIsAllRowsSelected() ||
-              table.getIsSomeRowsSelected()) && (
-              <Typography
-                variant="body2"
-                sx={{
-                  color: 'text.secondary',
-                  fontSize: { xs: '12px', md: '14px' },
-                  whiteSpace: 'nowrap',
-                  mr: 1,
-                }}
-              >
-                {table.getSelectedRowModel().rows.length} rows selected
-              </Typography>
-            )}
-
-            {/* Bulk Actions - inline with toolbar */}
-            {showBulkActionsButton && (
-              <Button
-                onClick={popover.handleOpen}
-                ref={popover.anchorRef}
-                startIcon={
-                  <SvgIcon fontSize="small">
-                    <ChevronDownIcon />
-                  </SvgIcon>
-                }
-                variant="outlined"
-                size="small"
-                sx={{
-                  flexShrink: 0,
-                  whiteSpace: 'nowrap',
-                  minWidth: 'auto',
-                  height: '32px',
-                  fontSize: { xs: '12px', md: '14px' },
-                  mr: 1,
-                }}
-              >
-                Bulk Actions
-              </Button>
-            )}
+            {/* Selected rows indicator + Bulk Actions - inline, unless portaled into the header */}
+            {!bulkActionsSlot && bulkActionsContent}
 
             {/* Queue tracker */}
             <CippQueueTracker
@@ -1565,7 +1511,35 @@ export const CIPPTableToptoolbar = React.memo(
           </Box>
 
         </Box>
+        <CippTableFilterSheet
+          open={mobileFilterSheetOpen}
+          onClose={mobileFilterSheet.cancel}
+          onExited={mobileFilterSheet.handleExited}
+          run={mobileFilterSheet.run}
+          tablePresetItems={tablePresetItems}
+          graphPresetItems={graphPresetItems}
+          activeFilters={activeFilters}
+          presetKey={presetKey}
+          onPresetClick={handlePresetClick}
+          columnItems={mobileColumnItems}
+          onToggleColumn={handleToggleColumn}
+          onResetFilters={handleResetFilters}
+          onEditGraphFilters={handleEditGraphFilters}
+          exportEnabled={exportEnabled}
+          onExportCsv={handleExportCsvClick}
+          onExportPdf={handleExportPdfClick}
+          onViewApiResponse={handleViewApiResponse}
+          onRefresh={handleRefresh}
+          isRefreshing={mobileIsRefreshing}
+          pageSize={table.getState().pagination.pageSize}
+          onPageSizeChange={(size) => table.setPageSize(size)}
+          pageSizeOptions={[25, 50, 100, 250, 500]}
+          dataSourceControls={dataSourceControls}
+        />
+        </>
         )}
+
+        {bulkActionsSlot && createPortal(bulkActionsContent, bulkActionsSlot)}
 
         {/* Hidden export buttons for triggering — outside the mode branch so the
             mobile filter sheet's export items can click them too */}

--- a/frontend/src/components/CippTable/CippDataTable.js
+++ b/frontend/src/components/CippTable/CippDataTable.js
@@ -14,6 +14,7 @@ import { ResourceUnavailable } from '../resource-unavailable'
 import { ResourceError } from '../resource-error'
 import { Scrollbar } from '../scrollbar'
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
+import { useRouter } from 'next/router'
 import { ApiGetCallWithPagination } from '../../api/ApiCall'
 import { utilTableMode } from './util-tablemode'
 import {
@@ -26,13 +27,14 @@ import { CippOffCanvas } from '../CippComponents/CippOffCanvas'
 import { useDialog } from '../../hooks/use-dialog'
 import { CippApiDialog } from '../CippComponents/CippApiDialog'
 import { getCippError } from '../../utils/get-cipp-error'
-import { Box } from '@mui/system'
+import { Box, Stack } from '@mui/system'
 import { useSettings } from '../../hooks/use-settings'
 import { parseCippDate } from '../../utils/parse-cipp-date'
 import { isEqual } from 'lodash' // Import lodash for deep comparison
 import { useLicenseBackfill } from '../../hooks/use-license-backfill'
-import { useTableViewMode } from '../../hooks/use-breakpoint'
+import { useTableViewMode, useIsNarrowForTables } from '../../hooks/use-breakpoint'
 import { CippMobileCardList } from './CippMobileCardList'
+import { CippPageActionsFab } from '../CippComponents/CippPageActionsFab'
 
 // Resolve dot-delimited property paths against arbitrary data objects.
 const getNestedValue = (source, path) => {
@@ -81,6 +83,22 @@ const compareNullable = (aVal, bVal) => {
     return 0
   }
   return aVal > bVal ? 1 : -1
+}
+
+// walk up from the toggled node to the page's scrolling ancestor (LayoutContainer,
+// overflowY auto) and reset it, so a narrow-table height measurement taken right after
+// starts from a deterministic scroll position
+const scrollScrollableAncestorToTop = (node) => {
+  let ancestor = node?.parentElement
+  while (ancestor && ancestor !== document.body) {
+    const overflowY = window.getComputedStyle(ancestor).overflowY
+    if (overflowY === 'auto' || overflowY === 'scroll') {
+      ancestor.scrollTop = 0
+      return
+    }
+    ancestor = ancestor.parentElement
+  }
+  window.scrollTo(0, 0)
 }
 
 // ── Module-level constants ──────────────────────────────────────────────────
@@ -393,6 +411,7 @@ export const CippDataTable = (props) => {
     showBulkExportAction = true,
     viewMode: viewModeProp,
     mobileCard,
+    dataSourceControls,
   } = props
 
   // Create a map of column IDs to their filterType for quick lookup
@@ -436,16 +455,40 @@ export const CippDataTable = (props) => {
   const [columnFilters, setColumnFilters] = useState([])
   const waitingBool = api?.url ? true : false
 
+  // The cards branch and the renderTopToolbar branch are two alternating CIPPTableToptoolbar
+  // instances (only one is ever mounted), so state that must survive the cards<->table flip
+  // lives here and is passed down as props to both.
+  const [activeFilters, setActiveFilters] = useState({ graph: null, table: null })
+  const [searchValue, setSearchValue] = useState('')
+  const restoredFiltersRef = useRef(new Set())
+
   const settings = useSettings()
+  const router = useRouter()
+  const pageName = router.pathname.split('/').slice(1).join('/')
 
   // 'cards' below the md breakpoint (or when forced via settings/prop), 'table' otherwise.
   // simple tables always resolve to 'table'.
   const resolvedViewMode = useTableViewMode({ viewMode: viewModeProp, simple })
-  const isCardView = resolvedViewMode === 'cards'
+  // same pivot as the cards/table auto mode, so the FAB and the card list agree on width
+  const isNarrowViewport = useIsNarrowForTables()
+  // viewMode prop or simple is a hard force, the toggle never overrides it
+  const toggleAllowed = !viewModeProp && !simple
   // Mobile select mode: checkboxes on cards + the bottom bulk bar. Lives here so the
   // toolbar (which renders the Select toggle) and the card list stay in sync. Picker
   // tables (onChange) force it on — selection is their entire purpose.
   const [mobileSelectMode, setMobileSelectMode] = useState(false)
+  // portal target for the header's bulk-actions slot, set by the CardHeader's ref callback
+  const [headerBulkSlot, setHeaderBulkSlot] = useState(null)
+
+  // transient cards<->table override, session-only, never persisted
+  const [viewOverride, setViewOverride] = useState(null)
+  const effectiveViewMode = toggleAllowed ? (viewOverride ?? resolvedViewMode) : resolvedViewMode
+  const isCardView = effectiveViewMode === 'cards'
+  const tableViewActive = effectiveViewMode === 'table'
+  const CardViewSurface = noCard ? Box : Card
+  const [narrowTableMaxHeight, setNarrowTableMaxHeight] = useState(null)
+  // way back button: table is only up because of the override, phone default is still cards
+  const showReturnToCards = toggleAllowed && tableViewActive && resolvedViewMode === 'cards'
 
   // Hook to trigger re-render when license backfill completes
   const { updateTrigger } = useLicenseBackfill()
@@ -645,6 +688,62 @@ export const CippDataTable = (props) => {
     filterTypeMap,
   ])
 
+  // Previous-value refs for the guards below: CippDataTable is the single owner of this
+  // state across both toolbar instances, so an effect can compare against the last value
+  // it actually saw rather than firing unconditionally on every render.
+  const prevTenantRef = useRef(settings?.currentTenant)
+  const prevQueryKeyRef = useRef(queryKey || title)
+  const prevPageNameRef = useRef(pageName)
+  const appliedColumnDefaultsRef = useRef({})
+
+  // if the currentTenant switches, remove graph filters and the active-filter highlight
+  useEffect(() => {
+    const currentTenant = settings?.currentTenant
+    if (prevTenantRef.current === currentTenant) {
+      return
+    }
+    prevTenantRef.current = currentTenant
+    if (currentTenant) {
+      setGraphFilterData({})
+      setActiveFilters({ graph: null, table: null })
+      restoredFiltersRef.current.delete(`${pageName}-graph`)
+    }
+  }, [settings?.currentTenant, pageName])
+
+  // clear the active-filter highlight when the effective query key changes (tenant swap,
+  // different queryKey/title)
+  useEffect(() => {
+    const effectiveKey = queryKey || title
+    if (prevQueryKeyRef.current === effectiveKey) {
+      return
+    }
+    prevQueryKeyRef.current = effectiveKey
+    setActiveFilters({ graph: null, table: null })
+  }, [queryKey, title])
+
+  // clear persisted-filter restoration tracking only when the page actually changes
+  useEffect(() => {
+    if (prevPageNameRef.current === pageName) {
+      return
+    }
+    prevPageNameRef.current = pageName
+    restoredFiltersRef.current.clear()
+  }, [pageName])
+
+  // apply preferred columns once per page, and again whenever the saved preference's
+  // identity changes
+  useEffect(() => {
+    const preferred = settings?.columnDefaults?.[pageName]
+    if (
+      preferred &&
+      Object.keys(preferred).length > 0 &&
+      appliedColumnDefaultsRef.current[pageName] !== preferred
+    ) {
+      appliedColumnDefaultsRef.current[pageName] = preferred
+      setColumnVisibility(preferred)
+    }
+  }, [settings?.columnDefaults?.[pageName], pageName])
+
   const createDialog = useDialog()
   const hasActions = !!actions
   const hasOffCanvas = !!offCanvas
@@ -662,7 +761,8 @@ export const CippDataTable = (props) => {
         onChange,
         maxHeightOffset,
         settings,
-        resolvedViewMode
+        effectiveViewMode,
+        isNarrowViewport
       ),
     [
       simple,
@@ -671,7 +771,8 @@ export const CippDataTable = (props) => {
       hasOnChange,
       maxHeightOffset,
       settings?.tablePageSize?.value,
-      resolvedViewMode,
+      effectiveViewMode,
+      isNarrowViewport,
     ]
   )
 
@@ -855,6 +956,16 @@ export const CippDataTable = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // the flipped table shows whatever columns are visible; horizontal scroll covers the width
+  const handleViewToggle = useCallback((event) => {
+    const nextView = effectiveViewMode === 'table' ? 'cards' : 'table'
+    setViewOverride(nextView)
+    if (nextView === 'table' && isNarrowViewport) {
+      scrollScrollableAncestorToTop(event?.currentTarget)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [effectiveViewMode, isNarrowViewport])
+
   // Memoize renderRowActionMenuItems to avoid re-creating on each render.
   const renderRowActionMenuItems = useMemo(() => {
     if (actions) {
@@ -952,6 +1063,16 @@ export const CippDataTable = (props) => {
               queueMetadata={getRequestData.data?.pages?.[0]?.Metadata}
               isInDialog={isInDialog}
               showBulkExportAction={showBulkExportAction}
+              onViewToggle={toggleAllowed ? handleViewToggle : undefined}
+              tableViewActive={toggleAllowed ? tableViewActive : undefined}
+              showReturnToCards={showReturnToCards}
+              bulkActionsSlot={isNarrowViewport && !isInDialog ? headerBulkSlot : null}
+              dataSourceControls={dataSourceControls}
+              activeFilters={activeFilters}
+              setActiveFilters={setActiveFilters}
+              searchValue={searchValue}
+              setSearchValue={setSearchValue}
+              restoredFiltersRef={restoredFiltersRef}
             />
           )}
         </>
@@ -975,6 +1096,15 @@ export const CippDataTable = (props) => {
       graphFilterData,
       isInDialog,
       showBulkExportAction,
+      toggleAllowed,
+      handleViewToggle,
+      tableViewActive,
+      showReturnToCards,
+      isNarrowViewport,
+      headerBulkSlot,
+      dataSourceControls,
+      activeFilters,
+      searchValue,
     ]
   )
 
@@ -1005,6 +1135,18 @@ export const CippDataTable = (props) => {
     renderEmptyRowsFallback,
     onColumnVisibilityChange: setColumnVisibility,
     ...modeInfo,
+    // narrow table views size their scroll viewport from measurement (see the effect below),
+    // the modeInfo calc budget only holds for desktop chrome
+    ...(isNarrowViewport &&
+      effectiveViewMode === 'table' && {
+        muiTableContainerProps: {
+          ...modeInfo.muiTableContainerProps,
+          sx: {
+            ...modeInfo.muiTableContainerProps?.sx,
+            maxHeight: narrowTableMaxHeight ? `${narrowTableMaxHeight}px` : 'none',
+          },
+        },
+      }),
     renderRowActionMenuItems,
     renderTopToolbar,
     sortingFns: SORTING_FNS,
@@ -1014,6 +1156,64 @@ export const CippDataTable = (props) => {
     renderGlobalFilterModeMenuItems: renderGlobalFilterModeMenuItemsFn,
     renderColumnFilterModeMenuItems: renderColumnFilterModeMenuItemsFn,
   })
+
+  // deselect all rows when the underlying data set actually changes, guarded so a toolbar
+  // remount (cards<->table flip) does not wipe an in-progress selection
+  const prevUsedDataRef = useRef(memoizedData)
+  useEffect(() => {
+    if (prevUsedDataRef.current === memoizedData) {
+      return
+    }
+    prevUsedDataRef.current = memoizedData
+    table.toggleAllRowsSelected(false)
+  }, [memoizedData])
+
+  // size the narrow table's scroll viewport from where it actually sits: viewport height
+  // minus the container's measured top, the real footer height and the chrome below the
+  // paper. the desktop calc assumes chrome heights that phone layouts do not have.
+  // deps include getRequestData.isSuccess so a cold load (table not yet mounted when the
+  // toggle flips tableViewActive true) re-arms the measurement once MRT actually renders
+  useEffect(() => {
+    if (!(isNarrowViewport && tableViewActive)) {
+      setNarrowTableMaxHeight(null)
+      return undefined
+    }
+    const measure = () => {
+      const container = table.refs.tableContainerRef?.current
+      if (!container) {
+        return
+      }
+      const footer = table.refs.bottomToolbarRef?.current?.offsetHeight ?? 0
+      // chrome between the paper's bottom edge and the page bottom (CardContent padding + page gap)
+      const BELOW_PAPER_PX = 40
+      // viewport-relative, so a scrolled page needs the toggle handler to reset scroll first
+      const top = container.getBoundingClientRect().top
+      let next = Math.max(240, Math.floor(window.innerHeight - top - footer - BELOW_PAPER_PX))
+      // 120 = minimal chrome allowance, keeps the table from claiming the full viewport
+      next = Math.min(next, window.innerHeight - 120)
+      setNarrowTableMaxHeight((prev) => {
+        if (prev !== null && Math.abs(prev - next) <= 1) {
+          return prev
+        }
+        return next
+      })
+    }
+    const raf = requestAnimationFrame(() => requestAnimationFrame(measure))
+    window.addEventListener('resize', measure)
+    let observer
+    // the paper mounts in the same commit as the container and the footer, so it is a
+    // reliable observation target even on the pass where the footer ref is still null
+    const paper = table.refs.tablePaperRef?.current
+    if (typeof ResizeObserver !== 'undefined' && paper) {
+      observer = new ResizeObserver(measure)
+      observer.observe(paper)
+    }
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', measure)
+      observer?.disconnect()
+    }
+  }, [isNarrowViewport, tableViewActive, table, getRequestData.isSuccess])
 
   // A card shows at most a title, subtitle, three chips and three detail rows, so the rest
   // of the row has to live in the drawer. On a page with no offCanvas that means every
@@ -1105,10 +1305,19 @@ export const CippDataTable = (props) => {
 
   const selectModeActive = hasOnChange ? true : mobileSelectMode
 
+  // below md, table-in-Card branch: the actions FAB carries cardButton
+  const headerAction = isNarrowViewport && !isInDialog ? undefined : cardButton
+
   return (
     <>
       {isCardView ? (
-        <Box data-testid="cipp-card-view">
+        // same paper surface as the table path; overflow visible keeps the controls bar sticky
+        <CardViewSurface
+          data-testid="cipp-card-view"
+          {...(noCard
+            ? {}
+            : { sx: { width: '100%', overflow: 'visible' }, ...props.cardProps })}
+        >
           {!hideTitle && (
             <Box
               sx={{
@@ -1168,6 +1377,14 @@ export const CippDataTable = (props) => {
                   hasOnChange ? undefined : handleMobileSelectModeChange
                 }
                 selectModeLocked={hasOnChange}
+                onViewToggle={toggleAllowed ? handleViewToggle : undefined}
+                tableViewActive={toggleAllowed ? tableViewActive : undefined}
+                dataSourceControls={dataSourceControls}
+                activeFilters={activeFilters}
+                setActiveFilters={setActiveFilters}
+                searchValue={searchValue}
+                setSearchValue={setSearchValue}
+                restoredFiltersRef={restoredFiltersRef}
               />
               <CippMobileCardList
                 table={table}
@@ -1192,7 +1409,7 @@ export const CippDataTable = (props) => {
               message={`Error Loading data:  ${getCippError(getRequestData.error)}`}
             />
           )}
-        </Box>
+        </CardViewSurface>
       ) : noCard ? (
         <Scrollbar>
           {!Array.isArray(usedData) && usedData ? (
@@ -1213,40 +1430,61 @@ export const CippDataTable = (props) => {
         </Scrollbar>
       ) : (
         // Render the table inside a Card
-        <Card style={{ width: '100%' }} {...props.cardProps}>
-          {cardButton || !hideTitle ? (
-            <>
-              <CardHeader
-                action={cardButton}
-                title={hideTitle ? '' : title}
-                {...props.cardHeaderProps}
-              />
-              <Divider />
-            </>
-          ) : null}
-          <CardContent sx={{ padding: '1rem' }}>
-            <Scrollbar>
-              {!Array.isArray(usedData) && usedData ? (
-                <ResourceUnavailable message={incorrectDataMessage} />
-              ) : (
-                <>
-                  {(getRequestData.isSuccess ||
-                    getRequestData.data?.pages.length >= 0 ||
-                    (data && !getRequestData.isError)) && (
-                    <MaterialReactTable table={table} />
-                  )}
-                </>
-              )}
-              {getRequestData.isError &&
-                !getRequestData.isFetchNextPageError && (
-                  <ResourceError
-                    onReload={() => getRequestData.refetch()}
-                    message={`Error Loading data:  ${getCippError(getRequestData.error)}`}
-                  />
+        <>
+          <Card style={{ width: '100%' }} {...props.cardProps}>
+            {cardButton || !hideTitle ? (
+              <>
+                <CardHeader
+                  action={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Box
+                        ref={setHeaderBulkSlot}
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                      />
+                      {/* narrow viewports carry these in the Table options sheet */}
+                      {dataSourceControls && !isNarrowViewport ? (
+                        <Stack direction='row' spacing={1} alignItems='center'>
+                          {dataSourceControls}
+                          {headerAction}
+                        </Stack>
+                      ) : (
+                        headerAction
+                      )}
+                    </Box>
+                  }
+                  title={hideTitle ? '' : title}
+                  {...props.cardHeaderProps}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <CardContent sx={{ padding: '1rem' }}>
+              <Scrollbar>
+                {!Array.isArray(usedData) && usedData ? (
+                  <ResourceUnavailable message={incorrectDataMessage} />
+                ) : (
+                  <>
+                    {(getRequestData.isSuccess ||
+                      getRequestData.data?.pages.length >= 0 ||
+                      (data && !getRequestData.isError)) && (
+                      <MaterialReactTable table={table} />
+                    )}
+                  </>
                 )}
-            </Scrollbar>
-          </CardContent>
-        </Card>
+                {getRequestData.isError &&
+                  !getRequestData.isFetchNextPageError && (
+                    <ResourceError
+                      onReload={() => getRequestData.refetch()}
+                      message={`Error Loading data:  ${getCippError(getRequestData.error)}`}
+                    />
+                  )}
+              </Scrollbar>
+            </CardContent>
+          </Card>
+          {isNarrowViewport && !isInDialog && cardButton && (
+            <CippPageActionsFab title="Actions">{cardButton}</CippPageActionsFab>
+          )}
+        </>
       )}
       <CippOffCanvas
         isFetching={getRequestData.isFetching}

--- a/frontend/src/components/CippTable/CippMobileTableControls.jsx
+++ b/frontend/src/components/CippTable/CippMobileTableControls.jsx
@@ -3,35 +3,31 @@ import {
   Badge,
   Box,
   Button,
-  Checkbox,
-  Chip,
   Divider,
-  IconButton,
-  InputAdornment,
   ListItemButton,
   ListItemIcon,
   ListItemText,
-  ListSubheader,
-  OutlinedInput,
-  Stack,
   SvgIcon,
   Typography,
 } from "@mui/material";
 import {
+  ModernSearchContainer,
+  ModernSearchInput,
+  ModernButton,
+  ModernIconButton,
+} from "./toolbar-primitives";
+import {
   ArrowDownward,
   ArrowUpward,
-  Check,
-  FilterList,
+  MoreVert,
   RestartAlt,
   Search,
   SwapVert,
-  Sync,
-  DataObject,
-  FileDownload,
-  PictureAsPdf,
+  TableChart,
 } from "@mui/icons-material";
 import { getCippTranslation } from "../../utils/get-cipp-translation";
 import { CippBottomSheet } from "../CippComponents/CippBottomSheet";
+import { CippTableFilterSheet } from "./CippTableFilterSheet";
 import { useSheetHandoff } from "../../hooks/use-sheet-handoff";
 
 // Presentational mobile controls for the card list. All filter/sort/visibility state and
@@ -48,6 +44,7 @@ export const CippMobileTableControls = (props) => {
     selectMode = false,
     onSelectModeChange,
     selectModeLocked = false,
+    onViewToggle,
     customBulkActions = [],
     onBulkAction,
     graphPresetItems = [],
@@ -66,6 +63,7 @@ export const CippMobileTableControls = (props) => {
     onViewApiResponse,
     fixedChrome = true,
     queueTracker,
+    dataSourceControls,
   } = props;
 
   const [sortOpen, setSortOpen] = useState(false);
@@ -97,26 +95,6 @@ export const CippMobileTableControls = (props) => {
   const totalCount = table.getFilteredRowModel().rows.length;
   const enabledBulkActions = customBulkActions.filter((action) => !action.disabled);
 
-  const renderPresetChips = (items, layer) => (
-    <Stack direction="row" useFlexGap flexWrap="wrap" spacing={1} sx={{ px: 2.25, py: 1 }}>
-      {items.map((filter) => {
-        const key = presetKey(filter);
-        const active = activeFilters[layer]?.id === key;
-        return (
-          <Chip
-            key={key}
-            label={filter.filterName}
-            color={active ? "primary" : "default"}
-            variant={active ? "filled" : "outlined"}
-            icon={active ? <Check /> : undefined}
-            onClick={() => onPresetClick(filter)}
-            sx={{ height: 36, borderRadius: 999 }}
-          />
-        );
-      })}
-    </Stack>
-  );
-
   return (
     <>
       <Box
@@ -128,67 +106,61 @@ export const CippMobileTableControls = (props) => {
           gap: 1,
           px: 1,
           py: 1,
-          bgcolor: "background.default",
+          // matches the card-view paper surface it sticks over
+          bgcolor: "background.paper",
           borderBottom: 1,
           borderColor: "divider",
         }}
       >
-        <OutlinedInput
-          fullWidth
-          type="search"
-          placeholder="Search…"
-          value={searchValue}
-          onChange={onSearchChange}
-          inputProps={{ enterKeyHint: "search", "aria-label": "Search" }}
-          startAdornment={
-            <InputAdornment position="start">
-              <Search fontSize="small" />
-            </InputAdornment>
-          }
-          sx={{ minHeight: 44, flex: 1, minWidth: 0 }}
-        />
+        <ModernSearchContainer elevation={0} sx={{ height: 44, flex: 1, minWidth: 0 }}>
+          <Search fontSize="small" sx={{ color: "text.secondary" }} />
+          <ModernSearchInput
+            type="search"
+            placeholder="Search…"
+            value={searchValue}
+            onChange={onSearchChange}
+            inputProps={{ enterKeyHint: "search", "aria-label": "Search" }}
+          />
+        </ModernSearchContainer>
         {selectionEnabled && !selectModeLocked && (
-          <Button
-            variant="outlined"
-            color="inherit"
+          <ModernButton
             onClick={() => onSelectModeChange?.(!selectMode)}
-            sx={{ minHeight: 44, flexShrink: 0, px: 1.5, borderColor: "divider" }}
+            sx={{ height: 44, flexShrink: 0 }}
           >
             {selectMode ? "Cancel" : "Select"}
-          </Button>
+          </ModernButton>
         )}
-        <IconButton
+        <ModernIconButton
           aria-label="Sort"
           onClick={() => setSortOpen(true)}
-          sx={{
-            minWidth: 44,
-            minHeight: 44,
-            border: 1,
-            borderColor: sorting.length ? "primary.main" : "divider",
-            borderRadius: 1,
-            color: sorting.length ? "primary.main" : "inherit",
-            flexShrink: 0,
-          }}
+          sx={sorting.length ? { borderColor: "primary.main", color: "primary.main" } : undefined}
         >
           <SwapVert fontSize="small" />
-        </IconButton>
-        <IconButton
-          aria-label="Filters"
+        </ModernIconButton>
+        {/* kebab, the sheet is a grab-bag (presets, fields, export, refresh), not just filters */}
+        <ModernIconButton
+          aria-label="Table options"
           onClick={() => setFilterOpen(true)}
-          sx={{
-            minWidth: 44,
-            minHeight: 44,
-            border: 1,
-            borderColor: activeSlotCount > 0 ? "primary.main" : "divider",
-            borderRadius: 1,
-            color: activeSlotCount > 0 ? "primary.main" : "inherit",
-            flexShrink: 0,
-          }}
+          sx={
+            activeSlotCount > 0
+              ? { borderColor: "primary.main", color: "primary.main" }
+              : undefined
+          }
         >
           <Badge badgeContent={activeSlotCount} color="primary">
-            <FilterList fontSize="small" />
+            <MoreVert fontSize="small" />
           </Badge>
-        </IconButton>
+        </ModernIconButton>
+        {onViewToggle && (
+          <ModernIconButton
+            aria-label="Toggle table view"
+            aria-pressed={false}
+            onClick={onViewToggle}
+          >
+            {/* destination icon: tapping here opens the table */}
+            <TableChart fontSize="small" />
+          </ModernIconButton>
+        )}
       </Box>
       {queueTracker && <Box sx={{ px: 1.5, py: 0.5 }}>{queueTracker}</Box>}
 
@@ -237,114 +209,28 @@ export const CippMobileTableControls = (props) => {
       </CippBottomSheet>
 
       {/* Filter sheet — presets first, then card fields, then table utilities */}
-      <CippBottomSheet
+      <CippTableFilterSheet
         open={filterOpen}
         onClose={filterSheet.cancel}
         onExited={filterSheet.handleExited}
-        title="Filters"
-        footer={
-          <Button fullWidth variant="contained" sx={{ minHeight: 44 }} onClick={() => setFilterOpen(false)}>
-            Done
-          </Button>
-        }
-      >
-        {tablePresetItems.length > 0 && (
-          <>
-            <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
-              Presets
-            </ListSubheader>
-            {renderPresetChips(tablePresetItems, "table")}
-          </>
-        )}
-        {graphPresetItems.length > 0 && (
-          <>
-            <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
-              Graph filters
-            </ListSubheader>
-            {renderPresetChips(graphPresetItems, "graph")}
-          </>
-        )}
-        {columnItems.length > 0 && (
-          <>
-            <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
-              Fields shown
-            </ListSubheader>
-            {columnItems.map((column) => (
-              <ListItemButton
-                key={column.id}
-                dense
-                onClick={() => onToggleColumn(column.id, column.visible)}
-                sx={{ minHeight: 44, py: 0 }}
-              >
-                <Checkbox checked={column.visible} size="small" sx={{ mr: 1 }} tabIndex={-1} />
-                <ListItemText primary={getCippTranslation(column.id)} />
-              </ListItemButton>
-            ))}
-          </>
-        )}
-        <Divider sx={{ my: 1 }} />
-        <ListItemButton
-          onClick={() => {
-            onResetFilters();
-            setFilterOpen(false);
-          }}
-          sx={{ minHeight: 48 }}
-        >
-          <ListItemIcon sx={{ minWidth: 40 }}>
-            <RestartAlt fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="Reset all filters" />
-        </ListItemButton>
-        {onEditGraphFilters && (
-          <ListItemButton
-            onClick={() => filterSheet.run(onEditGraphFilters)}
-            sx={{ minHeight: 48 }}
-          >
-            <ListItemIcon sx={{ minWidth: 40 }}>
-              <FilterList fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="Edit graph filters" />
-          </ListItemButton>
-        )}
-        {exportEnabled && (
-          <>
-            <ListItemButton onClick={onExportCsv} sx={{ minHeight: 48 }}>
-              <ListItemIcon sx={{ minWidth: 40 }}>
-                <FileDownload fontSize="small" />
-              </ListItemIcon>
-              <ListItemText primary="Export to CSV" />
-            </ListItemButton>
-            <ListItemButton onClick={onExportPdf} sx={{ minHeight: 48 }}>
-              <ListItemIcon sx={{ minWidth: 40 }}>
-                <PictureAsPdf fontSize="small" />
-              </ListItemIcon>
-              <ListItemText primary="Export to PDF" />
-            </ListItemButton>
-          </>
-        )}
-        <ListItemButton
-          onClick={() => filterSheet.run(onViewApiResponse)}
-          sx={{ minHeight: 48 }}
-        >
-          <ListItemIcon sx={{ minWidth: 40 }}>
-            <DataObject fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary="View API response" />
-        </ListItemButton>
-        <ListItemButton
-          disabled={isRefreshing}
-          onClick={() => {
-            onRefresh();
-            setFilterOpen(false);
-          }}
-          sx={{ minHeight: 48 }}
-        >
-          <ListItemIcon sx={{ minWidth: 40 }}>
-            <Sync fontSize="small" />
-          </ListItemIcon>
-          <ListItemText primary={isRefreshing ? "Refreshing…" : "Refresh data"} />
-        </ListItemButton>
-      </CippBottomSheet>
+        run={filterSheet.run}
+        tablePresetItems={tablePresetItems}
+        graphPresetItems={graphPresetItems}
+        activeFilters={activeFilters}
+        presetKey={presetKey}
+        onPresetClick={onPresetClick}
+        columnItems={columnItems}
+        onToggleColumn={onToggleColumn}
+        onResetFilters={onResetFilters}
+        onEditGraphFilters={onEditGraphFilters}
+        exportEnabled={exportEnabled}
+        onExportCsv={onExportCsv}
+        onExportPdf={onExportPdf}
+        onViewApiResponse={onViewApiResponse}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
+        dataSourceControls={dataSourceControls}
+      />
 
       {/* Bulk action bar — bottom, in thumb reach, instead of the desktop top-toolbar strip */}
       {selectMode && selectionEnabled && (

--- a/frontend/src/components/CippTable/CippTableFilterSheet.jsx
+++ b/frontend/src/components/CippTable/CippTableFilterSheet.jsx
@@ -1,0 +1,211 @@
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Divider,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  Stack,
+} from "@mui/material";
+import {
+  Check,
+  DataObject,
+  FileDownload,
+  FilterList,
+  PictureAsPdf,
+  RestartAlt,
+  Sync,
+} from "@mui/icons-material";
+import { getCippTranslation } from "../../utils/get-cipp-translation";
+import { CippBottomSheet } from "../CippComponents/CippBottomSheet";
+
+// Shared filter bottom sheet — presets, field visibility, and the export/API-response
+// utilities that live behind the desktop Filters menu on narrow layouts. Used by the
+// mobile card list and the mobile/compact table toolbar, one code path for both.
+export const CippTableFilterSheet = (props) => {
+  const {
+    open,
+    onClose,
+    onExited,
+    run,
+    tablePresetItems = [],
+    graphPresetItems = [],
+    activeFilters = { graph: null, table: null },
+    presetKey,
+    onPresetClick,
+    columnItems = [],
+    onToggleColumn,
+    onResetFilters,
+    onEditGraphFilters,
+    exportEnabled = false,
+    onExportCsv,
+    onExportPdf,
+    onViewApiResponse,
+    onRefresh,
+    isRefreshing = false,
+    // section renders only when onPageSizeChange is provided (the table-view sheet)
+    pageSize,
+    onPageSizeChange,
+    pageSizeOptions = [],
+    dataSourceControls,
+  } = props;
+
+  const renderPresetChips = (items, layer) => (
+    <Stack direction="row" useFlexGap flexWrap="wrap" spacing={1} sx={{ px: 2.25, py: 1 }}>
+      {items.map((filter) => {
+        const key = presetKey(filter);
+        const active = activeFilters[layer]?.id === key;
+        return (
+          <Chip
+            key={key}
+            label={filter.filterName}
+            color={active ? "primary" : "default"}
+            variant={active ? "filled" : "outlined"}
+            icon={active ? <Check /> : undefined}
+            onClick={() => onPresetClick(filter)}
+            sx={{ height: 36, borderRadius: 999 }}
+          />
+        );
+      })}
+    </Stack>
+  );
+
+  return (
+    <CippBottomSheet
+      open={open}
+      onClose={onClose}
+      onExited={onExited}
+      title="Filters"
+      footer={
+        <Button fullWidth variant="contained" sx={{ minHeight: 44 }} onClick={onClose}>
+          Done
+        </Button>
+      }
+    >
+      {dataSourceControls && (
+        <>
+          <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
+            Data source
+          </ListSubheader>
+          <Box sx={{ px: 2.25, py: 1 }}>{dataSourceControls}</Box>
+        </>
+      )}
+      {tablePresetItems.length > 0 && (
+        <>
+          <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
+            Presets
+          </ListSubheader>
+          {renderPresetChips(tablePresetItems, "table")}
+        </>
+      )}
+      {graphPresetItems.length > 0 && (
+        <>
+          <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
+            Graph filters
+          </ListSubheader>
+          {renderPresetChips(graphPresetItems, "graph")}
+        </>
+      )}
+      {columnItems.length > 0 && (
+        <>
+          <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
+            Fields shown
+          </ListSubheader>
+          {columnItems.map((column) => (
+            <ListItemButton
+              key={column.id}
+              dense
+              onClick={() => onToggleColumn(column.id, column.visible)}
+              sx={{ minHeight: 44, py: 0 }}
+            >
+              <Checkbox checked={column.visible} size="small" sx={{ mr: 1 }} tabIndex={-1} />
+              <ListItemText primary={getCippTranslation(column.id)} />
+            </ListItemButton>
+          ))}
+        </>
+      )}
+      {onPageSizeChange && pageSizeOptions.length > 0 && (
+        <>
+          <ListSubheader disableSticky sx={{ bgcolor: "transparent" }}>
+            Rows per page
+          </ListSubheader>
+          <Stack direction="row" useFlexGap flexWrap="wrap" spacing={1} sx={{ px: 2.25, py: 1 }}>
+            {pageSizeOptions.map((option) => {
+              const active = option === pageSize;
+              return (
+                <Chip
+                  key={option}
+                  label={String(option)}
+                  color={active ? "primary" : "default"}
+                  variant={active ? "filled" : "outlined"}
+                  icon={active ? <Check /> : undefined}
+                  onClick={() => onPageSizeChange(option)}
+                  sx={{ height: 36, borderRadius: 999 }}
+                />
+              );
+            })}
+          </Stack>
+        </>
+      )}
+      <Divider sx={{ my: 1 }} />
+      <ListItemButton
+        onClick={() => {
+          onResetFilters();
+          onClose();
+        }}
+        sx={{ minHeight: 48 }}
+      >
+        <ListItemIcon sx={{ minWidth: 40 }}>
+          <RestartAlt fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Reset all filters" />
+      </ListItemButton>
+      {onEditGraphFilters && (
+        <ListItemButton onClick={() => run(onEditGraphFilters)} sx={{ minHeight: 48 }}>
+          <ListItemIcon sx={{ minWidth: 40 }}>
+            <FilterList fontSize="small" />
+          </ListItemIcon>
+          <ListItemText primary="Edit graph filters" />
+        </ListItemButton>
+      )}
+      {exportEnabled && (
+        <>
+          <ListItemButton onClick={onExportCsv} sx={{ minHeight: 48 }}>
+            <ListItemIcon sx={{ minWidth: 40 }}>
+              <FileDownload fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Export to CSV" />
+          </ListItemButton>
+          <ListItemButton onClick={onExportPdf} sx={{ minHeight: 48 }}>
+            <ListItemIcon sx={{ minWidth: 40 }}>
+              <PictureAsPdf fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Export to PDF" />
+          </ListItemButton>
+        </>
+      )}
+      <ListItemButton onClick={() => run(onViewApiResponse)} sx={{ minHeight: 48 }}>
+        <ListItemIcon sx={{ minWidth: 40 }}>
+          <DataObject fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="View API response" />
+      </ListItemButton>
+      <ListItemButton
+        disabled={isRefreshing}
+        onClick={() => {
+          onRefresh();
+          onClose();
+        }}
+        sx={{ minHeight: 48 }}
+      >
+        <ListItemIcon sx={{ minWidth: 40 }}>
+          <Sync fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary={isRefreshing ? "Refreshing…" : "Refresh data"} />
+      </ListItemButton>
+    </CippBottomSheet>
+  );
+};

--- a/frontend/src/components/CippTable/toolbar-primitives.js
+++ b/frontend/src/components/CippTable/toolbar-primitives.js
@@ -1,0 +1,103 @@
+import { styled, alpha } from '@mui/material/styles'
+import { Button, IconButton, InputBase, Paper } from '@mui/material'
+
+// shared toolbar styling for the desktop table toolbar and the mobile card controls bar
+
+export const ModernSearchContainer = styled(Paper)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  maxWidth: '300px',
+  minWidth: '200px',
+  height: '40px',
+  backgroundColor: theme.palette.mode === 'dark' ? '#2A2D3A' : '#F8F9FA',
+  border: `1px solid ${theme.palette.mode === 'dark' ? '#404040' : '#E0E0E0'}`,
+  borderRadius: '8px',
+  padding: '0 12px',
+  '&:hover': {
+    borderColor: theme.palette.primary.main,
+  },
+  '&:focus-within': {
+    borderColor: theme.palette.primary.main,
+    boxShadow: `0 0 0 2px ${alpha(theme.palette.primary.main, 0.2)}`,
+  },
+  [theme.breakpoints.down('md')]: {
+    minWidth: '0',
+    maxWidth: 'none',
+    flex: 1,
+  },
+}))
+
+export const ModernSearchInput = styled(InputBase)(({ theme }) => ({
+  marginLeft: theme.spacing(1),
+  flex: 1,
+  fontSize: '14px',
+  '& .MuiInputBase-input': {
+    padding: '8px 0',
+    '&::placeholder': {
+      color: theme.palette.text.secondary,
+      opacity: 0.7,
+    },
+  },
+}))
+
+export const ModernButton = styled(Button)(({ theme }) => ({
+  height: '40px',
+  borderRadius: '8px',
+  textTransform: 'none',
+  fontWeight: 500,
+  fontSize: '14px',
+  padding: '8px 16px',
+  backgroundColor: theme.palette.mode === 'dark' ? '#2A2D3A' : '#F8F9FA',
+  border: `1px solid ${theme.palette.mode === 'dark' ? '#404040' : '#E0E0E0'}`,
+  color: theme.palette.text.primary,
+  minWidth: 'auto',
+  whiteSpace: 'nowrap',
+  '&:hover': {
+    backgroundColor: theme.palette.mode === 'dark' ? '#363A4A' : '#F0F0F0',
+    borderColor: theme.palette.primary.main,
+  },
+  '& .MuiButton-startIcon': {
+    marginRight: '8px',
+  },
+  '& .MuiButton-endIcon': {
+    marginLeft: '8px',
+  },
+  [theme.breakpoints.down('md')]: {
+    padding: '8px 12px',
+    fontSize: '13px',
+    '& .MuiButton-startIcon': {
+      marginRight: '6px',
+    },
+    '& .MuiButton-endIcon': {
+      marginLeft: '6px',
+    },
+  },
+  [theme.breakpoints.down('sm')]: {
+    padding: '8px 10px',
+    fontSize: '12px',
+    '& .MuiButton-startIcon': {
+      marginRight: '4px',
+    },
+    '& .MuiButton-endIcon': {
+      marginLeft: '4px',
+    },
+  },
+}))
+
+// tonal icon button matching ModernButton, 44px for phone touch targets
+export const ModernIconButton = styled(IconButton)(({ theme }) => ({
+  width: '44px',
+  height: '44px',
+  borderRadius: '8px',
+  backgroundColor: theme.palette.mode === 'dark' ? '#2A2D3A' : '#F8F9FA',
+  border: `1px solid ${theme.palette.mode === 'dark' ? '#404040' : '#E0E0E0'}`,
+  color: theme.palette.text.primary,
+  flexShrink: 0,
+  '&:hover': {
+    backgroundColor: theme.palette.mode === 'dark' ? '#363A4A' : '#F0F0F0',
+    borderColor: theme.palette.primary.main,
+  },
+}))
+
+export const RefreshButton = styled(IconButton)(({ theme }) => ({}))

--- a/frontend/src/components/CippTable/util-tablemode.js
+++ b/frontend/src/components/CippTable/util-tablemode.js
@@ -11,7 +11,8 @@ export const utilTableMode = (
   onChange,
   maxHeightOffset = '380px',
   settings = {},
-  viewMode = 'table'
+  viewMode = 'table',
+  narrowTable = false
 ) => {
   if (mode === true) {
     return {
@@ -63,9 +64,18 @@ export const utilTableMode = (
       enableColumnPinning: !isCards,
       muiPaginationProps: {
         rowsPerPageOptions: [25, 50, 100, 250, 500],
+        // a full footer wraps below MRT's 720px pivot, the extra row scrolls the page chrome
+        ...(narrowTable && {
+          showRowsPerPage: false,
+          showFirstButton: false,
+          showLastButton: false,
+        }),
       },
       muiTableContainerProps: {
-        sx: { maxHeight: `calc(100vh - ${maxHeightOffset})` },
+        // offset numbers are tuned against desktop chrome, narrow viewports page-scroll
+        sx: {
+          maxHeight: narrowTable ? 'none' : `calc(100vh - ${maxHeightOffset})`,
+        },
       },
       displayColumnDefOptions: {
         'mrt-row-actions': {

--- a/frontend/src/hooks/use-breakpoint.js
+++ b/frontend/src/hooks/use-breakpoint.js
@@ -8,7 +8,7 @@ import { useSettings } from "./use-settings";
 export const useIsMobileLayout = () => useMediaQuery((theme) => theme.breakpoints.down("lg"));
 
 // Tables pivot narrower: a table still reads fine at 1100, cards that wide are mostly whitespace.
-const useIsNarrowForTables = () => useMediaQuery((theme) => theme.breakpoints.down("md"));
+export const useIsNarrowForTables = () => useMediaQuery((theme) => theme.breakpoints.down("md"));
 
 export const useIsTabletLayout = () =>
   useMediaQuery((theme) => theme.breakpoints.between("sm", "md"));

--- a/frontend/src/pages/email/administration/hve-accounts/index.js
+++ b/frontend/src/pages/email/administration/hve-accounts/index.js
@@ -190,9 +190,9 @@ const Page = () => {
         cardButton={
           <Stack direction="row" spacing={1} alignItems="center">
             <CippHVEUserDrawer />
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/email/administration/mailbox-rules/index.js
+++ b/frontend/src/pages/email/administration/mailbox-rules/index.js
@@ -114,7 +114,7 @@ const Page = () => {
         simpleColumns={simpleColumns}
         offCanvas={offCanvas}
         actions={actions}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/email/administration/mailboxes/index.js
+++ b/frontend/src/pages/email/administration/mailboxes/index.js
@@ -101,9 +101,9 @@ const Page = () => {
         cardButton={
           <Stack direction="row" spacing={1} alignItems="center">
             <CippSharedMailboxDrawer />
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/email/administration/tenant-allow-block-lists/index.js
+++ b/frontend/src/pages/email/administration/tenant-allow-block-lists/index.js
@@ -61,9 +61,9 @@ const Page = () => {
         cardButton={
           <Stack direction="row" spacing={1} alignItems="center">
             <CippAddTenantAllowBlockListDrawer requiredPermissions={cardButtonPermissions} />
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/email/reports/SharedMailboxEnabledAccount/index.js
+++ b/frontend/src/pages/email/reports/SharedMailboxEnabledAccount/index.js
@@ -29,7 +29,7 @@ const Page = () => {
         title="Shared Mailbox with Enabled Account"
         apiUrl={reportDB.resolvedApiUrl}
         queryKey={reportDB.resolvedQueryKey}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
         actions={[
           {
             label: "Block Sign In",

--- a/frontend/src/pages/email/reports/calendar-permissions/index.js
+++ b/frontend/src/pages/email/reports/calendar-permissions/index.js
@@ -56,7 +56,6 @@ const Page = () => {
           variant="outlined"
         />
       </Tooltip>
-      {reportDB.controls}
     </Stack>
   )
 
@@ -70,6 +69,7 @@ const Page = () => {
         apiData={{ ...reportDB.resolvedApiData, ByUser: byUser }}
         simpleColumns={columns}
         cardButton={pageActions}
+        dataSourceControls={reportDB.controls}
         offCanvas={null}
       />
       {reportDB.syncDialog}

--- a/frontend/src/pages/email/reports/mailbox-forwarding/index.js
+++ b/frontend/src/pages/email/reports/mailbox-forwarding/index.js
@@ -45,7 +45,7 @@ const Page = () => {
         apiData={reportDB.resolvedApiData}
         simpleColumns={columns}
         filters={filters}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
         offCanvas={null}
       />
       {reportDB.syncDialog}

--- a/frontend/src/pages/email/reports/mailbox-permissions/index.js
+++ b/frontend/src/pages/email/reports/mailbox-permissions/index.js
@@ -181,7 +181,6 @@ const Page = () => {
           variant="outlined"
         />
       </Tooltip>
-      {reportDB.controls}
     </Stack>
   )
 
@@ -196,6 +195,7 @@ const Page = () => {
         simpleColumns={columns}
         actions={byUser ? byUserActions : byMailboxActions}
         cardButton={pageActions}
+        dataSourceControls={reportDB.controls}
         offCanvas={null}
       />
       {reportDB.syncDialog}

--- a/frontend/src/pages/endpoint/MEM/assignment-filters/index.js
+++ b/frontend/src/pages/endpoint/MEM/assignment-filters/index.js
@@ -88,9 +88,9 @@ const Page = () => {
             <Button component={Link} href="assignment-filters/add" startIcon={<Add />}>
               Add Assignment Filter
             </Button>
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
         apiUrl={reportDB.resolvedApiUrl}
         queryKey={reportDB.resolvedQueryKey}
         actions={actions}

--- a/frontend/src/pages/endpoint/MEM/list-appprotection-policies/index.js
+++ b/frontend/src/pages/endpoint/MEM/list-appprotection-policies/index.js
@@ -67,9 +67,9 @@ const Page = () => {
               requiredPermissions={cardButtonPermissions}
               PermissionButton={PermissionButton}
             />
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/endpoint/MEM/list-compliance-policies/index.js
+++ b/frontend/src/pages/endpoint/MEM/list-compliance-policies/index.js
@@ -65,9 +65,9 @@ const Page = () => {
               requiredPermissions={cardButtonPermissions}
               PermissionButton={PermissionButton}
             />
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/endpoint/MEM/list-policies/index.js
+++ b/frontend/src/pages/endpoint/MEM/list-policies/index.js
@@ -69,9 +69,9 @@ const Page = () => {
               requiredPermissions={cardButtonPermissions}
               PermissionButton={PermissionButton}
             />
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/endpoint/MEM/list-scripts/index.jsx
+++ b/frontend/src/pages/endpoint/MEM/list-scripts/index.jsx
@@ -502,7 +502,7 @@ const Page = () => {
         actions={actions}
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
 
       <Dialog open={codeOpen} maxWidth="lg" fullWidth>

--- a/frontend/src/pages/endpoint/MEM/reusable-settings/index.js
+++ b/frontend/src/pages/endpoint/MEM/reusable-settings/index.js
@@ -76,9 +76,9 @@ const Page = () => {
         cardButton={
           <Stack direction="row" spacing={1} alignItems="center">
             <CippReusableSettingsDeployDrawer requiredPermissions={["Endpoint.MEM.ReadWrite"]} />
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
         apiUrl={reportDB.resolvedApiUrl}
         queryKey={reportDB.resolvedQueryKey}
         actions={actions}

--- a/frontend/src/pages/endpoint/applications/list/index.js
+++ b/frontend/src/pages/endpoint/applications/list/index.js
@@ -386,9 +386,9 @@ const Page = () => {
             <Button onClick={vppSyncDialog.handleOpen} startIcon={<Sync />}>
               Sync VPP
             </Button>
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       <CippApiDialog
         title="Sync VPP Tokens"

--- a/frontend/src/pages/identity/administration/groups/index.js
+++ b/frontend/src/pages/identity/administration/groups/index.js
@@ -380,9 +380,9 @@ const Page = () => {
             >
               Deploy Group Template
             </Button>
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
         apiUrl={reportDB.resolvedApiUrl}
         apiData={
           reportDB.useReportDB

--- a/frontend/src/pages/identity/reports/inactive-users-report/index.js
+++ b/frontend/src/pages/identity/reports/inactive-users-report/index.js
@@ -89,7 +89,7 @@ const Page = () => {
         actions={actions}
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/identity/reports/mfa-report/index.js
+++ b/frontend/src/pages/identity/reports/mfa-report/index.js
@@ -117,7 +117,7 @@ const Page = () => {
         simpleColumns={simpleColumns}
         filters={filters}
         actions={actions}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
         initialFilters={urlFilters}
       />
       {reportDB.syncDialog}

--- a/frontend/src/pages/security/reports/mde-onboarding/index.js
+++ b/frontend/src/pages/security/reports/mde-onboarding/index.js
@@ -355,7 +355,7 @@ const Page = () => {
           "partnerUnresponsivenessThresholdInDays",
           "CacheTimestamp",
         ]}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/teams-share/onedrive/index.js
+++ b/frontend/src/pages/teams-share/onedrive/index.js
@@ -119,7 +119,7 @@ const Page = () => {
         queryKey={reportDB.resolvedQueryKey}
         actions={actions}
         simpleColumns={simpleColumns}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/teams-share/sharepoint/index.js
+++ b/frontend/src/pages/teams-share/sharepoint/index.js
@@ -712,7 +712,6 @@ const Page = () => {
       >
         Bulk Add Sites
       </Button>
-      {reportDB.controls}
     </Stack>
   )
 
@@ -727,6 +726,7 @@ const Page = () => {
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
         cardButton={pageActions}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/teams-share/teams/business-voice/index.js
+++ b/frontend/src/pages/teams-share/teams/business-voice/index.js
@@ -139,7 +139,7 @@ const Page = () => {
               "Complex: AssignmentStatus eq Unassigned; AcquiredCapabilities like UserAssignment",
           },
         ]}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/teams-share/teams/list-team/index.js
+++ b/frontend/src/pages/teams-share/teams/list-team/index.js
@@ -62,9 +62,9 @@ const Page = () => {
             <Button component={Link} href="/teams-share/teams/list-team/add" startIcon={<GroupAdd />}>
               Add Team
             </Button>
-            {reportDB.controls}
           </Stack>
         }
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/teams-share/teams/teams-activity/index.js
+++ b/frontend/src/pages/teams-share/teams/teams-activity/index.js
@@ -39,7 +39,7 @@ const Page = () => {
           "CallCount",
           "TeamsChat",
         ]}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/tenant/reports/application-consent/index.js
+++ b/frontend/src/pages/tenant/reports/application-consent/index.js
@@ -31,7 +31,7 @@ const Page = () => {
         apiUrl={reportDB.resolvedApiUrl}
         queryKey={reportDB.resolvedQueryKey}
         simpleColumns={simpleColumns}
-        cardButton={reportDB.controls}
+        dataSourceControls={reportDB.controls}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/tests/components/CippComponents/CippSettingsSideBar.test.jsx
+++ b/frontend/tests/components/CippComponents/CippSettingsSideBar.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+import { renderWithProviders } from '../../test-utils'
+
+vi.mock('../../../src/api/ApiCall', async () => (await import('../../mocks/api-call')).apiCallMock())
+import { api, getResult, postResult } from '../../mocks/api-call'
+
+import { CippSettingsSideBar } from '../../../src/components/CippComponents/CippSettingsSideBar'
+
+const meResult = getResult({ data: { clientPrincipal: { userDetails: 'admin@contoso.com' } } })
+api.get = meResult
+
+// handleSaveChanges posts an explicit field allowlist, a preference missing from it saves
+// as a silent no-op ("Settings saved successfully" toast, nothing stored)
+const Harness = () => {
+  const formcontrol = useForm({
+    defaultValues: {
+      user: { label: 'Current User', value: 'admin@contoso.com' },
+      tableViewMode: { value: 'table', label: 'Always classic table' },
+      tablePageSize: { value: '50', label: '50' },
+    },
+  })
+  return <CippSettingsSideBar formcontrol={formcontrol} />
+}
+
+describe('CippSettingsSideBar save allowlist', () => {
+  it('Save Changes posts tableViewMode with the settings blob', async () => {
+    const user = userEvent.setup()
+    api.post = postResult()
+    renderWithProviders(<Harness />)
+
+    await user.click(await screen.findByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => expect(api.post.mutate).toHaveBeenCalled())
+    const payload = api.post.mutate.mock.calls[0][0]
+    expect(payload.data.user).toBe('admin@contoso.com')
+    expect(payload.data.currentSettings.tableViewMode).toEqual({
+      value: 'table',
+      label: 'Always classic table',
+    })
+    expect(payload.data.currentSettings.tablePageSize).toEqual({ value: '50', label: '50' })
+  })
+})

--- a/frontend/tests/components/CippTable/CIPPTableToptoolbar.test.jsx
+++ b/frontend/tests/components/CippTable/CIPPTableToptoolbar.test.jsx
@@ -388,3 +388,25 @@ describe('CIPPTableToptoolbar - preset list refresh', () => {
     })
   }, 30000)
 })
+
+describe('CIPPTableToptoolbar desktop export', () => {
+  it('Export menu carries the row exports and opens the API response viewer', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <CippDataTable
+        data={rows}
+        simpleColumns={['displayName', 'mail']}
+        title="Users"
+        maxHeightOffset="100px"
+      />
+    )
+    await screen.findByText('Users')
+
+    await user.click(screen.getByRole('button', { name: /Export/ }))
+    await screen.findByRole('menuitem', { name: 'Export to CSV' })
+    expect(screen.getByRole('menuitem', { name: 'Export to PDF' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('menuitem', { name: 'View API Response' }))
+    await screen.findByText('API Response')
+  })
+})

--- a/frontend/tests/components/CippTable/CippMobileCardList.stories.jsx
+++ b/frontend/tests/components/CippTable/CippMobileCardList.stories.jsx
@@ -4,10 +4,9 @@ import { Box, Button } from '@mui/material'
 import { Add, Block, Delete, Edit } from '@mui/icons-material'
 import { CippDataTable } from '../../../src/components/CippTable/CippDataTable'
 import { SettingsProvider } from '../../../src/contexts/settings-context'
+import { shrinkToPhoneViewport, growToDesktopViewport } from '../../viewport'
 
-// Card view is normally chosen by viewport (below md), but no story in this repo sets a
-// viewport — the explicit viewMode prop is the supported override and is what the unit
-// tests use too.
+// most stories force cards via the viewMode prop; TableViewToggle shrinks the real viewport instead, since the toggle needs no explicit prop
 const users = [
   {
     id: 'u-1',
@@ -100,6 +99,17 @@ export const Default = {
       const body = within(document.body)
       await waitFor(() => expect(body.getByText('Block sign-in')).toBeInTheDocument())
       expect(body.getByText('Delete user')).toBeInTheDocument()
+      await userEvent.keyboard('{Escape}')
+      await waitFor(() => expect(body.queryByRole('dialog')).toBeNull())
+    })
+
+    await step('Filters opens the shared bottom sheet with the card fields', async () => {
+      const body = within(document.body)
+      await userEvent.click(canvas.getByRole('button', { name: 'Table options' }))
+      const filterSheet = await body.findByRole('dialog')
+      expect(within(filterSheet).getByText('Fields shown')).toBeInTheDocument()
+      await userEvent.keyboard('{Escape}')
+      await waitFor(() => expect(body.queryByRole('dialog')).toBeNull())
     })
   },
 }
@@ -240,5 +250,174 @@ export const MobileCards = {
       const matched = await applyDepartmentSearch(canvas)
       expect(matched).toHaveLength(2)
     })
+  },
+}
+
+export const TableViewToggle = {
+  render: () => (
+    <SettingsProvider>
+      <CippDataTable data={users} simpleColumns={simpleColumns} title="Users" />
+    </SettingsProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    // shrink for real: a viewMode prop would also force cards, but hides the toggle (precedence rule)
+    const onAPhone = await shrinkToPhoneViewport()
+    const canvas = within(canvasElement)
+    await canvas.findByText('Alice Smith')
+    if (!onAPhone) {
+      return
+    }
+
+    // 'Alice Smith' renders in both branches, so the card list itself has to settle
+    await waitFor(() => expect(canvas.getByTestId('cipp-mobile-card-list')).toBeInTheDocument())
+
+    await userEvent.click(await canvas.findByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => {
+      expect(canvasElement.querySelector('table')).not.toBeNull()
+      expect(canvas.queryByTestId('cipp-mobile-card-list')).toBeNull()
+    })
+
+    // real MRT table mounts with the page's configured columns
+    await waitFor(() => expect(canvas.getAllByRole('columnheader').length).toBeGreaterThan(0))
+    const headerText = canvas.getAllByRole('columnheader').map((cell) => cell.textContent)
+    expect(headerText.some((text) => text.includes('Display Name'))).toBe(true)
+
+    // transient: the toggle never persists
+    const persisted = JSON.parse(window.localStorage.getItem('app.settings'))
+    expect(persisted.tableViewMode).toBe('auto')
+
+    // phone table bar: kebab opens the shared sheet, which carries refresh.
+    // MUI's Tooltip stamps the 'Refresh data' aria-label onto the wrapping span, so that's
+    // the queryable anchor for the desktop refresh button (the IconButton has no name of its own)
+    expect(canvasElement.querySelector('[aria-label="Refresh data"]')).toBeNull()
+    const optionsButton = canvas.getByRole('button', { name: 'Table options' })
+    await userEvent.click(optionsButton)
+    const filterSheet = await within(document.body).findByRole('dialog')
+    expect(within(filterSheet).getByText('Fields shown')).toBeInTheDocument()
+    expect(within(filterSheet).getByText('Reset all filters')).toBeInTheDocument()
+    expect(within(filterSheet).getByText('Refresh data')).toBeInTheDocument()
+    // the sheet owns page size on phones, current size marked active
+    expect(within(filterSheet).getByText('Rows per page')).toBeInTheDocument()
+    const activeSize = within(filterSheet).getByText('25').closest('.MuiChip-root')
+    expect(activeSize.className).toContain('MuiChip-filled')
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(within(document.body).queryByRole('dialog')).toBeNull())
+
+    // same aria-label, now the desktop toolbar's "way back" button
+    await userEvent.click(canvas.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(canvas.getByTestId('cipp-mobile-card-list')).toBeInTheDocument())
+  },
+}
+
+export const TableViewToggleWithActions = {
+  // render ignores the meta's default args (viewMode: 'cards' would hide the toggle button)
+  render: () => (
+    <SettingsProvider>
+      <CippDataTable
+        data={users}
+        simpleColumns={simpleColumns}
+        title="Users"
+        cardButton={
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button variant="contained" startIcon={<Add />}>
+              Add User
+            </Button>
+          </Box>
+        }
+      />
+    </SettingsProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const onAPhone = await shrinkToPhoneViewport()
+    const canvas = within(canvasElement)
+    const body = within(document.body)
+    await canvas.findByText('Alice Smith')
+    if (!onAPhone) {
+      return
+    }
+
+    await waitFor(() => expect(canvas.getByTestId('cipp-mobile-card-list')).toBeInTheDocument())
+
+    await userEvent.click(await canvas.findByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => {
+      expect(canvasElement.querySelector('table')).not.toBeNull()
+      expect(canvas.queryByTestId('cipp-mobile-card-list')).toBeNull()
+    })
+
+    // narrow table view: cardButton lives behind the page actions FAB, absent from the canvas until opened
+    expect(canvas.queryByRole('button', { name: 'Add User' })).toBeNull()
+    const fab = await body.findByRole('button', { name: 'Page actions' })
+
+    await userEvent.click(fab)
+    await waitFor(() => expect(body.getByRole('button', { name: 'Add User' })).toBeInTheDocument())
+  },
+}
+
+export const TableViewToggleBulkActionsInHeader = {
+  // render ignores the meta's default args, same reason as the sibling toggle stories
+  render: () => (
+    <SettingsProvider>
+      <CippDataTable data={users} simpleColumns={simpleColumns} title="Users" actions={actions} />
+    </SettingsProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const onAPhone = await shrinkToPhoneViewport()
+    const canvas = within(canvasElement)
+    await canvas.findByText('Alice Smith')
+    if (!onAPhone) {
+      return
+    }
+
+    await waitFor(() => expect(canvas.getByTestId('cipp-mobile-card-list')).toBeInTheDocument())
+    await userEvent.click(await canvas.findByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => {
+      expect(canvasElement.querySelector('table')).not.toBeNull()
+      expect(canvas.queryByTestId('cipp-mobile-card-list')).toBeNull()
+    })
+
+    const firstRow = await waitFor(() => {
+      const row = canvasElement.querySelector('tbody tr')
+      expect(row).not.toBeNull()
+      return row
+    })
+    await userEvent.click(within(firstRow).getByRole('checkbox'))
+
+    // the mostly-empty header row is where the narrow toolbar's selection UI lands
+    const header = canvasElement.querySelector('.MuiCardHeader-root')
+    await waitFor(() => {
+      expect(within(header).getByText(/rows selected/)).toBeInTheDocument()
+      expect(within(header).getByRole('button', { name: 'Bulk Actions' })).toBeInTheDocument()
+    })
+    // exactly one Bulk Actions button on screen — it moved, it did not duplicate
+    expect(canvas.getAllByRole('button', { name: 'Bulk Actions' })).toHaveLength(1)
+
+    await userEvent.click(within(header).getByRole('button', { name: 'Bulk Actions' }))
+    const body = within(document.body)
+    await waitFor(() => expect(body.getByText('Delete user')).toBeInTheDocument())
+    await userEvent.keyboard('{Escape}')
+  },
+}
+
+export const DesktopBulkActionsStayInToolbar = {
+  args: {
+    title: 'Users',
+    viewMode: 'table',
+    data: users,
+    simpleColumns,
+    actions,
+  },
+  play: async ({ canvasElement }) => {
+    await growToDesktopViewport()
+    const canvas = within(canvasElement)
+    await waitFor(() => expect(canvasElement.querySelector('table')).not.toBeNull())
+    await canvas.findByText('Alice Smith')
+
+    const firstRow = canvasElement.querySelector('tbody tr')
+    await userEvent.click(within(firstRow).getByRole('checkbox'))
+
+    await waitFor(() => expect(canvas.getByRole('button', { name: 'Bulk Actions' })).toBeInTheDocument())
+    // the header exists (title-only, no cardButton on this story) but never received the portal
+    const header = canvasElement.querySelector('.MuiCardHeader-root')
+    expect(within(header).queryByRole('button', { name: 'Bulk Actions' })).toBeNull()
   },
 }

--- a/frontend/tests/components/CippTable/CippMobileCardList.test.jsx
+++ b/frontend/tests/components/CippTable/CippMobileCardList.test.jsx
@@ -1,0 +1,320 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Button } from '@mui/material'
+import { renderWithProviders, settingsWith } from '../../test-utils'
+
+// jsdom matchMedia never matches, so this overrides only useIsNarrowForTables for the FAB pivot, useTableViewMode stays real
+const narrowState = vi.hoisted(() => ({ narrow: false }))
+vi.mock('../../../src/hooks/use-breakpoint', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useIsNarrowForTables: () => narrowState.narrow }
+})
+
+import { CippDataTable } from '../../../src/components/CippTable/CippDataTable'
+
+// wide enough that full mode overflows into "+N more fields"
+const users = [
+  {
+    displayName: 'Alice Smith',
+    userPrincipalName: 'alice@contoso.com',
+    department: 'IT',
+    jobTitle: 'Engineer',
+    city: 'Seattle',
+    country: 'US',
+    accountEnabled: true,
+  },
+]
+const columns = [
+  'displayName',
+  'userPrincipalName',
+  'department',
+  'jobTitle',
+  'city',
+  'country',
+  'accountEnabled',
+]
+
+// no viewMode prop, so settings.tableViewMode='cards' forces cards but leaves the toggle allowed
+const renderCards = (settings = {}, componentProps = {}) =>
+  renderWithProviders(
+    <CippDataTable data={users} simpleColumns={columns} title="Users" {...componentProps} />,
+    { settings: settingsWith({ tableViewMode: 'cards', ...settings }) }
+  )
+
+describe('CippMobileCardList card anatomy', () => {
+  it('shows the slotted anatomy: overflow counter, secondary slot as bare text', async () => {
+    renderCards()
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    // details cap at 3 of the 4 remaining columns -> 1 overflow
+    expect(screen.getByText(/more field/)).toBeInTheDocument()
+    // secondary slot is bare text, its column label never renders
+    expect(screen.queryByText('User Principal Name')).not.toBeInTheDocument()
+  })
+})
+
+describe('CippMobileCardList table view toggle', () => {
+  afterEach(() => {
+    narrowState.narrow = false
+  })
+
+  it('opens the table view and the way back restores cards, never touching settings', async () => {
+    // narrow viewport: the round trip must hand back the card view intact
+    narrowState.narrow = true
+    const user = userEvent.setup()
+    const handleUpdate = vi.fn()
+    const { container } = renderCards({ handleUpdate })
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    expect(screen.getByTestId('cipp-mobile-card-list')).toBeInTheDocument()
+    expect(screen.getByText('Department')).toBeInTheDocument()
+    expect(screen.getByText(/more field/)).toBeInTheDocument()
+
+    // jsdom renders no MRT header/row text, so just check the table mounts and cards unmount
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(container.querySelector('table')).not.toBeNull())
+    expect(screen.queryByTestId('cipp-mobile-card-list')).not.toBeInTheDocument()
+
+    // same aria-label, now the desktop toolbar's "way back" button
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(screen.getByTestId('cipp-mobile-card-list')).toBeInTheDocument())
+
+    // full card content is back: detail rows and the overflow counter
+    expect(screen.getByText('Department')).toBeInTheDocument()
+    expect(screen.getByText(/more field/)).toBeInTheDocument()
+
+    // transient: the view toggle never persists
+    expect(handleUpdate).not.toHaveBeenCalled()
+  })
+
+  it('the toggled table keeps every configured column visible', async () => {
+    narrowState.narrow = true
+    const user = userEvent.setup()
+    renderCards()
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Columns' })).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'Columns' }))
+
+    // Columns menu reads table.getAllColumns(), unaffected by the virtualized header row
+    const menu = within(screen.getAllByRole('menu')[0])
+    const checkbox = (name) => within(menu.getByRole('menuitem', { name })).getByRole('checkbox')
+    for (const name of [
+      'Display Name',
+      'User Principal Name',
+      'Account Enabled',
+      'Department',
+      'Job Title',
+      'City',
+      'Country',
+    ]) {
+      expect(checkbox(name)).toBeChecked()
+    }
+  })
+
+  it('a Fields shown toggle in the shared filter sheet changes what the card renders', async () => {
+    const user = userEvent.setup()
+    renderCards()
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    // department is a detail row on the card before the toggle
+    expect(screen.getByText('Department')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Table options' }))
+    await screen.findByText('Fields shown')
+    // the sheet is a portal appended to body, so its entry sorts after the card's label
+    await user.click(screen.getAllByText('Department').at(-1))
+    await user.click(screen.getByRole('button', { name: 'Done' }))
+
+    await waitFor(() => expect(screen.queryByText('Department')).not.toBeInTheDocument())
+  })
+
+  it('an explicit viewMode prop hides the toggle button', async () => {
+    renderWithProviders(
+      <CippDataTable viewMode="cards" data={users} simpleColumns={columns} title="Users" />,
+      { settings: settingsWith() }
+    )
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: 'Toggle table view' })).not.toBeInTheDocument()
+  })
+
+  // Regression: the cards branch and the table branch are two alternating CIPPTableToptoolbar
+  // instances (only one mounts at a time), so activeFilters/searchValue/restoredFiltersRef used
+  // to live in the toolbar's own useState and reset on every flip. The table-branch kebab is
+  // unreachable here (mdDown from useMediaQuery never matches in jsdom, and useCompactMode stays
+  // false since offsetWidth/scrollWidth are always 0) — reopening the sheet after the round trip
+  // is the observable proxy for "state survived the two remounts".
+  it('an applied preset and its badge survive a flip to table and back', async () => {
+    narrowState.narrow = true
+    const user = userEvent.setup()
+    const presetFilters = [
+      { filterName: 'IT department', value: [{ id: 'department', value: 'IT' }], type: 'column' },
+    ]
+    renderCards({}, { filters: presetFilters })
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Table options' }))
+    const sheet = await screen.findByRole('dialog')
+    await user.click(within(sheet).getByText('IT department'))
+    await user.click(within(sheet).getByRole('button', { name: 'Done' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    // preset active before the flip — the sheet's aria-hidden overlay is gone now
+    await waitFor(() => {
+      expect(within(screen.getByRole('button', { name: 'Table options' })).getByText('1')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(document.querySelector('table')).not.toBeNull())
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(screen.getByTestId('cipp-mobile-card-list')).toBeInTheDocument())
+
+    // badge count survived both remounts
+    expect(within(screen.getByRole('button', { name: 'Table options' })).getByText('1')).toBeInTheDocument()
+
+    // the preset chip is marked active too
+    await user.click(screen.getByRole('button', { name: 'Table options' }))
+    const reopened = await screen.findByRole('dialog')
+    const chip = within(reopened).getByText('IT department').closest('.MuiChip-root')
+    expect(chip.className).toContain('MuiChip-filled')
+  }, 15000)
+
+  it('a manual field-visibility change survives a flip, even with preferred columns saved for the page', async () => {
+    narrowState.narrow = true
+    const user = userEvent.setup()
+    // router mock resolves pageName to '' in tests, matching CIPPTableToptoolbar.test.jsx's convention
+    const allColumnsVisible = Object.fromEntries(columns.map((c) => [c, true]))
+    renderCards({ columnDefaults: { '': allColumnsVisible } })
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    expect(screen.getByText('Department')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Table options' }))
+    await screen.findByText('Fields shown')
+    await user.click(screen.getAllByText('Department').at(-1))
+    await user.click(screen.getByRole('button', { name: 'Done' }))
+    await waitFor(() => expect(screen.queryByText('Department')).not.toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(document.querySelector('table')).not.toBeNull())
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(screen.getByTestId('cipp-mobile-card-list')).toBeInTheDocument())
+
+    // the manual hide must not be reverted by the saved preferred-columns set on remount
+    expect(screen.queryByText('Department')).not.toBeInTheDocument()
+  }, 15000)
+})
+
+describe('CippMobileCardList table-view page actions FAB', () => {
+  afterEach(() => {
+    narrowState.narrow = false
+  })
+
+  it('narrow viewport moves cardButton into the actions FAB once toggled to table view', async () => {
+    narrowState.narrow = true
+    const user = userEvent.setup()
+    renderCards({}, { cardButton: <Button>Add user</Button> })
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Page actions' })).toBeInTheDocument())
+
+    // action content stays behind the FAB until opened
+    expect(screen.queryByRole('button', { name: 'Add user' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Page actions' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Add user' })).toBeInTheDocument())
+  })
+
+  it('desktop viewport keeps cardButton in the header, no FAB', async () => {
+    const user = userEvent.setup()
+    renderCards({}, { cardButton: <Button>Add user</Button> })
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Add user' })).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: 'Page actions' })).not.toBeInTheDocument()
+  })
+})
+
+// The Card header hosts a portal target for the toolbar's bulk-actions UI on narrow
+// viewports (CIPPTableToptoolbar's bulkActionsSlot). Row selection itself can't be driven
+// here: CippDataTable's table renders with enableRowVirtualization + enableColumnVirtualization
+// always on, and jsdom never reports a nonzero container size, so react-virtual computes an
+// empty range — thead and tbody both mount with zero cells (verified: no checkboxes, no
+// columnheaders, table-view page actions FAB tests above only ever check for the <table>
+// element itself, never header/row content). Selecting a row to exercise the portal is
+// covered in the CippMobileCardList.stories.jsx browser story instead.
+describe('CippMobileCardList table-view header mounts as the bulk-actions portal target', () => {
+  afterEach(() => {
+    narrowState.narrow = false
+  })
+
+  it('narrow + hideTitle + cardButton: header still mounts even though the FAB owns cardButton', async () => {
+    narrowState.narrow = true
+    const user = userEvent.setup()
+    const { container } = renderCards(
+      {},
+      { hideTitle: true, cardButton: <Button>Add user</Button> }
+    )
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(container.querySelector('table')).not.toBeNull())
+
+    // headerAction is undefined here (FAB owns cardButton), so the gate has to key off
+    // cardButton directly or this mounts nothing and the portal target never exists
+    expect(container.querySelector('.MuiCardHeader-root')).not.toBeNull()
+  })
+
+  it('desktop + hideTitle + cardButton: header mounts with cardButton in it, same as before', async () => {
+    const user = userEvent.setup()
+    const { container } = renderCards(
+      {},
+      { hideTitle: true, cardButton: <Button>Add user</Button> }
+    )
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(container.querySelector('table')).not.toBeNull())
+
+    const header = container.querySelector('.MuiCardHeader-root')
+    expect(header).not.toBeNull()
+    expect(within(header).getByRole('button', { name: 'Add user' })).toBeInTheDocument()
+  })
+})
+
+describe('CippMobileCardList data source controls', () => {
+  afterEach(() => {
+    narrowState.narrow = false
+  })
+
+  it('renders in the Table options sheet, not in the page actions FAB', async () => {
+    narrowState.narrow = true
+    const user = userEvent.setup()
+    renderCards(
+      {},
+      { dataSourceControls: <span>Live badge</span>, cardButton: <Button>Add user</Button> }
+    )
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Table options' }))
+    const filterSheet = await within(document.body).findByRole('dialog')
+    expect(within(filterSheet).getByText('Data source')).toBeInTheDocument()
+    expect(within(filterSheet).getByText('Live badge')).toBeInTheDocument()
+
+    await user.click(within(filterSheet).getByRole('button', { name: 'Done' }))
+    await waitFor(() => expect(within(document.body).queryByRole('dialog')).not.toBeInTheDocument())
+
+    // narrow + table view: cardButton lives behind the FAB, dataSourceControls must not follow it there
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Page actions' })).toBeInTheDocument())
+
+    // and the table's card header must not double-render them (sheet is the only narrow home)
+    expect(screen.queryByText('Live badge')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Page actions' }))
+    const fabSheet = await within(document.body).findByRole('dialog')
+    await waitFor(() => expect(within(fabSheet).getByRole('button', { name: 'Add user' })).toBeInTheDocument())
+    expect(within(fabSheet).queryByText('Live badge')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/tests/components/CippTable/util-tablemode.test.jsx
+++ b/frontend/tests/components/CippTable/util-tablemode.test.jsx
@@ -42,6 +42,26 @@ describe('utilTableMode', () => {
     expect(result.muiPaginationProps.rowsPerPageOptions).toBeDefined()
   })
 
+  it('narrow table slims the footer so it cannot wrap below MRT 720px pivot', () => {
+    const result = utilTableMode({}, false, null, [], false, null, '380px', defaultSettings, 'table', true)
+    expect(result.muiPaginationProps.showRowsPerPage).toBe(false)
+    expect(result.muiPaginationProps.showFirstButton).toBe(false)
+    expect(result.muiPaginationProps.showLastButton).toBe(false)
+  })
+
+  it('narrow table page-scrolls instead of keeping an inner scroll viewport', () => {
+    const result = utilTableMode({}, false, null, [], false, null, '380px', defaultSettings, 'table', true)
+    expect(result.muiTableContainerProps.sx.maxHeight).toBe('none')
+  })
+
+  it('wide table keeps the full footer and the viewport-budget maxHeight', () => {
+    const result = utilTableMode({}, false, null, [], false, null, '380px', defaultSettings, 'table', false)
+    expect(result.muiPaginationProps.showRowsPerPage).toBeUndefined()
+    expect(result.muiPaginationProps.showFirstButton).toBeUndefined()
+    expect(result.muiPaginationProps.showLastButton).toBeUndefined()
+    expect(result.muiTableContainerProps.sx.maxHeight).toBe('calc(100vh - 380px)')
+  })
+
   it('returns table container height config', () => {
     const result = utilTableMode({}, false, null, [], false, null, '500px', defaultSettings)
     expect(result.muiTableContainerProps).toBeDefined()

--- a/frontend/tests/components/CippWizard/CippWizardAutopilotImport.test.jsx
+++ b/frontend/tests/components/CippWizard/CippWizardAutopilotImport.test.jsx
@@ -8,7 +8,9 @@ import { CippWizardAutopilotImport } from '../../../src/components/CippWizard/Ci
 
 // jsdom has no width-based matchMedia, so the mobile branch is driven by mocking the hook
 const layoutState = vi.hoisted(() => ({ isMobile: false }))
-vi.mock('../../../src/hooks/use-breakpoint', () => ({
+// partial mock: real module spread first, so new exports keep working here
+vi.mock('../../../src/hooks/use-breakpoint', async (importOriginal) => ({
+  ...(await importOriginal()),
   useIsMobileLayout: () => layoutState.isMobile,
   useIsTabletLayout: () => false,
   useTableViewMode: () => 'table',

--- a/frontend/tests/layouts/TabbedLayout.test.jsx
+++ b/frontend/tests/layouts/TabbedLayout.test.jsx
@@ -7,7 +7,9 @@ import { renderWithProviders } from "../test-utils";
 
 // jsdom has no width-based matchMedia, so the mobile branch is driven by mocking the hook
 const layoutState = vi.hoisted(() => ({ isMobile: false, viewMode: "table" }));
-vi.mock("../../src/hooks/use-breakpoint", () => ({
+// partial mock: real module spread first, so new exports keep working here
+vi.mock("../../src/hooks/use-breakpoint", async (importOriginal) => ({
+  ...(await importOriginal()),
   useIsMobileLayout: () => layoutState.isMobile,
   useIsTabletLayout: () => false,
   useTableViewMode: () => layoutState.viewMode,


### PR DESCRIPTION
Why
Mobile card view is great for scanning but there was no way to get back to a real table on a phone. Wide datasets were stuck in cards, and the "Table view on small screens" preference helps but you'd have to navigate away and back to change the mode. Working through this surfaced several related mobile table problems (double scrollbars, state loss when switching views, controls buried or duplicated), so this PR fixes that cluster together.

Desktop table behavior is unchanged except for the minor ordering change of the table toolbar action buttons & live/cached button

Changes (Mobile only)
  - Card lists get a per-session toggle to the real MRT table and back.  Currently it doesn't persist, refresh returns to the tableViewMode preference.
  - Lifted card view chrome into shared components, phone table view shares these now
  - Same mental model between cards/mobile cable -> FAB for actions, actions button for filters+columns+presets+etc
  - Match paper elevation for mobile cards vs rest of app and the card controls bar reuses the desktop toolbar's styling primitives, so the two views read as one component
  - Move page size selector into bottom drawer to prevent line from wrapping on mobile creating double scrollbar on narrow viewports

Fixes (Mobile only)
  - Move the live/cache control out of the action FAB into the bottom drawer.   Switching the cache/live is a view setting, not an action.  Had to edit some existing reports to accomplish this, that's the one line change on the 25 reports. 
  - This moves the button to the left on tables with actions, or is otherwise unchanged. 
  - Double scrollbars on phone tables, two causes: MRT wraps its pagination footer into a second row below its internal 720px pivot (footer now slims to range + prev/next there, rows-per-page moved into the sheet), and the table's height budget is a viewport calc tuned against desktop chrome (narrow viewports now measure the actual space available instead).
  - Switching cards -> table -> cards lost applied graph filters, session column changes, preset highlights, and in-progress selections. The two views mount alternating toolbar instances, and toolbar-local state plus mount effects reset everything on each flip. That state moved up into CippDataTable, shared by both, with effects guarded to fire on real changes only. The table kebab also gained the active-filter badge the card bar already had.
  - The tableViewMode preference silently never saved: the preferences save posts an explicit field allowlist that omitted it. Added the field.
  - Lift ModernSearchContainer, ModernSearchInput, ModernButton, RefreshButton into a shared table primatives so all three views can share the same chrome.
  - Clean up Toolbar prop instantiation for easier reasoning about how the component is structured 
  - Change filter icon to 3 dots kebab because this button handles more than just filtering and this icon seems more appropriate for the mental model of what it's doing

Tests
  - jsdom: toggle round trip (cards return intact, settings untouched), filter/column state survives the flip, sheet contents and placement, preference save allowlist, footer and container sizing props.
  - storybook: toggle at phone breakpoints, sheet sections, no toolbar refresh on phones.
  - Full suite: 127 files / 865 tests green.


Known/deferred
  - Duplicate Columns menu in the toolbar (two Menus on one anchor) is pre-existing and untouched.
  - The structural desktop height-budget fix (flex sizing, retiring maxHeightOffset) is a separate PR.
  - Mobile side nav uses incorrect elevation causing improper sponsor styling, this is a separate PR. 