### PR TITLE
Fix(mobile): text clipping, button overflows

### DIFF
--- a/frontend/src/components/CippComponents/CippAppRegistrationPermissions.jsx
+++ b/frontend/src/components/CippComponents/CippAppRegistrationPermissions.jsx
@@ -161,8 +161,18 @@ const ResourcePermissionsAccordion = ({
       }}
       disableGutters
     >
-      <AccordionSummary expandIcon={<ExpandMore />}>
-        <Stack direction="row" spacing={2} alignItems="center" sx={{ width: "100%", pr: 1 }}>
+      <AccordionSummary
+        expandIcon={<ExpandMore />}
+        // summary is a centered ButtonBase, an unshrinkable row spills both edges
+        sx={{ "& .MuiAccordionSummary-content": { minWidth: 0 } }}
+      >
+        <Stack
+          direction="row"
+          spacing={2}
+          useFlexGap
+          alignItems="center"
+          sx={{ width: "100%", pr: 1, flexWrap: "wrap", rowGap: 1 }}
+        >
           <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>
             {title}
           </Typography>
@@ -180,7 +190,12 @@ const ResourcePermissionsAccordion = ({
               />
             </Tooltip>
           )}
-          <Chip size="small" label={resourceAppId} variant="outlined" sx={{ maxWidth: 280 }} />
+          <Chip
+            size="small"
+            label={resourceAppId}
+            variant="outlined"
+            sx={{ maxWidth: 280, minWidth: 0 }}
+          />
           <Chip size="small" label={`${resourceAccess.length}`} />
         </Stack>
       </AccordionSummary>

--- a/frontend/src/components/CippComponents/CippEnterpriseAppPermissions.jsx
+++ b/frontend/src/components/CippComponents/CippEnterpriseAppPermissions.jsx
@@ -191,8 +191,18 @@ const ResourceAccordion = ({ title, resourceId, chipLabel, children, riskSummary
       }}
       disableGutters
     >
-      <AccordionSummary expandIcon={<ExpandMore />}>
-        <Stack direction="row" spacing={2} alignItems="center" sx={{ width: "100%", pr: 1 }}>
+      <AccordionSummary
+        expandIcon={<ExpandMore />}
+        // summary is a centered ButtonBase, an unshrinkable row spills both edges
+        sx={{ "& .MuiAccordionSummary-content": { minWidth: 0 } }}
+      >
+        <Stack
+          direction="row"
+          spacing={2}
+          useFlexGap
+          alignItems="center"
+          sx={{ width: "100%", pr: 1, flexWrap: "wrap", rowGap: 1 }}
+        >
           <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>
             {title}
           </Typography>
@@ -210,7 +220,12 @@ const ResourceAccordion = ({ title, resourceId, chipLabel, children, riskSummary
               />
             </Tooltip>
           )}
-          <Chip size="small" label={resourceId} variant="outlined" sx={{ maxWidth: 260 }} />
+          <Chip
+            size="small"
+            label={resourceId}
+            variant="outlined"
+            sx={{ maxWidth: 260, minWidth: 0 }}
+          />
           {chipLabel != null && <Chip size="small" label={String(chipLabel)} />}
         </Stack>
       </AccordionSummary>

--- a/frontend/src/components/CippTable/CippMobileCardList.jsx
+++ b/frontend/src/components/CippTable/CippMobileCardList.jsx
@@ -285,6 +285,8 @@ export const CippMobileCardList = (props) => {
                                 display: "inline-flex",
                                 alignItems: "center",
                                 gap: 0.5,
+                                // long column names: caption ellipsizes, icon stays inside the card clip
+                                maxWidth: "100%",
                                 ...(isBareBoolean && {
                                   border: 1,
                                   borderColor: "divider",

--- a/frontend/src/pages/tenant/baselines/template.jsx
+++ b/frontend/src/pages/tenant/baselines/template.jsx
@@ -885,14 +885,19 @@ const Page = () => {
           </Button>
         </Box>
         <Stack
-          direction="row"
+          direction={{ xs: 'column', sm: 'row' }}
           justifyContent="space-between"
-          alignItems="center"
-          spacing={4}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          spacing={{ xs: 2, sm: 4 }}
           sx={{ mb: 1 }}
         >
           <Typography variant="h4">{pageTitle}</Typography>
-          <Stack direction="row" spacing={2}>
+          <Stack
+            direction="row"
+            spacing={2}
+            useFlexGap
+            sx={{ flexWrap: 'wrap' }}
+          >
             <PermissionButton
               requiredPermissions={['Tenant.Standards.ReadWrite']}
               variant="contained"

--- a/frontend/src/pages/tenant/standards/templates/template.jsx
+++ b/frontend/src/pages/tenant/standards/templates/template.jsx
@@ -367,10 +367,10 @@ const Page = () => {
 
       <Stack spacing={2}>
         <Stack
-          direction="row"
+          direction={{ xs: 'column', sm: 'row' }}
           justifyContent="space-between"
-          alignItems="center"
-          spacing={4}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          spacing={{ xs: 2, sm: 4 }}
           sx={{ mb: 3 }}
         >
           <Typography variant="h4">
@@ -382,7 +382,12 @@ const Page = () => {
                 ? 'Add Drift Template'
                 : 'Add Standards Template'}
           </Typography>
-          <Stack direction="row" spacing={2}>
+          <Stack
+            direction="row"
+            spacing={2}
+            useFlexGap
+            sx={{ flexWrap: 'wrap' }}
+          >
             <Button
               variant="contained"
               color="primary"


### PR DESCRIPTION
issues:
1.  card chips overflow is hidden on narrow viewports
<img width="238" height="500" alt="Screenshot 2026-08-21 223158" src="https://github.com/user-attachments/assets/d0159b43-835f-4762-b1ed-1b9bde559710" />  
  
2. template editor headers grow incorrectly on narrow viewports
<img width="295" height="500" alt="Screenshot 2026-08-21 232533" src="https://github.com/user-attachments/assets/c86980eb-bccf-4b0c-b8bc-5b96bb3825bb" />  

3. accordion header spills on narrow viewports
<img width="292" height="500" alt="Screenshot 2026-08-21 194425" src="https://github.com/user-attachments/assets/e2ed9807-41e6-4e26-bbf4-e20c68910ceb" />  

fixes:
1. set max width so overflow is truncated with ellipses
2. stack the buttons on xs viewport, sm and larger keep as row
3. add flexwrap on the row, and midWidth on the summary+guid so the row wraps on phones


  
