### PR TITLE
feat(scheduler): add a countdown to the next scheduler run

### DIFF
--- a/docs/user-documentation/tools/scheduler/README.md
+++ b/docs/user-documentation/tools/scheduler/README.md
@@ -10,6 +10,12 @@ Scheduling a task in the past makes it run at the next interval the scheduler ru
 
 The scheduler operates on 15-minute intervals, and no other cadence is available. A task created through the API for 10:10 runs at 10:15. A recurring task returns to a planned state immediately after it executes.
 
+A banner above the table counts down to the next scheduler run, shows the time it is due, and reports how many tasks that run will pick up. A task whose scheduled time has already passed stays **Planned** until that run, so a time in the recent past is not a sign the task has failed.
+
+The count covers the tasks currently listed, so it follows the **Show System Jobs** toggle: with system jobs hidden it counts only your own tasks. Tasks in a stuck state that the scheduler recovers on its own are not included.
+
+A second count appears whenever tasks are already being worked on. Once the scheduler picks a task up it leaves **Planned** and stops being due, so it moves out of the due count and is reported as in progress until it finishes. A task shown as **Pending** has therefore already been claimed rather than being sat waiting for the next run.
+
 ## Action Buttons
 
 <details>

--- a/frontend/src/components/CippComponents/CippSchedulerCountdown.jsx
+++ b/frontend/src/components/CippComponents/CippSchedulerCountdown.jsx
@@ -1,0 +1,240 @@
+import { useSyncExternalStore } from 'react'
+import { Avatar, Box, Card, Chip, Divider, Skeleton, Typography } from '@mui/material'
+import { AccessTime } from '@mui/icons-material'
+import { ApiGetCallWithPagination } from '../../api/ApiCall'
+import { useSettings } from '../../hooks/use-settings'
+import { parseCippDate } from '../../utils/parse-cipp-date'
+
+// Scheduled tasks are picked up by Start-UserTasksOrchestrator, which runs on the fixed cron
+// `0 */15 * * * *` (backend/Config/CIPPTimers.json). Every IANA UTC offset is a whole multiple of
+// 15 minutes, so those boundaries fall on the same instants in the browser's local clock as in
+// whatever timezone the backend schedules in - the next run can be derived locally.
+export const SCHEDULER_INTERVAL_MINUTES = 15
+
+// The states the orchestrator treats as awaiting a run. Its filter also recovers stuck tasks
+// (Pending > 1h, Running/Processing > 4h), which are deliberately not counted here: that is a
+// self-heal path, and counting them would make a stuck job look like upcoming work.
+const PLANNED_STATES = ['Planned', 'Failed - Planned']
+
+// Already claimed by an orchestrator rather than waiting for one: Pending is "picked up, queuing
+// commands", Running and Processing are executing. These are reported separately because they are
+// not what the next run will pick up, but a task visibly sitting in one of them alongside a bare
+// "no tasks due" reads as though nothing is happening.
+const IN_FLIGHT_STATES = ['Pending', 'Running', 'Processing']
+
+/** The next quarter-hour boundary strictly after `now`, with seconds and milliseconds zeroed. */
+export const getNextSchedulerRun = (now = new Date()) => {
+  const nextRun = new Date(now)
+  nextRun.setSeconds(0, 0)
+  // setMinutes(60) rolls into the next hour on its own, so hour, day and DST boundaries are all
+  // handled by Date rather than by arithmetic here.
+  nextRun.setMinutes(
+    (Math.floor(now.getMinutes() / SCHEDULER_INTERVAL_MINUTES) + 1) * SCHEDULER_INTERVAL_MINUTES
+  )
+  return nextRun
+}
+
+/** Milliseconds as `m:ss`, floored at 0:00 so a passed boundary never renders as negative. */
+export const formatCountdown = (ms) => {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+// A row with no usable scheduled time is not counted. The guard is load-bearing: `new Date(null)`
+// is the epoch rather than an Invalid Date, so without it a row missing ScheduledTime would parse
+// to 1970 and always look due.
+const isDueBy = (scheduledTime, nextRun) => {
+  if (scheduledTime === null || scheduledTime === undefined) return false
+  const scheduled = parseCippDate(scheduledTime)
+  return !Number.isNaN(scheduled.getTime()) && scheduled <= nextRun
+}
+
+/**
+ * How many of `rows` the run at `nextRun` will pick up: enabled, awaiting a run, and due by then.
+ *
+ * `Disabled` is absent on every task created before the flag existed, so this tests for an
+ * explicit true rather than for falsiness, matching the orchestrator's own client-side filter.
+ */
+export const countDueTasks = (rows, nextRun) =>
+  rows.filter(
+    (row) =>
+      row?.Disabled !== true &&
+      PLANNED_STATES.includes(row?.TaskState) &&
+      isDueBy(row?.ScheduledTime, nextRun)
+  ).length
+
+/** Chip text for a due-task count. */
+export const formatDueLabel = (count) => {
+  if (count === 0) return 'No tasks due'
+  return count === 1 ? '1 task due' : `${count} tasks due`
+}
+
+/**
+ * How many of `rows` an orchestrator is already working on.
+ *
+ * Unlike the due count this does not exclude disabled tasks: disabling one mid-run does not stop
+ * the run, and this reports observed state rather than eligibility for the next one.
+ */
+export const countInFlightTasks = (rows) =>
+  rows.filter((row) => IN_FLIGHT_STATES.includes(row?.TaskState)).length
+
+/** Chip text for an in-flight count. */
+export const formatInFlightLabel = (count) =>
+  count === 1 ? '1 in progress' : `${count} in progress`
+
+// Hidden below sm, where the row wraps and a rule between wrapped lines reads as noise.
+const VerticalRule = () => (
+  <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', sm: 'block' } }} />
+)
+
+// The wall clock is external state, so it is read through useSyncExternalStore rather than an
+// effect. That also gives correct SSR behaviour for the static export: the server snapshot is null
+// so nothing renders, and React reads the real time after hydration instead of mismatching.
+const subscribeToClock = (listener) => {
+  const interval = setInterval(listener, 1000)
+  return () => clearInterval(interval)
+}
+
+// Whole seconds, so the snapshot is referentially stable between ticks - returning a fresh Date
+// would re-render forever. Reading the clock per tick rather than decrementing also means
+// background-tab timer throttling corrects itself on refocus instead of accumulating drift.
+const getClockSnapshot = () => Math.floor(Date.now() / 1000)
+const getServerClockSnapshot = () => null
+
+/**
+ * Live countdown to the next scheduler pass, for the CippTablePage `tableFilter` slot on the
+ * Scheduled Tasks page.
+ *
+ * Scheduled Time renders as relative time, so a task whose time has passed reads "3 minutes ago"
+ * while its state is still Planned - which looks overdue when it is only waiting for the next
+ * 15-minute pass. This says when that pass is due, and how much work it will pick up.
+ *
+ * Styled as a metric tile rather than an alert: it is standing information about the page, not a
+ * notice to act on. Follows the dashboard card idiom - avatar icon, caption label, prominent value.
+ *
+ * @param {string} apiUrl   - The table's apiUrl, verbatim.
+ * @param {string} queryKey - The table's queryKey, verbatim. Matching both subscribes to the same
+ *                            React Query cache entry the table already populates, so the count
+ *                            costs no extra request. It also scopes the count to the rows on
+ *                            screen, so it tracks the Show System Jobs toggle.
+ */
+export const CippSchedulerCountdown = ({ apiUrl, queryKey }) => {
+  const clock = useSyncExternalStore(subscribeToClock, getClockSnapshot, getServerClockSnapshot)
+  const tenant = useSettings().currentTenant
+  const tasks = ApiGetCallWithPagination({
+    url: apiUrl,
+    data: { tenantFilter: tenant },
+    queryKey,
+    waiting: Boolean(apiUrl && queryKey),
+  })
+
+  if (clock === null) return null
+
+  const now = new Date(clock * 1000)
+  const nextRun = getNextSchedulerRun(now)
+
+  // Held at the last successful result through a background refetch: dropping to the skeleton on
+  // every poll would flicker a number that has almost certainly not changed.
+  const rows = tasks.isSuccess
+    ? (tasks.data?.pages ?? []).flatMap((page) => (Array.isArray(page) ? page : []))
+    : null
+  const dueCount = rows === null ? null : countDueTasks(rows, nextRun)
+  const inFlightCount = rows === null ? 0 : countInFlightTasks(rows)
+
+  return (
+    // A group rather than a live region: an aria-live element would announce the countdown once a
+    // second. The text is ambient, and is read normally when navigated to.
+    <Card role="group" aria-label="Next scheduler run">
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: { xs: 1.5, sm: 2 },
+          p: { xs: 1.5, sm: 2 },
+          flexWrap: 'wrap',
+        }}
+      >
+        <Avatar
+          sx={{
+            bgcolor: 'primary.main',
+            color: 'primary.contrastText',
+            width: { xs: 34, md: 38 },
+            height: { xs: 34, md: 38 },
+            flexShrink: 0,
+          }}
+        >
+          <AccessTime sx={{ fontSize: { xs: 20, md: 22 }, color: 'inherit' }} />
+        </Avatar>
+
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="caption" color="text.secondary" noWrap>
+            Next scheduler run
+          </Typography>
+          {/* The countdown is the point of the tile; the due time is a qualifier on it, so it
+              rides on the same baseline at body size rather than as a second peer metric. */}
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'wrap' }}>
+            <Typography
+              variant="h5"
+              sx={{
+                lineHeight: 1.2,
+                fontSize: { xs: '1.25rem', md: '1.5rem' },
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {formatCountdown(nextRun - now)}
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              noWrap
+              sx={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              due at {nextRun.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
+            </Typography>
+          </Box>
+        </Box>
+
+        <VerticalRule />
+
+        {/* Sits in the outer row rather than on the value line: a chip has no text baseline to
+            share with the countdown, so it centres against the tile instead. */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          {dueCount === null ? (
+            <Skeleton variant="rounded" width={86} height={24} />
+          ) : (
+            <Chip
+              size="small"
+              variant="outlined"
+              color={dueCount > 0 ? 'primary' : 'default'}
+              label={formatDueLabel(dueCount)}
+            />
+          )}
+          {/* Only when there is something to report - a permanent "0 in progress" is noise. */}
+          {inFlightCount > 0 && (
+            <Chip
+              size="small"
+              variant="outlined"
+              color="info"
+              label={formatInFlightLabel(inFlightCount)}
+            />
+          )}
+        </Box>
+
+        <VerticalRule />
+
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ flex: '1 1 260px', minWidth: 0 }}
+        >
+          Scheduled tasks are picked up every {SCHEDULER_INTERVAL_MINUTES} minutes. A task whose
+          scheduled time has passed stays Planned until the next run.
+        </Typography>
+      </Box>
+    </Card>
+  )
+}
+
+export default CippSchedulerCountdown

--- a/frontend/src/pages/cipp/scheduler/index.js
+++ b/frontend/src/pages/cipp/scheduler/index.js
@@ -6,6 +6,7 @@ import { useState } from "react";
 import ScheduledTaskDetails from "../../../components/CippComponents/ScheduledTaskDetails";
 import { CippScheduledTaskActions } from "../../../components/CippComponents/CippScheduledTaskActions";
 import { CippSchedulerDrawer } from "../../../components/CippComponents/CippSchedulerDrawer";
+import { CippSchedulerCountdown } from "../../../components/CippComponents/CippSchedulerCountdown";
 import { useSettings } from "../../../hooks/use-settings";
 
 const Page = () => {
@@ -55,6 +56,14 @@ const Page = () => {
     actions: actions,
   };
   const [showHiddenJobs, setShowHiddenJobs] = useState(false);
+  // Hoisted so the countdown can subscribe to exactly the cache entry the table populates,
+  // rather than issuing a second request for the same rows.
+  const apiUrl = showHiddenJobs
+    ? `/api/ListScheduledItems?ShowHidden=true`
+    : `/api/ListScheduledItems`;
+  const queryKey = showHiddenJobs
+    ? `ListScheduledItems-hidden-${currentTenant}`
+    : `ListScheduledItems-${currentTenant}`;
   return (
     <>
       <CippTablePage
@@ -67,14 +76,9 @@ const Page = () => {
           </>
         }
         title="Scheduled Tasks"
-        apiUrl={
-          showHiddenJobs ? `/api/ListScheduledItems?ShowHidden=true` : `/api/ListScheduledItems`
-        }
-        queryKey={
-          showHiddenJobs
-            ? `ListScheduledItems-hidden-${currentTenant}`
-            : `ListScheduledItems-${currentTenant}`
-        }
+        tableFilter={<CippSchedulerCountdown apiUrl={apiUrl} queryKey={queryKey} />}
+        apiUrl={apiUrl}
+        queryKey={queryKey}
         simpleColumns={[
           "ExecutedTime",
           "TaskState",

--- a/frontend/tests/components/CippComponents/CippSchedulerCountdown.test.jsx
+++ b/frontend/tests/components/CippComponents/CippSchedulerCountdown.test.jsx
@@ -1,0 +1,264 @@
+import React from 'react'
+import { act, screen } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { renderWithTheme } from '../../test-utils'
+import {
+  CippSchedulerCountdown,
+  countDueTasks,
+  countInFlightTasks,
+  formatCountdown,
+  formatDueLabel,
+  formatInFlightLabel,
+  getNextSchedulerRun,
+} from '../../../src/components/CippComponents/CippSchedulerCountdown'
+
+// The component subscribes to the table's React Query cache entry. Standing in for that hook keeps
+// these tests off the network and lets each one state exactly what the table has loaded.
+const apiMock = vi.hoisted(() => ({ result: { isSuccess: false, data: undefined } }))
+vi.mock('../../../src/api/ApiCall', () => ({
+  ApiGetCallWithPagination: () => apiMock.result,
+}))
+
+// Local-time constructor, so the quarter-hour maths is exercised in whatever timezone the
+// test runner happens to be in.
+const at = (hours, minutes, seconds, ms = 0) => new Date(2026, 0, 15, hours, minutes, seconds, ms)
+
+const plannedAt = (date) => ({ TaskState: 'Planned', ScheduledTime: date.toISOString() })
+
+// Rows reach the component as pages of the paginated query.
+const loaded = (rows) => ({ isSuccess: true, data: { pages: [rows] } })
+
+beforeEach(() => {
+  apiMock.result = { isSuccess: false, data: undefined }
+})
+
+describe('getNextSchedulerRun', () => {
+  it.each([
+    ['on the boundary, moves to the next one', at(14, 15, 0), at(14, 30, 0)],
+    ['just before a boundary', at(14, 14, 59), at(14, 15, 0)],
+    ['start of an hour', at(14, 0, 0), at(14, 15, 0)],
+    ['rolls over the hour', at(14, 59, 30), at(15, 0, 0)],
+  ])('%s', (_label, now, expected) => {
+    expect(getNextSchedulerRun(now).getTime()).toBe(expected.getTime())
+  })
+
+  it('rolls over midnight', () => {
+    const nextRun = getNextSchedulerRun(at(23, 59, 30))
+    expect(nextRun.getTime()).toBe(new Date(2026, 0, 16, 0, 0, 0).getTime())
+  })
+
+  it('zeroes seconds and milliseconds', () => {
+    const nextRun = getNextSchedulerRun(at(14, 3, 47, 512))
+    expect(nextRun.getSeconds()).toBe(0)
+    expect(nextRun.getMilliseconds()).toBe(0)
+  })
+
+  it('does not mutate the date it is given', () => {
+    const now = at(14, 3, 47)
+    getNextSchedulerRun(now)
+    expect(now.getTime()).toBe(at(14, 3, 47).getTime())
+  })
+})
+
+describe('formatCountdown', () => {
+  it('pads seconds to two digits', () => {
+    expect(formatCountdown(5000)).toBe('0:05')
+    expect(formatCountdown(272000)).toBe('4:32')
+  })
+
+  it('floors a passed boundary at zero', () => {
+    expect(formatCountdown(-1000)).toBe('0:00')
+    expect(formatCountdown(0)).toBe('0:00')
+  })
+})
+
+describe('countDueTasks', () => {
+  const nextRun = at(14, 15, 0)
+
+  it('counts planned tasks whose time falls before the run', () => {
+    expect(countDueTasks([plannedAt(at(14, 0, 0)), plannedAt(at(13, 0, 0))], nextRun)).toBe(2)
+  })
+
+  it('counts a task scheduled exactly on the boundary', () => {
+    expect(countDueTasks([plannedAt(at(14, 15, 0))], nextRun)).toBe(1)
+  })
+
+  it('skips a task scheduled after the run', () => {
+    expect(countDueTasks([plannedAt(at(14, 20, 0))], nextRun)).toBe(0)
+  })
+
+  it('counts Failed - Planned, which the orchestrator also picks up', () => {
+    const row = { ...plannedAt(at(14, 0, 0)), TaskState: 'Failed - Planned' }
+    expect(countDueTasks([row], nextRun)).toBe(1)
+  })
+
+  it.each(['Completed', 'Failed', 'Running', 'Pending', 'Processing'])(
+    'skips %s tasks',
+    (TaskState) => {
+      expect(countDueTasks([{ ...plannedAt(at(14, 0, 0)), TaskState }], nextRun)).toBe(0)
+    }
+  )
+
+  it('skips explicitly disabled tasks only', () => {
+    const due = plannedAt(at(14, 0, 0))
+    expect(countDueTasks([{ ...due, Disabled: true }], nextRun)).toBe(0)
+    // Disabled is absent on every task predating the flag, so only an explicit true excludes.
+    expect(countDueTasks([{ ...due, Disabled: false }, due], nextRun)).toBe(2)
+  })
+
+  it('accepts a scheduled time stored as epoch seconds', () => {
+    const epoch = String(Math.floor(at(14, 0, 0).getTime() / 1000))
+    expect(countDueTasks([{ TaskState: 'Planned', ScheduledTime: epoch }], nextRun)).toBe(1)
+  })
+
+  it('skips rows with an unusable scheduled time', () => {
+    const rows = [
+      { TaskState: 'Planned' },
+      { TaskState: 'Planned', ScheduledTime: 'not a date' },
+      { TaskState: 'Planned', ScheduledTime: null },
+    ]
+    expect(countDueTasks(rows, nextRun)).toBe(0)
+  })
+})
+
+describe('formatDueLabel', () => {
+  it('reads naturally at each count', () => {
+    expect(formatDueLabel(0)).toBe('No tasks due')
+    expect(formatDueLabel(1)).toBe('1 task due')
+    expect(formatDueLabel(4)).toBe('4 tasks due')
+  })
+})
+
+describe('countInFlightTasks', () => {
+  it.each(['Pending', 'Running', 'Processing'])('counts %s tasks', (TaskState) => {
+    expect(countInFlightTasks([{ TaskState }])).toBe(1)
+  })
+
+  it.each(['Planned', 'Failed - Planned', 'Completed', 'Failed'])(
+    'does not count %s tasks',
+    (TaskState) => {
+      expect(countInFlightTasks([{ TaskState }])).toBe(0)
+    }
+  )
+
+  it('counts a task disabled mid-run, since disabling does not stop it', () => {
+    expect(countInFlightTasks([{ TaskState: 'Running', Disabled: true }])).toBe(1)
+  })
+
+  it('does not double-count against the due total', () => {
+    // A claimed task leaves Planned, so the two counts never see the same row.
+    const rows = [plannedAt(at(14, 0, 0)), { TaskState: 'Pending' }]
+    expect(countDueTasks(rows, at(14, 15, 0))).toBe(1)
+    expect(countInFlightTasks(rows)).toBe(1)
+  })
+})
+
+describe('formatInFlightLabel', () => {
+  it('reads naturally at each count', () => {
+    expect(formatInFlightLabel(1)).toBe('1 in progress')
+    expect(formatInFlightLabel(3)).toBe('3 in progress')
+  })
+})
+
+describe('CippSchedulerCountdown', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const renderAt = (now) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+    return renderWithTheme(
+      <CippSchedulerCountdown apiUrl="/api/ListScheduledItems" queryKey="ListScheduledItems-test" />
+    )
+  }
+
+  it('renders nothing on the server, so hydration cannot mismatch', () => {
+    expect(renderToStaticMarkup(<CippSchedulerCountdown />)).toBe('')
+  })
+
+  it('counts down to the next quarter hour', () => {
+    renderAt(at(14, 10, 28))
+
+    expect(screen.getByText('4:32')).toBeInTheDocument()
+    // Locale-agnostic: built with the same call the component makes.
+    const expectedTime = at(14, 15, 0).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    expect(screen.getByRole('group', { name: /next scheduler run/i })).toHaveTextContent(
+      expectedTime
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(screen.getByText('4:31')).toBeInTheDocument()
+  })
+
+  it('rolls to the following run once the boundary passes', () => {
+    renderAt(at(14, 14, 59))
+    expect(screen.getByText('0:01')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(screen.getByText('15:00')).toBeInTheDocument()
+  })
+
+  it('is not a live region, so it is not announced on every tick', () => {
+    renderAt(at(14, 10, 28))
+    expect(screen.getByRole('group', { name: /next scheduler run/i })).not.toHaveAttribute(
+      'aria-live'
+    )
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('reports how many of the loaded tasks the next run will pick up', () => {
+    apiMock.result = loaded([
+      plannedAt(at(14, 0, 0)),
+      plannedAt(at(14, 20, 0)), // after the run
+      { ...plannedAt(at(14, 0, 0)), TaskState: 'Completed' },
+    ])
+    renderAt(at(14, 10, 28))
+
+    expect(screen.getByText('1 task due')).toBeInTheDocument()
+  })
+
+  it('says so when the next run has nothing to do', () => {
+    apiMock.result = loaded([])
+    renderAt(at(14, 10, 28))
+
+    expect(screen.getByText('No tasks due')).toBeInTheDocument()
+    expect(screen.queryByText(/in progress/)).not.toBeInTheDocument()
+  })
+
+  // The case that prompted this: a task already claimed by an off-cycle run sits in Pending, so
+  // nothing is due for the next run, but the row on screen is plainly not idle.
+  it('reports a claimed task as in progress rather than as nothing at all', () => {
+    apiMock.result = loaded([{ TaskState: 'Pending', ScheduledTime: at(14, 9, 41).toISOString() }])
+    renderAt(at(14, 10, 28))
+
+    expect(screen.getByText('No tasks due')).toBeInTheDocument()
+    expect(screen.getByText('1 in progress')).toBeInTheDocument()
+  })
+
+  it('shows both counts when work is queued and running at once', () => {
+    apiMock.result = loaded([
+      plannedAt(at(14, 0, 0)),
+      plannedAt(at(14, 1, 0)),
+      { TaskState: 'Running' },
+    ])
+    renderAt(at(14, 10, 28))
+
+    expect(screen.getByText('2 tasks due')).toBeInTheDocument()
+    expect(screen.getByText('1 in progress')).toBeInTheDocument()
+  })
+
+  it('shows no count until the table has loaded', () => {
+    renderAt(at(14, 10, 28))
+
+    expect(screen.getByText('4:32')).toBeInTheDocument()
+    expect(screen.queryByText(/due$/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
The scheduler page shows scheduled tasks in relative time, a task where the scheduled time has passed for example shows "3 minutes ago" with the state of "Planned" which to an unexperienced CIPP user reads as overdue or a problem with CIPP - when in reality it missed the last orchestrator run by a small margin.. I know this causes no end of confusion for MSPs and even myself at times..

This PR aims to address these issues by adding a tile above the Scheduled Tasks table showing the following:
- how long until the next scheduler run
- the time that run is due
- how many of the listed tasks that run will pick up
- how many tasks are already being worked on

<img width="1214" height="94" alt="image" src="https://github.com/user-attachments/assets/772b61a3-aac6-40ee-b9b9-63f824c6d67a" />
