### PR TITLE
test: fix frontend unit suite

### DIFF
--- a/frontend/src/components/CippTable/CippDataTableButton.jsx
+++ b/frontend/src/components/CippTable/CippDataTableButton.jsx
@@ -37,7 +37,7 @@ const CippDataTableButton = ({
   const settings = useSettings();
   const isLive = Boolean(api?.url);
 
-  const nestedTitle = tableProps.title ?? tableTitle ?? title ?? "Data";
+  const nestedTitle = title ?? tableTitle ?? "Data";
 
   const handleOpenStaticDialog = (event) => {
     event?.stopPropagation();

--- a/frontend/src/pages/identity/administration/guest-users/index.js
+++ b/frontend/src/pages/identity/administration/guest-users/index.js
@@ -133,6 +133,7 @@ const Page = () => {
 
   const tableFilter = (
     <Grid container spacing={2}>
+      {/* stat tiles sit two-up on phones, six stacked rows push the table below the fold. mobile-layout-ok */}
       <Grid size={{ xs: 6, sm: 4, md: 2 }}>
         <SummaryCard
           title="Total Guests"
@@ -144,6 +145,7 @@ const Page = () => {
           onClick={() => setStatusFilter(null)}
         />
       </Grid>
+      {/* mobile-layout-ok */}
       {GUEST_STATUSES.map(({ status, color, icon }) => (
         <Grid size={{ xs: 6, sm: 4, md: 2 }} key={status}>
           <SummaryCard

--- a/frontend/tests/components/CippComponents/CippAddUserDrawer.test.jsx
+++ b/frontend/tests/components/CippComponents/CippAddUserDrawer.test.jsx
@@ -54,6 +54,31 @@ vi.mock('../../../src/components/CippComponents/CippOffCanvas', () => ({
 const idleGet = { isSuccess: false, isFetching: false, isError: false, data: undefined, refetch: vi.fn() }
 const okGet = (data) => ({ isSuccess: true, isFetching: false, isError: false, data, refetch: vi.fn() })
 
+// built once: CippAutoComplete's option mapping keys on data identity, a fresh literal per call never settles
+const userDefaults = okGet([])
+const extensionsConfig = okGet({})
+const groups = okGet([])
+const customDataMappings = okGet({ Results: [] })
+const userGroups = okGet([])
+const tenantDomains = {
+  isSuccess: true,
+  isFetching: false,
+  isError: false,
+  data: {
+    pages: [
+      {
+        Results: [
+          { id: 'testdomain.com', isDefault: true, isInitial: false, isVerified: true },
+          { id: 'other.com', isDefault: false, isInitial: false, isVerified: true },
+        ],
+      },
+    ],
+  },
+  fetchNextPage: vi.fn(),
+  refetch: vi.fn(),
+}
+const idlePaginated = { ...idleGet, fetchNextPage: vi.fn() }
+
 // Mutable state backing the ApiPostCall mock: flipping it and re-rendering imitates the
 // react-query mutation lifecycle (idle -> pending -> success) the drawer sees in production.
 let postState
@@ -61,35 +86,16 @@ let mutateSpy
 
 function mockApis() {
   ApiGetCall.mockImplementation(({ url }) => {
-    if (url.startsWith('/api/ListNewUserDefaults')) return okGet([])
-    if (url.startsWith('/api/ListExtensionsConfig')) return okGet({})
-    if (url.startsWith('/api/ListGroups')) return okGet([])
-    if (url.startsWith('/api/ListCustomDataMappings')) return okGet({ Results: [] })
-    if (url.startsWith('/api/ListUserGroups')) return okGet([])
+    if (url.startsWith('/api/ListNewUserDefaults')) return userDefaults
+    if (url.startsWith('/api/ListExtensionsConfig')) return extensionsConfig
+    if (url.startsWith('/api/ListGroups')) return groups
+    if (url.startsWith('/api/ListCustomDataMappings')) return customDataMappings
+    if (url.startsWith('/api/ListUserGroups')) return userGroups
     return idleGet
   })
-  ApiGetCallWithPagination.mockImplementation(({ url }) => {
-    if (url === '/api/ListGraphRequest') {
-      return {
-        isSuccess: true,
-        isFetching: false,
-        isError: false,
-        data: {
-          pages: [
-            {
-              Results: [
-                { id: 'testdomain.com', isDefault: true, isInitial: false, isVerified: true },
-                { id: 'other.com', isDefault: false, isInitial: false, isVerified: true },
-              ],
-            },
-          ],
-        },
-        fetchNextPage: vi.fn(),
-        refetch: vi.fn(),
-      }
-    }
-    return { ...idleGet, fetchNextPage: vi.fn() }
-  })
+  ApiGetCallWithPagination.mockImplementation(({ url }) =>
+    url === '/api/ListGraphRequest' ? tenantDomains : idlePaginated
+  )
   ApiPostCall.mockImplementation(() => ({ ...postState, mutate: mutateSpy }))
 }
 
@@ -193,5 +199,6 @@ describe('CippAddUserDrawer - create another user without a page refresh (issue 
       username: 'second.user',
       primDomain: { value: 'testdomain.com' },
     })
-  })
+    // two full form fills through userEvent.type
+  }, 15000)
 })

--- a/frontend/tests/components/CippSettings/CippContainerManagement.test.jsx
+++ b/frontend/tests/components/CippSettings/CippContainerManagement.test.jsx
@@ -9,7 +9,10 @@ vi.mock('../../../src/api/ApiCall', async () => (await import('../../mocks/api-c
 import { api, getResult, paginatedResult, postResult } from '../../mocks/api-call'
 
 // stable references, fresh literals per call spin CippAutoComplete's mapping effect
-api.get = getResult()
+const statusGet = getResult()
+// status payload only answers its own url, the page's other GETs stay idle
+const idleGet = getResult({ isSuccess: false })
+api.get = (opts) => (opts.url === '/api/ExecContainerManagement' ? statusGet : idleGet)
 api.paginated = paginatedResult()
 api.post = postResult()
 
@@ -55,26 +58,26 @@ const ALERT_RE = /unsupported build from an unmerged branch/
 describe('CippContainerManagement branch-build flagging', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    api.get.data = undefined
+    statusGet.data = undefined
     api.paginated.data = { pages: [{ Results: [] }] }
   })
 
   it('running pinned branch build chips the split tag, not Unknown', () => {
-    api.get.data = { Results: statusResults('fix-sso-thing-a1b2c3d') }
+    statusGet.data = { Results: statusResults('fix-sso-thing-a1b2c3d') }
     renderWithProviders(<CippContainerManagement />)
     expect(screen.getByText(PINNED_PRETTY)).toBeInTheDocument()
     expect(screen.queryByText('Unknown')).not.toBeInTheDocument()
   })
 
   it('running branch build shows the unsupported-build alert and seeds the picker with its tag', async () => {
-    api.get.data = { Results: statusResults('feat-new-widget') }
+    statusGet.data = { Results: statusResults('feat-new-widget') }
     renderWithProviders(<CippContainerManagement />)
     expect(await screen.findByText(ALERT_RE)).toBeInTheDocument()
     expect(screen.getByRole('combobox', { name: 'Release Channel' })).toHaveValue('feat-new-widget')
   })
 
   it('standard channel chips its friendly label and raises no branch alert', async () => {
-    api.get.data = { Results: statusResults('dev') }
+    statusGet.data = { Results: statusResults('dev') }
     renderWithProviders(<CippContainerManagement />)
     expect(screen.getByText('Dev')).toBeInTheDocument()
     // wait for the seed effect so the alert-absence check runs against the settled form
@@ -86,7 +89,7 @@ describe('CippContainerManagement branch-build flagging', () => {
 
   it('unrecognized non-branch tag chips Unknown without raising the branch alert', async () => {
     // bare version tag: not a valid channel, does not match BuildChannelPattern
-    api.get.data = { Results: statusResults('8.0.1') }
+    statusGet.data = { Results: statusResults('8.0.1') }
     renderWithProviders(<CippContainerManagement />)
     expect(screen.getByText('Unknown')).toBeInTheDocument()
     await waitFor(() => {
@@ -96,7 +99,7 @@ describe('CippContainerManagement branch-build flagging', () => {
   })
 
   it('picking a branch build raises the alert, switching back to a standard channel clears it', async () => {
-    api.get.data = { Results: statusResults('latest') }
+    statusGet.data = { Results: statusResults('latest') }
     api.paginated.data = { pages: [{ Results: channelListResults }] }
     const user = userEvent.setup()
     renderWithProviders(<CippContainerManagement />)

--- a/frontend/tests/components/CippTable/CIPPTableToptoolbar.test.jsx
+++ b/frontend/tests/components/CippTable/CIPPTableToptoolbar.test.jsx
@@ -220,14 +220,15 @@ describe('CIPPTableToptoolbar - preset list refresh', () => {
     })
   }, 30000)
 
+  // pageName '' (jsdom router is '/') means no persistence, the slot tests name their key
   it('restores both persisted slots and discards garbage global values', async () => {
-    renderGraphTable({}, {
+    renderGraphTable({ persistenceKey: 'SlotsTest' }, {
       settings: settingsWith({
         persistFilters: true,
         setLastUsedFilter: vi.fn(),
         lastUsedFilters: {
           // legacy single-slot shape with a non-string global value
-          '': { type: 'global', value: [{ id: 'department', value: 'IT' }], name: 'Legacy Garbage' },
+          SlotsTest: { type: 'global', value: [{ id: 'department', value: 'IT' }], name: 'Legacy Garbage' },
         },
       }),
     })
@@ -241,13 +242,13 @@ describe('CIPPTableToptoolbar - preset list refresh', () => {
   })
 
   it('restores both persisted slots and discards new-shape garbage global values', async () => {
-    renderGraphTable({}, {
+    renderGraphTable({ persistenceKey: 'SlotsTest' }, {
       settings: settingsWith({
         persistFilters: true,
         setLastUsedFilter: vi.fn(),
         lastUsedFilters: {
           // new shape can carry the same non-string global garbage the legacy branch discards
-          '': {
+          SlotsTest: {
             graph: null,
             table: { id: 'Garbage', name: 'Garbage', type: 'global', value: [{ id: 'department', value: 'IT' }] },
           },
@@ -264,12 +265,12 @@ describe('CIPPTableToptoolbar - preset list refresh', () => {
   })
 
   it('restores a legacy column filter into the table slot', async () => {
-    renderGraphTable({}, {
+    renderGraphTable({ persistenceKey: 'SlotsTest' }, {
       settings: settingsWith({
         persistFilters: true,
         setLastUsedFilter: vi.fn(),
         lastUsedFilters: {
-          '': { type: 'column', value: [{ id: 'department', value: 'IT' }], name: 'IT only' },
+          SlotsTest: { type: 'column', value: [{ id: 'department', value: 'IT' }], name: 'IT only' },
         },
       }),
     })
@@ -284,12 +285,12 @@ describe('CIPPTableToptoolbar - preset list refresh', () => {
   // overwriting whatever the user had just applied with the persisted filter.
   it('does not clobber a user filter applied after the persisted one was restored', async () => {
     const user = userEvent.setup()
-    renderGraphTable({}, {
+    renderGraphTable({ persistenceKey: 'SlotsTest' }, {
       settings: settingsWith({
         persistFilters: true,
         setLastUsedFilter: vi.fn(),
         lastUsedFilters: {
-          '': { type: 'column', value: [{ id: 'department', value: 'IT' }], name: 'IT only' },
+          SlotsTest: { type: 'column', value: [{ id: 'department', value: 'IT' }], name: 'IT only' },
         },
       }),
     })

--- a/frontend/tests/components/CippTable/CippDataTable.stories.jsx
+++ b/frontend/tests/components/CippTable/CippDataTable.stories.jsx
@@ -480,3 +480,40 @@ export const GraphBackedEditFilters = {
     })
   },
 }
+
+// cached report column (membersCsv) wears the subTable header, no nested-table button. MRT renders no header cells in jsdom
+export const CachedReportColumns = {
+  args: {
+    title: 'Groups',
+    data: [{ id: 'parent-1', displayName: 'Finance', membersCsv: 'Jane, Bob' }],
+    simpleColumns: ['displayName', 'members'],
+    subTables: [
+      {
+        id: 'members',
+        header: 'Members',
+        label: 'View members',
+        cachedColumn: 'membersCsv',
+        table: {
+          title: 'Members of [displayName]',
+          api: { url: '/api/TestRelated', dataKey: 'Results' },
+          simpleColumns: ['displayName'],
+        },
+      },
+    ],
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('cached csv column takes the subTable header', async () => {
+      await waitFor(() => {
+        expect(canvas.getByRole('columnheader', { name: /Members/ })).toBeVisible()
+      })
+      expect(canvas.queryByRole('columnheader', { name: /csv/i })).toBeNull()
+    })
+
+    await step('cell shows the cached value, no nested table button', async () => {
+      await expect(canvas.getByText('Jane, Bob')).toBeVisible()
+      expect(canvas.queryByRole('button', { name: 'View members' })).toBeNull()
+    })
+  },
+}

--- a/frontend/tests/components/CippTable/CippDataTable.test.jsx
+++ b/frontend/tests/components/CippTable/CippDataTable.test.jsx
@@ -6,6 +6,15 @@ import { renderWithProviders } from '../../test-utils'
 import { CippDataTable } from '../../../src/components/CippTable/CippDataTable'
 import { resetOverlayHistory } from '../../../src/utils/overlay-history'
 
+vi.mock('../../../src/api/ApiCall', async () => (await import('../../mocks/api-call')).apiCallMock())
+import { api, paginatedResult } from '../../mocks/api-call'
+
+// idle keeps static-data tables on their data prop; the nested result is re-wrapped per call like react-query's tracked copy, the memo'd toolbar needs it to see selection
+const nestedRows = [{ id: 'child-1', displayName: 'Jane Doe' }]
+const nestedResult = paginatedResult(nestedRows)
+const idlePaginated = paginatedResult([], { isSuccess: false })
+api.paginated = (opts) => (opts?.url === '/api/TestRelated' ? { ...nestedResult } : idlePaginated)
+
 const basicData = [
   { displayName: 'Alice Smith', mail: 'alice@contoso.com', department: 'IT', accountEnabled: true },
   { displayName: 'Bob Johnson', mail: 'bob@contoso.com', department: 'Sales', accountEnabled: true },
@@ -718,7 +727,13 @@ describe('CippDataTable cards->table toggle scroll', () => {
 
 describe('CippDataTable subTables', () => {
   const parentRows = [{ id: 'parent-1', displayName: 'Finance' }]
-  const relatedRows = [{ id: 'child-1', displayName: 'Jane Doe' }]
+  // live nested table, the shape groups/index.js ships
+  const nestedTable = {
+    title: 'Related for [displayName]',
+    api: { url: '/api/TestRelated', dataKey: 'Results' },
+    simpleColumns: ['displayName'],
+    viewMode: 'cards',
+  }
 
   it('injects a button column that opens a nested table', async () => {
     const user = userEvent.setup()
@@ -733,12 +748,7 @@ describe('CippDataTable subTables', () => {
             id: 'related',
             header: 'Related',
             label: 'View',
-            table: {
-              title: 'Related for [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-              viewMode: 'cards',
-            },
+            table: nestedTable,
           },
         ]}
       />
@@ -771,10 +781,7 @@ describe('CippDataTable subTables', () => {
             header: 'Related',
             label: 'View',
             table: {
-              title: 'Related for [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-              viewMode: 'cards',
+              ...nestedTable,
               actions: [
                 {
                   label: 'Remove',
@@ -797,15 +804,18 @@ describe('CippDataTable subTables', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Row actions' }))
     await user.click(await screen.findByText('Remove'))
 
-    expect(rowFn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'child-1',
-        displayName: 'Jane Doe',
-        parent: expect.objectContaining({ id: 'parent-1', displayName: 'Finance' }),
-      }),
-      expect.anything(),
-      expect.anything()
-    )
+    // the row sheet hands the action off to its exit transition
+    await waitFor(() => {
+      expect(rowFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'child-1',
+          displayName: 'Jane Doe',
+          parent: expect.objectContaining({ id: 'parent-1', displayName: 'Finance' }),
+        }),
+        expect.anything(),
+        expect.anything()
+      )
+    })
 
     rowFn.mockClear()
     await user.click(within(dialog).getByRole('button', { name: 'Select' }))
@@ -813,14 +823,16 @@ describe('CippDataTable subTables', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Actions' }))
     await user.click(await screen.findByText('Remove'))
 
-    expect(rowFn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'child-1',
-        parent: expect.objectContaining({ id: 'parent-1' }),
-      }),
-      expect.anything(),
-      expect.anything()
-    )
+    await waitFor(() => {
+      expect(rowFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'child-1',
+          parent: expect.objectContaining({ id: 'parent-1' }),
+        }),
+        expect.anything(),
+        expect.anything()
+      )
+    })
   })
 
   it('replaces a data column that shares the subTable id', async () => {
@@ -836,12 +848,7 @@ describe('CippDataTable subTables', () => {
             id: 'related',
             header: 'Related',
             label: 'View',
-            table: {
-              title: 'Related for [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-              viewMode: 'cards',
-            },
+            table: nestedTable,
           },
         ]}
       />
@@ -869,12 +876,7 @@ describe('CippDataTable subTables', () => {
             id: 'related',
             header: 'Related',
             label: 'View',
-            table: {
-              title: 'Related for [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-              viewMode: 'cards',
-            },
+            table: nestedTable,
           },
         ]}
       />
@@ -897,12 +899,7 @@ describe('CippDataTable subTables', () => {
             header: 'Members',
             label: 'View members',
             cachedColumn: 'membersCsv',
-            table: {
-              title: 'Members of [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-              viewMode: 'cards',
-            },
+            table: { ...nestedTable, title: 'Members of [displayName]' },
           },
         ]}
       />
@@ -911,34 +908,6 @@ describe('CippDataTable subTables', () => {
     await waitFor(() => expect(screen.getByText('Finance')).toBeInTheDocument())
     expect(screen.queryByRole('button', { name: 'View members' })).not.toBeInTheDocument()
     expect(screen.getByText('Jane, Bob')).toBeInTheDocument()
-  })
-
-  it('renders cached report columns in table view without a stale column order crash', async () => {
-    renderWithProviders(
-      <CippDataTable
-        viewMode="table"
-        data={[{ id: 'parent-1', displayName: 'Finance', membersCsv: 'Jane, Bob' }]}
-        simpleColumns={['displayName', 'members']}
-        title="Groups"
-        subTables={[
-          {
-            id: 'members',
-            header: 'Members',
-            label: 'View members',
-            cachedColumn: 'membersCsv',
-            table: {
-              title: 'Members of [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-            },
-          },
-        ]}
-      />
-    )
-
-    await waitFor(() => expect(screen.getByText('Finance')).toBeInTheDocument())
-    expect(screen.getByRole('columnheader', { name: 'Members' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'View members' })).not.toBeInTheDocument()
   })
 
   it('still shows the nested table button when cachedColumn is configured but missing from the data', async () => {
@@ -954,12 +923,7 @@ describe('CippDataTable subTables', () => {
             header: 'Members',
             label: 'View members',
             cachedColumn: 'membersCsv',
-            table: {
-              title: 'Members of [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-              viewMode: 'cards',
-            },
+            table: { ...nestedTable, title: 'Members of [displayName]' },
           },
         ]}
       />
@@ -972,7 +936,7 @@ describe('CippDataTable subTables', () => {
   it('shows the nested table button when cachedColumn exists but is empty (live API shape)', async () => {
     renderWithProviders(
       <CippDataTable
-        viewMode="table"
+        viewMode="cards"
         data={[{ id: 'parent-1', displayName: 'Finance', membersCsv: '', ownersCsv: '' }]}
         simpleColumns={['displayName', 'members']}
         title="Groups"
@@ -982,11 +946,7 @@ describe('CippDataTable subTables', () => {
             header: 'Members',
             label: 'View members',
             cachedColumn: 'membersCsv',
-            table: {
-              title: 'Members of [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-            },
+            table: { ...nestedTable, title: 'Members of [displayName]' },
           },
         ]}
       />
@@ -1010,10 +970,9 @@ describe('CippDataTable subTables', () => {
             header: 'Related',
             label: 'View',
             table: {
-              title: 'Related for [displayName]',
-              data: relatedRows,
-              simpleColumns: ['displayName'],
-              viewMode: 'cards',
+              ...nestedTable,
+              // table view, the card header is the only cardButton slot inside a dialog
+              viewMode: 'table',
               cardButton: {
                 label: 'Add Members',
                 url: '/api/EditGroup',

--- a/frontend/tests/components/PrivateRoute.test.jsx
+++ b/frontend/tests/components/PrivateRoute.test.jsx
@@ -19,6 +19,7 @@ vi.mock('../../src/api/ApiCall', () => ({
     // /.auth/me
     return authState.swa
   },
+  ApiPostCall: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 // the gate page hosts the entire setup wizard via next/dynamic - the routing

--- a/frontend/tests/mocks/api-call.js
+++ b/frontend/tests/mocks/api-call.js
@@ -31,6 +31,7 @@ export const paginatedResult = (rows = [], overrides = {}) => ({
 
 export const postResult = (overrides = {}) => ({
   mutate: vi.fn(),
+  reset: vi.fn(),
   isPending: false,
   isSuccess: false,
   isError: false,

--- a/frontend/tests/pages/MessageEncryptionPage.test.jsx
+++ b/frontend/tests/pages/MessageEncryptionPage.test.jsx
@@ -32,10 +32,15 @@ describe('Message Encryption page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     api.post = postResult()
-    api.paginated = paginatedResult([
-      { displayName: 'Admin', UPN: 'admin@contoso.com' },
-      { displayName: 'Helpdesk', UPN: 'helpdesk@contoso.com' },
-    ])
+    // ListMailboxes returns a bare array (no Results wrapper, the page's api sets no dataKey)
+    api.paginated = paginatedResult([], {
+      data: {
+        pages: [[
+          { displayName: 'Admin', UPN: 'admin@contoso.com' },
+          { displayName: 'Helpdesk', UPN: 'helpdesk@contoso.com' },
+        ]],
+      },
+    })
   })
 
   it('renders the current IRM state for the tenant', async () => {

--- a/frontend/tests/pages/UnauthenticatedPage.test.jsx
+++ b/frontend/tests/pages/UnauthenticatedPage.test.jsx
@@ -18,6 +18,7 @@ vi.mock('../../src/api/ApiCall', () => ({
     // /.auth/me and /version.json
     return authState.swa
   },
+  ApiPostCall: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 const successResult = (data) => ({


### PR DESCRIPTION
- fix CippDataTableButton destructuring. `tableProps.title` was always undefined and the subTable header beat the `table.title` template; the groups Members/Owners dialog now reads "Members of <group>".
- fix regression added from CippAddUserDrawer.test.jsx that looped the domain selector forever from bacb822ee 
- update other test files from feature work