### PR TITLE
fix: Update Compliance Portal URL to Purview link

### DIFF
--- a/backend/Modules/CippExtensions/Public/Hudu/Invoke-HuduExtensionSync.ps1
+++ b/backend/Modules/CippExtensions/Public/Hudu/Invoke-HuduExtensionSync.ps1
@@ -223,7 +223,7 @@ function Invoke-HuduExtensionSync {
         if ($Configuration.IncludeComplianceLink) {
             $Links.Add(@{
                     Title = 'Compliance Portal'
-                    URL   = 'https://compliance.microsoft.com/?tid={0}' -f $Tenant.customerId
+                    URL   = 'https://purview.microsoft.com/home?tid={0}' -f $Tenant.customerId
                     Icon  = 'fas fa-caret-up'
                 })
         }


### PR DESCRIPTION
When using the current link, they reach this page and are redirected to the new page.
<img width="1120" height="780" alt="image" src="https://github.com/user-attachments/assets/18af09b1-c51a-4975-a1f5-418249056b39" />
