### PR TITLE
fix: Handle existing branding localization for PhishProtection standard

### DIFF
--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishProtection.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardPhishProtection.ps1
@@ -75,13 +75,32 @@ function Invoke-CIPPStandardPhishProtection {
 
         try {
             if (!$currentBody) {
-                $AddedHeaders = @{'Accept-Language' = 0 }
-                $defaultBrandingBody = '{"usernameHintText":null,"signInPageText":null,"backgroundColor":null,"customPrivacyAndCookiesText":null,"customCannotAccessYourAccountText":null,"customForgotMyPasswordText":null,"customTermsOfUseText":null,"loginPageLayoutConfiguration":{"layoutTemplateType":"default","isFooterShown":true,"isHeaderShown":false},"loginPageTextVisibilitySettings":{"hideAccountResetCredentials":false,"hideTermsOfUse":true,"hidePrivacyAndCookies":true},"contentCustomization":{"conditionalAccess":[],"attributeCollection":[]}}'
+                $DefaultLocalizationExists = $false
                 try {
-                    New-GraphPostRequest -tenantid $tenant -Uri "https://graph.microsoft.com/beta/organization/$($TenantId.customerId)/branding/localizations/" -ContentType 'application/json' -asApp $true -Type POST -Body $defaultBrandingBody -AddedHeaders $AddedHeaders
+                    $Localizations = New-GraphGetRequest -Uri "https://graph.microsoft.com/beta/organization/$($TenantId.customerId)/branding/localizations" -tenantid $tenant -AsApp $true
+                    $DefaultLocalizationExists = [bool]($Localizations | Where-Object { $_.id -eq '0' })
                 } catch {
                     $ErrorMessage = Get-CippException -Exception $_
-                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to create default branding localization. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+                    Write-LogMessage -API 'Standards' -tenant $tenant -message "Could not check for the default branding localization. Creation will be attempted. Error: $($ErrorMessage.NormalizedError)" -sev Warning -LogData $ErrorMessage
+                }
+
+                if (-not $DefaultLocalizationExists) {
+                    $AddedHeaders = @{'Accept-Language' = 0 }
+                    $defaultBrandingBody = '{"usernameHintText":null,"signInPageText":null,"backgroundColor":null,"customPrivacyAndCookiesText":null,"customCannotAccessYourAccountText":null,"customForgotMyPasswordText":null,"customTermsOfUseText":null,"loginPageLayoutConfiguration":{"layoutTemplateType":"default","isFooterShown":true,"isHeaderShown":false},"loginPageTextVisibilitySettings":{"hideAccountResetCredentials":false,"hideTermsOfUse":true,"hidePrivacyAndCookies":true},"contentCustomization":{"conditionalAccess":[],"attributeCollection":[]}}'
+                    try {
+                        New-GraphPostRequest -tenantid $tenant -Uri "https://graph.microsoft.com/beta/organization/$($TenantId.customerId)/branding/localizations/" -ContentType 'application/json' -AsApp $true -Type POST -Body $defaultBrandingBody -AddedHeaders $AddedHeaders
+                    } catch {
+                        $ErrorMessage = Get-CippException -Exception $_
+                        $GraphError = $null
+                        try { $GraphError = $ErrorMessage.RawError | ConvertFrom-Json -ErrorAction Stop } catch {}
+                        $IsDefaultLocalizationConflict = ($GraphError.error.code -eq 'Request_BadRequest') -and [bool]($GraphError.error.details | Where-Object { $_.code -eq 'ObjectConflict' -and $_.target -eq 'id' })
+
+                        if ($IsDefaultLocalizationConflict) {
+                            Write-LogMessage -API 'Standards' -tenant $tenant -message 'Default branding localization already exists; continuing with the existing localization.' -sev Info
+                        } else {
+                            Write-LogMessage -API 'Standards' -tenant $tenant -message "Failed to create default branding localization. Error: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+                        }
+                    }
                 }
             }
             if ($currentBody -like "*$CSS*") {

--- a/backend/Tests/Standards/Invoke-CIPPStandardPhishProtection.Tests.ps1
+++ b/backend/Tests/Standards/Invoke-CIPPStandardPhishProtection.Tests.ps1
@@ -1,0 +1,144 @@
+# Pester tests for Invoke-CIPPStandardPhishProtection branding localization handling.
+#
+# An existing default localization can legitimately have no custom CSS. That state must not be
+# mistaken for a missing localization: POSTing another default object produces ObjectConflict even
+# though the subsequent customCSS PUT succeeds, leaving a misleading Error in the standards log.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $StandardPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-CIPPStandardPhishProtection.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $StandardPath) { throw 'Could not locate Invoke-CIPPStandardPhishProtection.ps1 under Modules/' }
+
+    function Test-CIPPStandardLicense { [CmdletBinding()] param($StandardName, $TenantFilter, $Preset, $RequiredCapabilities) }
+    function Get-Tenants { [CmdletBinding()] param($TenantFilter) }
+    function Get-CIPPTable { [CmdletBinding()] param($TableName) }
+    function Get-CIPPAzDataTableEntity { [CmdletBinding()] param($Table) }
+    function New-GraphGetRequest { [CmdletBinding()] param($Uri, $tenantid, $AsApp) }
+    function New-GraphPostRequest { [CmdletBinding()] param($tenantid, $Uri, $ContentType, $AsApp, $Type, $Body, $AddedHeaders) }
+    function Write-LogMessage { [CmdletBinding()] param($API, $tenant, $message, $sev, $LogData) }
+    function Get-CippException { [CmdletBinding()] param($Exception) [pscustomobject]@{ NormalizedError = ($Exception | Out-String); RawError = ($Exception.ErrorDetails.Message ?? '') } }
+    function Get-NormalizedError { [CmdletBinding()] param($Message) $Message }
+    function Write-StandardsAlert { [CmdletBinding()] param($message, $object, $tenant, $standardName, $standardId) }
+    function Add-CIPPBPAField { [CmdletBinding()] param($FieldName, $FieldValue, $StoreAs, $Tenant) }
+    function Set-CIPPStandardsCompareField { [CmdletBinding()] param($FieldName, $CurrentValue, $ExpectedValue, $Tenant) }
+
+    . $StandardPath
+}
+
+Describe 'Invoke-CIPPStandardPhishProtection localization handling' {
+    BeforeEach {
+        Mock Test-CIPPStandardLicense { $true }
+        Mock Get-Tenants {
+            [pscustomobject]@{ customerId = '11111111-1111-1111-1111-111111111111' }
+        }
+        Mock Get-CIPPTable { @{ Table = 'Config' } }
+        Mock Get-CIPPAzDataTableEntity {
+            @([pscustomobject]@{ RowKey = 'CIPPURL'; Value = 'cipp.example.com' })
+        }
+        Mock Write-LogMessage { }
+        Mock Write-StandardsAlert { }
+        Mock Add-CIPPBPAField { }
+        Mock Set-CIPPStandardsCompareField { }
+        Mock New-GraphPostRequest { }
+    }
+
+    It 'uses an existing default localization when custom CSS is empty' {
+        $script:GraphGetCalls = 0
+        Mock New-GraphGetRequest {
+            $script:GraphGetCalls++
+            if ($script:GraphGetCalls -eq 1) { return $null }
+            return @([pscustomobject]@{ id = '0' })
+        }
+
+        Invoke-CIPPStandardPhishProtection -Tenant 'contoso.onmicrosoft.com' -Settings ([pscustomobject]@{
+                remediate = $true
+                alert     = $false
+                report    = $false
+            })
+
+        Should -Invoke New-GraphPostRequest -Times 0 -ParameterFilter {
+            $Type -eq 'POST' -and $Uri -like '*/branding/localizations/'
+        }
+        Should -Invoke New-GraphPostRequest -Times 1 -Exactly -ParameterFilter {
+            $Type -eq 'PUT' -and $Uri -like '*/branding/localizations/0/customCSS'
+        }
+        Should -Invoke Write-LogMessage -Times 0 -ParameterFilter {
+            $sev -eq 'Error' -and $message -like 'Failed to create default branding localization*'
+        }
+    }
+
+    It 'creates the default localization when localization id zero is absent' {
+        Mock New-GraphGetRequest { return @() }
+
+        Invoke-CIPPStandardPhishProtection -Tenant 'contoso.onmicrosoft.com' -Settings ([pscustomobject]@{
+                remediate = $true
+                alert     = $false
+                report    = $false
+            })
+
+        Should -Invoke New-GraphPostRequest -Times 1 -Exactly -ParameterFilter {
+            $Type -eq 'POST' -and $Uri -like '*/branding/localizations/'
+        }
+        Should -Invoke New-GraphPostRequest -Times 1 -Exactly -ParameterFilter {
+            $Type -eq 'PUT' -and $Uri -like '*/branding/localizations/0/customCSS'
+        }
+    }
+
+    It 'treats a create conflict as a recovered race when id zero appeared after the list' {
+        Mock New-GraphGetRequest { @() }
+        Mock New-GraphPostRequest {
+            param($tenantid, $Uri, $ContentType, $AsApp, $Type, $Body, $AddedHeaders)
+            if ($Type -eq 'POST') { throw 'Another object with the same value for property id already exists.' }
+        }
+        Mock Get-CippException {
+            [pscustomobject]@{
+                NormalizedError = 'Another object with the same value for property id already exists.'
+                RawError        = '{"error":{"code":"Request_BadRequest","details":[{"code":"ObjectConflict","target":"id"}]}}'
+            }
+        }
+
+        Invoke-CIPPStandardPhishProtection -Tenant 'contoso.onmicrosoft.com' -Settings ([pscustomobject]@{
+                remediate = $true
+                alert     = $false
+                report    = $false
+            })
+
+        Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter {
+            $sev -eq 'Info' -and $message -like 'Default branding localization already exists*'
+        }
+        Should -Invoke Write-LogMessage -Times 0 -ParameterFilter {
+            $sev -eq 'Error' -and $message -like 'Failed to create default branding localization*'
+        }
+        Should -Invoke New-GraphPostRequest -Times 1 -Exactly -ParameterFilter {
+            $Type -eq 'PUT' -and $Uri -like '*/branding/localizations/0/customCSS'
+        }
+    }
+
+    It 'keeps unexpected default localization creation failures at error severity' {
+        Mock New-GraphGetRequest { @() }
+        Mock New-GraphPostRequest {
+            param($tenantid, $Uri, $ContentType, $AsApp, $Type, $Body, $AddedHeaders)
+            if ($Type -eq 'POST') { throw 'Authorization_RequestDenied' }
+        }
+        Mock Get-CippException {
+            [pscustomobject]@{
+                NormalizedError = 'Authorization_RequestDenied'
+                RawError        = '{"error":{"code":"Authorization_RequestDenied"}}'
+            }
+        }
+
+        Invoke-CIPPStandardPhishProtection -Tenant 'contoso.onmicrosoft.com' -Settings ([pscustomobject]@{
+                remediate = $true
+                alert     = $false
+                report    = $false
+            })
+
+        Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter {
+            $sev -eq 'Error' -and $message -like 'Failed to create default branding localization*Authorization_RequestDenied*'
+        }
+        Should -Invoke Write-LogMessage -Times 0 -ParameterFilter {
+            $sev -eq 'Info' -and $message -like 'Default branding localization already exists*'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes misleading errors from the `PhishProtection` standard when the tenant's default branding localization already exists but has no custom CSS.

Previously, the standard used the response from `/branding/localizations/0/customCSS` to infer whether the default localization existed. An existing localization with no custom CSS was therefore treated as missing, causing CIPP to attempt to create localization ID `0` again.

Microsoft Graph correctly rejected that request with:

> Another object with the same value for property id already exists.

The standard subsequently applied the CSS successfully, but the recovered creation conflict remained in the Logbook at Error severity and could make the standard appear to have failed.

## Changes

- Query the tenant's branding localizations and explicitly check for localization ID `0`.
- Reuse the existing default localization when it is already present.
- Create the default localization only when ID `0` is absent.
- Treat only the specific Graph `Request_BadRequest` / `ObjectConflict` response targeting `id` as a recovered race condition.
- Log that recovered condition at Info severity.
- Preserve Error severity and diagnostic data for all other localization creation failures.
- Continue applying the PhishProtection custom CSS after a recovered conflict.

## Why retain conflict handling after the existence check?

The existence check prevents the normal duplicate-create case, but another process could create localization ID `0` between the GET and POST requests.

The targeted `ObjectConflict` handling covers that race without suppressing unrelated Graph failures.

## Tests

Added Pester coverage for:

- An existing default localization with empty custom CSS.
- Creating the default localization when ID `0` is absent.
- Recovering from the specific duplicate-ID race without writing a misleading Error.
- Retaining Error severity for unexpected localization creation failures.