### PR TITLE
feat: Add SharePoint Portal link to Hudu Magic Dash

### DIFF
--- a/backend/Modules/CippExtensions/Public/Hudu/Invoke-HuduExtensionSync.ps1
+++ b/backend/Modules/CippExtensions/Public/Hudu/Invoke-HuduExtensionSync.ps1
@@ -207,6 +207,11 @@ function Invoke-HuduExtensionSync {
                 URL   = 'https://admin.teams.microsoft.com/?delegatedOrg={0}' -f $Tenant.defaultDomainName
                 Icon  = 'fas fa-users'
             }
+			@{
+                Title = 'SharePoint Portal'
+                URL   = 'https://admin.cloud.microsoft/Partner/beginclientsession.aspx?CTID={0}&CSDEST=SharePoint' -f $Tenant.customerId
+                Icon  = 'fas fa-sitemap'
+            }
             @{
                 Title = 'Azure Portal'
                 URL   = 'https://portal.azure.com/{0}' -f $Tenant.defaultDomainName


### PR DESCRIPTION
This adds a link to the SharePoint Admin portal. I put it near teams because they are similar and did not make it configurable because it's a core feature. We're completely flexible on location and configurability if someone has a different preference.