### PR TITLE
fix(mobile): cards->table toggle scroll and mobile nav drawer surface

### DIFF
--- a/frontend/src/components/CippTable/CippDataTable.js
+++ b/frontend/src/components/CippTable/CippDataTable.js
@@ -85,20 +85,24 @@ const compareNullable = (aVal, bVal) => {
   return aVal > bVal ? 1 : -1
 }
 
-// walk up from the toggled node to the page's scrolling ancestor (LayoutContainer,
-// overflowY auto) and reset it, so a narrow-table height measurement taken right after
-// starts from a deterministic scroll position
-const scrollScrollableAncestorToTop = (node) => {
-  let ancestor = node?.parentElement
+// walk up from the card surface to the page's scrolling ancestor (LayoutContainer,
+// overflowY auto) and align the surface with its top. the table flips in at the same
+// page slot, so the height measurement taken right after reads a deterministic top
+// and pages with content above the table keep the table in view
+const scrollNodeToScrollableAncestorTop = (node) => {
+  if (!node) {
+    return
+  }
+  let ancestor = node.parentElement
   while (ancestor && ancestor !== document.body) {
     const overflowY = window.getComputedStyle(ancestor).overflowY
     if (overflowY === 'auto' || overflowY === 'scroll') {
-      ancestor.scrollTop = 0
+      ancestor.scrollTop += node.getBoundingClientRect().top - ancestor.getBoundingClientRect().top
       return
     }
     ancestor = ancestor.parentElement
   }
-  window.scrollTo(0, 0)
+  window.scrollTo(0, window.scrollY + node.getBoundingClientRect().top)
 }
 
 // ── Module-level constants ──────────────────────────────────────────────────
@@ -957,13 +961,13 @@ export const CippDataTable = (props) => {
   }, [])
 
   // the flipped table shows whatever columns are visible; horizontal scroll covers the width
-  const handleViewToggle = useCallback((event) => {
+  const cardViewSurfaceRef = useRef(null)
+  const handleViewToggle = useCallback(() => {
     const nextView = effectiveViewMode === 'table' ? 'cards' : 'table'
     setViewOverride(nextView)
     if (nextView === 'table' && isNarrowViewport) {
-      scrollScrollableAncestorToTop(event?.currentTarget)
+      scrollNodeToScrollableAncestorTop(cardViewSurfaceRef.current)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [effectiveViewMode, isNarrowViewport])
 
   // Memoize renderRowActionMenuItems to avoid re-creating on each render.
@@ -1186,7 +1190,8 @@ export const CippDataTable = (props) => {
       const footer = table.refs.bottomToolbarRef?.current?.offsetHeight ?? 0
       // chrome between the paper's bottom edge and the page bottom (CardContent padding + page gap)
       const BELOW_PAPER_PX = 40
-      // viewport-relative, so a scrolled page needs the toggle handler to reset scroll first
+      // viewport-relative, the toggle handler aligns the card surface with the scroll
+      // viewport top first so this reads a deterministic position
       const top = container.getBoundingClientRect().top
       let next = Math.max(240, Math.floor(window.innerHeight - top - footer - BELOW_PAPER_PX))
       // 120 = minimal chrome allowance, keeps the table from claiming the full viewport
@@ -1313,6 +1318,7 @@ export const CippDataTable = (props) => {
       {isCardView ? (
         // same paper surface as the table path; overflow visible keeps the controls bar sticky
         <CardViewSurface
+          ref={cardViewSurfaceRef}
           data-testid="cipp-card-view"
           {...(noCard
             ? {}

--- a/frontend/src/layouts/mobile-nav.js
+++ b/frontend/src/layouts/mobile-nav.js
@@ -136,6 +136,8 @@ export const MobileNav = (props) => {
       slotProps={{ transition: swipeClose.transitionProps }}
       PaperProps={{
         sx: {
+          // desktop side-nav renders on background.default, keep the drawer on the same surface
+          backgroundColor: "background.default",
           width: MOBILE_NAV_WIDTH,
           // Column layout so the sponsor footer pins to the bottom and the menu scrolls
           // between it and the sticky header, rather than the footer riding the list.
@@ -234,7 +236,6 @@ export const MobileNav = (props) => {
           flexShrink: 0,
           px: 2,
           pb: "calc(env(safe-area-inset-bottom) + 8px)",
-          bgcolor: "background.default",
         }}
       >
         <CippSponsor compact />

--- a/frontend/tests/components/CippTable/CippDataTable.test.jsx
+++ b/frontend/tests/components/CippTable/CippDataTable.test.jsx
@@ -604,3 +604,56 @@ describe('CippDataTable offcanvas row navigation', () => {
     expect(within(drawer).getByText('bob@contoso.com')).toBeInTheDocument()
   })
 })
+
+// the narrow-table height measurement reads viewport-relative positions, so the toggle
+// aligns the card surface with the scrolling ancestor's top before the table flips in
+describe('CippDataTable cards->table toggle scroll', () => {
+  const useMobileViewport = () => {
+    const cache = new Map()
+    window.matchMedia = (query) => {
+      if (!cache.has(query)) {
+        cache.set(query, {
+          matches: query.includes('max-width'),
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        })
+      }
+      return cache.get(query)
+    }
+  }
+
+  beforeEach(() => {
+    useMobileViewport()
+  })
+
+  afterEach(() => {
+    delete window.matchMedia
+  })
+
+  it('keeps a mid-page table in view instead of yanking the page to the top', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <div data-testid="scroller" style={{ overflowY: 'auto' }}>
+        <CippDataTable data={basicData} simpleColumns={['displayName', 'mail']} title="Users" />
+      </div>
+    )
+    await waitFor(() => expect(screen.getByTestId('cipp-card-view')).toBeInTheDocument())
+
+    // surface sits below the scroller's viewport top, page already scrolled
+    const scroller = screen.getByTestId('scroller')
+    const surface = screen.getByTestId('cipp-card-view')
+    scroller.getBoundingClientRect = () => ({ top: 64 })
+    surface.getBoundingClientRect = () => ({ top: 300 })
+    scroller.scrollTop = 120
+
+    await user.click(screen.getByRole('button', { name: 'Toggle table view' }))
+
+    // prior scroll plus the surface's offset from the scroller viewport top
+    expect(scroller.scrollTop).toBe(120 + (300 - 64))
+  })
+})


### PR DESCRIPTION
- fix the page scroll when toggling between card/table on mobile on pages where the table isn't anchored to the top of the page
  - this autoscroll is needed so when flipping between the very long card view and the table view, it doesn't randomly move the page scroll based on the browser's arbitrary scroll handling
  - it is also used to measure where the top of the table's container sits in the viewport before the flip, for varied size small viewports and size the mobile table appropriately
- fix the side nav mobile surface to match desktop surface

update tests