### PR TITLE
feat: add display name separator support to colleague impersonation alert

### DIFF
--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardColleagueImpersonationAlert.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardColleagueImpersonationAlert.ps1
@@ -21,6 +21,8 @@ function Invoke-CIPPStandardColleagueImpersonationAlert {
         ADDEDCOMPONENT
             {"type":"heading","label":"Alert Banner (HTML)","required":false}
             {"type":"textField","name":"standards.ColleagueImpersonationAlert.disclaimerHtml","label":"Disclaimer HTML – Paste the full HTML for the warning banner","required":true}
+            {"type":"heading","label":"Display Name Matching","required":false}
+            {"type":"textField","name":"standards.ColleagueImpersonationAlert.displayNameSeparator","label":"Display name separator – Optional, for example |","required":false} 
             {"type":"heading","label":"Keyword Exclusions (Exclude certain users by keywords)","required":false}
             {"type":"autoComplete","name":"standards.ColleagueImpersonationAlert.excludedMailboxes","label":"Exclude mailboxes by keywords for example any Displayname starting with (Leaver)","multiple":true,"creatable":true,"required":false}
             {"type":"heading","label":"Exempt Senders (Email Accounts)","required":false}
@@ -52,6 +54,7 @@ function Invoke-CIPPStandardColleagueImpersonationAlert {
     } #we're done.
 
     $ruleHtml = $Settings.disclaimerHtml
+    $displayNameSeparator = [string]$Settings.displayNameSeparator
 
     $excludeKeywords = @(
         @($Settings.excludedMailboxes) | ForEach-Object {
@@ -135,7 +138,25 @@ function Invoke-CIPPStandardColleagueImpersonationAlert {
             $range    = $entry.Key
             $pattern  = $entry.Value
             $ruleName = "($range) Colleague Impersonation Alert"
-            $names    = @($displayNames | Where-Object { $_ -match $pattern } | ForEach-Object { [regex]::Escape($_) })
+            $names = @(
+                $displayNames | Where-Object { $_ -match $pattern } | ForEach-Object {
+                    $fullName = $_.Trim()
+
+                    [regex]::Escape($fullName)
+
+                    if (-not [string]::IsNullOrWhiteSpace($displayNameSeparator)) {
+                        $separatorPattern = [regex]::Escape($displayNameSeparator.Trim())
+
+                        if ($fullName -match $separatorPattern) {
+                            $shortName = ($fullName -split "\s*$separatorPattern\s*", 2)[0].Trim()
+
+                            if (-not [string]::IsNullOrWhiteSpace($shortName) -and $shortName -ne $fullName) {
+                                [regex]::Escape($shortName)
+                            }
+                        }
+                    }
+                } | Sort-Object -Unique
+            ) 
             if ($names.Count -eq 0) { $names = @([regex]::Escape("($range)")) }
             $existing = $Rules | Where-Object { $_.Name -eq $ruleName } | Select-Object -First 1
 


### PR DESCRIPTION
Adds an optional display name separator setting to the Colleague Impersonation Alert standard.

When configured, CIPP adds both the full mailbox display name and the portion before the separator to HeaderMatchesPatterns.

Example:

Display name:
John Doe | Contoso

Separator:
|

Protected names:
- John Doe | Contoso
- John Doe

This helps protect tenants that append a company name or other identifier to user display names, while attackers may impersonate only the user's name.

If no separator is configured, the existing behavior remains unchanged.