### PR TITLE
feat(standards): add external compliance trust standard

### DIFF
--- a/backend/Config/BaselineStandards/Entra (AAD) Standards/ExternalComplianceTrusted.json
+++ b/backend/Config/BaselineStandards/Entra (AAD) Standards/ExternalComplianceTrusted.json
@@ -1,0 +1,41 @@
+{
+  "name": "ExternalComplianceTrusted",
+  "label": "Sets the Cross-tenant Access Setting to Trust External Compliant Devices",
+  "cat": "Entra (AAD) Standards",
+  "tag": [],
+  "impact": "Low Impact",
+  "helpText": "Sets the default state for whether device compliance performed in an external tenant is trusted for inbound B2B access.",
+  "executiveText": "Controls whether guests using compliant devices from their home organization can access this tenant without requiring device compliance to be evaluated again. Trusting external compliance reduces partner friction while preserving device-based access controls.",
+  "docsDescription": "Grades and sets inboundTrust.isCompliantDeviceAccepted on the default cross-tenant access policy. Remediation reads the live policy and rewrites the merged inboundTrust object, preserving the MFA and hybrid-join trust flags alongside it.",
+  "impactColour": "info",
+  "addedDate": "2026-08-25",
+  "powershellEquivalent": "Update-MgPolicyCrossTenantAccessPolicyDefault",
+  "recommendedBy": [],
+  "requiredCapabilities": [
+    "AAD_PREMIUM",
+    "AAD_PREMIUM_P2"
+  ],
+  "disabledFeatures": {
+    "report": false,
+    "warn": false,
+    "remediate": false
+  },
+  "secureScoreImpact": 0,
+  "compare": "subset",
+  "variables": {
+    "state": {
+      "type": "switch",
+      "label": "Trust compliant devices from external tenants",
+      "default": false,
+      "recommended": true
+    }
+  },
+  "read": {
+    "cacheType": "CrossTenantAccessPolicy"
+  },
+  "prepare": "Get-CIPPBaselineExternalComplianceTrustedState",
+  "remediate": {
+    "executor": "ExternalComplianceTrusted",
+    "trusted": "%state%"
+  }
+}

--- a/backend/Config/standards.json
+++ b/backend/Config/standards.json
@@ -1354,6 +1354,32 @@
     "recommendedBy": []
   },
   {
+    "name": "standards.ExternalComplianceTrusted",
+    "cat": "Entra (AAD) Standards",
+    "tag": [],
+    "helpText": "Sets the state of the Cross-tenant access setting to trust external compliant devices. This allows guest users to use a compliant device from their home tenant to access your tenant.",
+    "executiveText": "Allows external partners and vendors to use compliant devices from their own organization when accessing company resources, streamlining collaboration while maintaining security standards. This reduces friction for external users while ensuring their devices still meet compliance requirements.",
+    "addedComponent": [
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "label": "Select value",
+        "name": "standards.ExternalComplianceTrusted.state",
+        "options": [
+          { "label": "Enabled", "value": "true" },
+          { "label": "Disabled", "value": "false" }
+        ]
+      }
+    ],
+    "label": "Sets the Cross-tenant access setting to trust external compliant devices",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "addedDate": "2026-08-25",
+    "powershellEquivalent": "Update-MgBetaPolicyCrossTenantAccessPolicyDefault",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.DisableTenantCreation",
     "cat": "Entra (AAD) Standards",
     "tag": ["CIS M365 7.0.0 (5.1.2.3)", "CISA (MS.AAD.6.1v1)", "SMB1001 (2.8)"],

--- a/backend/Modules/CIPPCore/Public/Baselines/Get-CIPPBaselineExternalComplianceTrustedState.ps1
+++ b/backend/Modules/CIPPCore/Public/Baselines/Get-CIPPBaselineExternalComplianceTrustedState.ps1
@@ -1,0 +1,26 @@
+function Get-CIPPBaselineExternalComplianceTrustedState {
+    <#
+    .SYNOPSIS
+        Prepare hook for ExternalComplianceTrusted: does the tenant trust device compliance from external tenants.
+    .DESCRIPTION
+        One graded boolean, read from the default cross-tenant access policy's inboundTrust.
+        A hook rather than a declarative expected because the operator's switch has to grade
+        in BOTH directions - trusting external device compliance and deliberately not trusting it
+        are both valid postures.
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        $Item,
+        $TenantFilter
+    )
+
+    $Policy = @(Get-CIPPBaselineCacheRows -TenantFilter $TenantFilter -Type 'CrossTenantAccessPolicy') | Select-Object -First 1
+    if (-not $Policy) { return @{ Current = $null } }
+
+    @{
+        Expected = [PSCustomObject]@{ isCompliantDeviceAccepted = [bool]($Item.Variables.state -eq $true) }
+        Current  = [PSCustomObject]@{ isCompliantDeviceAccepted = [bool]$Policy.inboundTrust.isCompliantDeviceAccepted }
+    }
+}

--- a/backend/Modules/CIPPCore/Public/Baselines/Invoke-CIPPBaselineExternalComplianceTrusted.ps1
+++ b/backend/Modules/CIPPCore/Public/Baselines/Invoke-CIPPBaselineExternalComplianceTrusted.ps1
@@ -1,0 +1,27 @@
+function Invoke-CIPPBaselineExternalComplianceTrusted {
+    <#
+    .SYNOPSIS
+        ExternalComplianceTrusted executor: sets inbound device compliance trust on the default
+        cross-tenant access policy.
+    .DESCRIPTION
+        Reads the policy LIVE and patches the merged inboundTrust object, never the single
+        flag: Graph replaces the whole complex value on PATCH, so a bare
+        isCompliantDeviceAccepted body would silently reset the MFA and hybrid-join trust flags.
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        $Remediate,
+        $TenantFilter,
+        $Current
+    )
+
+    $Policy = New-GraphGetRequest -uri 'https://graph.microsoft.com/v1.0/policies/crossTenantAccessPolicy/default?$select=inboundTrust' -tenantid $TenantFilter
+    if (-not $Policy.inboundTrust) { throw 'Could not read the default cross-tenant access policy - refusing a blind write.' }
+
+    $Policy.inboundTrust.isCompliantDeviceAccepted = [bool]($Remediate.trusted -eq $true -or "$($Remediate.trusted)" -eq 'True')
+    $Body = ConvertTo-Json -Compress -Depth 10 -InputObject ([PSCustomObject]@{ inboundTrust = $Policy.inboundTrust })
+    $null = New-GraphPostRequest -tenantid $TenantFilter -uri 'https://graph.microsoft.com/v1.0/policies/crossTenantAccessPolicy/default' -type PATCH -body $Body
+    Write-LogMessage -API 'Baselines' -tenant $TenantFilter -message "Set external device compliance trust to $($Policy.inboundTrust.isCompliantDeviceAccepted)." -Sev 'Info'
+}

--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExternalComplianceTrusted.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExternalComplianceTrusted.ps1
@@ -1,0 +1,97 @@
+function Invoke-CIPPStandardExternalComplianceTrusted {
+    <#
+    .FUNCTIONALITY
+        Internal
+    .COMPONENT
+        (APIName) ExternalComplianceTrusted
+    .SYNOPSIS
+        (Label) Sets the Cross-tenant access setting to trust external compliant devices
+    .DESCRIPTION
+        (Helptext) Sets the state of the Cross-tenant access setting to trust external compliant devices. This allows guest users to use a compliant device from their home tenant to access your tenant.
+        (DocsDescription) Sets the state of the Cross-tenant access setting to trust external compliant devices. This allows guest users to use a compliant device from their home tenant to access your tenant.
+    .NOTES
+        CAT
+            Entra (AAD) Standards
+        ADDEDCOMPONENT
+            {"type":"autoComplete","multiple":false,"creatable":false,"label":"Select value","name":"standards.ExternalComplianceTrusted.state","options":[{"label":"Enabled","value":"true"},{"label":"Disabled","value":"false"}]}
+        IMPACT
+            Low Impact
+        ADDEDDATE
+            2026-08-25
+        POWERSHELLEQUIVALENT
+            Update-MgBetaPolicyCrossTenantAccessPolicyDefault
+        RECOMMENDEDBY
+        REQUIREDCAPABILITIES
+            "AAD_PREMIUM"
+            "AAD_PREMIUM_P2"
+        UPDATECOMMENTBLOCK
+            Run the Tools\Update-StandardsComments.ps1 script to update this comment block
+    .LINK
+        https://docs.cipp.app/user-documentation/tenant/standards/alignment/templates/available-standards
+    #>
+
+    param($Tenant, $Settings)
+    $TestResult = Test-CIPPStandardLicense -StandardName 'ExternalComplianceTrusted' -TenantFilter $Tenant -Preset Entra
+
+    if ($TestResult -eq $false) {
+        return $true
+    } #we're done.
+
+    try {
+        $ExternalComplianceTrusted = (New-GraphGetRequest -uri 'https://graph.microsoft.com/v1.0/policies/crossTenantAccessPolicy/default?$select=inboundTrust' -tenantid $Tenant)
+    } catch {
+        $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+        Write-LogMessage -API 'Standards' -Tenant $Tenant -Message "Could not get the ExternalComplianceTrusted state for $Tenant. Error: $ErrorMessage" -Sev Error
+        return
+    }
+
+    # Get state value using null-coalescing operator
+    $state = $Settings.state.value ?? $Settings.state
+    $WantedState = if ($state -eq 'true') { $true } else { $false }
+    $StateMessage = if ($WantedState) { 'enabled' } else { 'disabled' }
+
+    # Input validation
+    if (([string]::IsNullOrWhiteSpace($state) -or $state -eq 'Select a value') -and ($Settings.remediate -eq $true -or $Settings.alert -eq $true)) {
+        Write-LogMessage -API 'Standards' -tenant $Tenant -message 'ExternalComplianceTrusted: Invalid state parameter set' -sev Error
+        return
+    }
+
+    if ($Settings.remediate -eq $true) {
+        if ($ExternalComplianceTrusted.inboundTrust.isCompliantDeviceAccepted -eq $WantedState ) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "External Compliance Trusted is already $StateMessage." -sev Info
+        } else {
+            try {
+                $NewBody = $ExternalComplianceTrusted
+                $NewBody.inboundTrust.isCompliantDeviceAccepted = $WantedState
+                $NewBody = ConvertTo-Json -Depth 10 -InputObject $NewBody -Compress
+                $null = New-GraphPostRequest -tenantid $Tenant -Uri 'https://graph.microsoft.com/v1.0/policies/crossTenantAccessPolicy/default' -Type patch -Body $NewBody -ContentType 'application/json'
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Set External Compliance Trusted to $StateMessage." -sev Info
+            } catch {
+                $ErrorMessage = Get-NormalizedError -Message $_.Exception.Message
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Failed to set External Compliance Trusted to $StateMessage. Error: $ErrorMessage" -sev Error
+            }
+        }
+    }
+
+    if ($Settings.report -eq $true) {
+        $CurrentValue = @{
+            isCompliantDeviceAccepted = $ExternalComplianceTrusted.inboundTrust.isCompliantDeviceAccepted
+        }
+        $ExpectedValue = @{
+            isCompliantDeviceAccepted = $WantedState
+        }
+
+        Set-CIPPStandardsCompareField -FieldName 'standards.ExternalComplianceTrusted' -CurrentValue $CurrentValue -ExpectedValue $ExpectedValue -TenantFilter $Tenant
+        Add-CIPPBPAField -FieldName 'ExternalComplianceTrusted' -FieldValue $ExternalComplianceTrusted.inboundTrust.isCompliantDeviceAccepted -StoreAs bool -Tenant $Tenant
+    }
+
+    if ($Settings.alert -eq $true) {
+
+        if ($ExternalComplianceTrusted.inboundTrust.isCompliantDeviceAccepted -eq $WantedState) {
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "External Compliance Trusted is $StateMessage." -sev Info
+        } else {
+            Write-StandardsAlert -message "External Compliance Trusted is not $StateMessage" -object $ExternalComplianceTrusted.inboundTrust -tenant $Tenant -standardName 'ExternalComplianceTrusted' -standardId $Settings.standardId
+            Write-LogMessage -API 'Standards' -tenant $Tenant -message "External Compliance Trusted is not $StateMessage." -sev Info
+        }
+    }
+}

--- a/backend/Tests/Baselines/BaselineOneOffStandards.Tests.ps1
+++ b/backend/Tests/Baselines/BaselineOneOffStandards.Tests.ps1
@@ -18,7 +18,7 @@ BeforeAll {
     . (Join-Path $script:RepoRoot 'Modules/CIPPCore/Public/Compare-CIPPIntuneObject.ps1')
     . (Join-Path $Baselines 'Get-CIPPBaselineCacheRows.ps1')
     . (Join-Path $Baselines 'Test-CIPPBaselineCacheCollected.ps1')
-    foreach ($Name in @('ExternalMFATrusted', 'IntuneDeviceRetirementDays', 'AppManagementPolicy', 'EnableAppConsentRequests', 'TeamsFederationConfiguration', 'OMEBranding')) {
+    foreach ($Name in @('ExternalMFATrusted', 'ExternalComplianceTrusted', 'IntuneDeviceRetirementDays', 'AppManagementPolicy', 'EnableAppConsentRequests', 'TeamsFederationConfiguration', 'OMEBranding')) {
         . (Join-Path $Baselines "Get-CIPPBaseline${Name}State.ps1")
         . (Join-Path $Baselines "Invoke-CIPPBaseline${Name}.ps1")
     }
@@ -54,6 +54,30 @@ Describe 'Get-CIPPBaselineExternalMFATrustedState' {
         Invoke-CIPPBaselineExternalMFATrusted -Remediate ([PSCustomObject]@{ trusted = $true }) -TenantFilter $script:Tenant -Current $null
         Should -Invoke New-GraphPostRequest -Times 1 -Exactly -ParameterFilter {
             $type -eq 'PATCH' -and $body -match '"isMfaAccepted":\s*true' -and $body -match 'isCompliantDeviceAccepted'
+        }
+    }
+}
+
+Describe 'Get-CIPPBaselineExternalComplianceTrustedState' {
+    It 'grades the compliance switch in BOTH directions' {
+        Mock New-CIPPDbRequest { @(@{ inboundTrust = @{ isCompliantDeviceAccepted = $true } } | ConvertTo-Cached) }
+        $Off = [PSCustomObject]@{ Variables = [PSCustomObject]@{ state = $false } }
+        $Prepared = Get-CIPPBaselineExternalComplianceTrustedState -Item $Off -TenantFilter $script:Tenant
+        (Get-Verdict -Expected $Prepared.Expected -Current $Prepared.Current).Count | Should -BeGreaterThan 0
+        $On = [PSCustomObject]@{ Variables = [PSCustomObject]@{ state = $true } }
+        $Prepared2 = Get-CIPPBaselineExternalComplianceTrustedState -Item $On -TenantFilter $script:Tenant
+        (Get-Verdict -Expected $Prepared2.Expected -Current $Prepared2.Current).Count | Should -Be 0
+    }
+
+    It 'patches the merged inboundTrust, never the lone flag' {
+        Mock New-GraphGetRequest { [PSCustomObject]@{ inboundTrust = [PSCustomObject]@{ isMfaAccepted = $true; isCompliantDeviceAccepted = $false; isHybridAzureADJoinedDeviceAccepted = $true } } }
+        Mock New-GraphPostRequest { }
+        Invoke-CIPPBaselineExternalComplianceTrusted -Remediate ([PSCustomObject]@{ trusted = $true }) -TenantFilter $script:Tenant -Current $null
+        Should -Invoke New-GraphPostRequest -Times 1 -Exactly -ParameterFilter {
+            $type -eq 'PATCH' -and
+            $body -match '"isCompliantDeviceAccepted":\s*true' -and
+            $body -match 'isMfaAccepted' -and
+            $body -match 'isHybridAzureADJoinedDeviceAccepted'
         }
     }
 }

--- a/backend/Tests/Standards/Invoke-CIPPStandardExternalComplianceTrusted.Tests.ps1
+++ b/backend/Tests/Standards/Invoke-CIPPStandardExternalComplianceTrusted.Tests.ps1
@@ -1,0 +1,62 @@
+# Pester tests for Invoke-CIPPStandardExternalComplianceTrusted.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $StandardPath = Join-Path $RepoRoot 'Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardExternalComplianceTrusted.ps1'
+
+    function Test-CIPPStandardLicense { [CmdletBinding()] param($StandardName, $TenantFilter, $Preset, [switch]$SkipLog) }
+    function New-GraphGetRequest { [CmdletBinding()] param($uri, $tenantid, $AsApp) }
+    function New-GraphPostRequest { [CmdletBinding()] param($tenantid, $uri, $type, $body, $AsApp, $ContentType) }
+    function Write-LogMessage { [CmdletBinding()] param($API, $tenant, $message, $sev, $LogData) }
+    function Write-StandardsAlert { [CmdletBinding()] param($message, $object, $tenant, $standardName, $standardId) }
+    function Set-CIPPStandardsCompareField { [CmdletBinding()] param($FieldName, $CurrentValue, $ExpectedValue, $TenantFilter) }
+    function Add-CIPPBPAField { [CmdletBinding()] param($FieldName, $FieldValue, $StoreAs, $Tenant) }
+    function Get-NormalizedError { [CmdletBinding()] param($Message) $Message }
+
+    . $StandardPath
+    $script:Tenant = 'contoso.onmicrosoft.com'
+}
+
+Describe 'Invoke-CIPPStandardExternalComplianceTrusted' {
+    BeforeEach {
+        Mock Test-CIPPStandardLicense { $true }
+        Mock New-GraphGetRequest {
+            [PSCustomObject]@{
+                inboundTrust = [PSCustomObject]@{
+                    isMfaAccepted = $false
+                    isCompliantDeviceAccepted = $false
+                    isHybridAzureADJoinedDeviceAccepted = $true
+                }
+            }
+        }
+        Mock New-GraphPostRequest { }
+        Mock Write-LogMessage { }
+        Mock Write-StandardsAlert { }
+        Mock Set-CIPPStandardsCompareField { }
+        Mock Add-CIPPBPAField { }
+    }
+
+    It 'remediates compliant-device trust without resetting sibling trust flags' {
+        Invoke-CIPPStandardExternalComplianceTrusted -Tenant $script:Tenant -Settings @{ remediate = $true; state = 'true' }
+
+        Should -Invoke New-GraphPostRequest -Times 1 -Exactly -ParameterFilter {
+            $type -eq 'patch' -and
+            ($body | ConvertFrom-Json).inboundTrust.isCompliantDeviceAccepted -eq $true -and
+            ($body | ConvertFrom-Json).inboundTrust.isMfaAccepted -eq $false -and
+            ($body | ConvertFrom-Json).inboundTrust.isHybridAzureADJoinedDeviceAccepted -eq $true
+        }
+    }
+
+    It 'reports the compliant-device property as the comparison field' {
+        Invoke-CIPPStandardExternalComplianceTrusted -Tenant $script:Tenant -Settings @{ report = $true; state = 'true' }
+
+        Should -Invoke Set-CIPPStandardsCompareField -Times 1 -Exactly -ParameterFilter {
+            $FieldName -eq 'standards.ExternalComplianceTrusted' -and
+            $CurrentValue.isCompliantDeviceAccepted -eq $false -and
+            $ExpectedValue.isCompliantDeviceAccepted -eq $true
+        }
+        Should -Invoke Add-CIPPBPAField -Times 1 -Exactly -ParameterFilter {
+            $FieldName -eq 'ExternalComplianceTrusted' -and $FieldValue -eq $false
+        }
+    }
+}

--- a/frontend/src/data/standards.json
+++ b/frontend/src/data/standards.json
@@ -1354,6 +1354,32 @@
     "recommendedBy": []
   },
   {
+    "name": "standards.ExternalComplianceTrusted",
+    "cat": "Entra (AAD) Standards",
+    "tag": [],
+    "helpText": "Sets the state of the Cross-tenant access setting to trust external compliant devices. This allows guest users to use a compliant device from their home tenant to access your tenant.",
+    "executiveText": "Allows external partners and vendors to use compliant devices from their own organization when accessing company resources, streamlining collaboration while maintaining security standards. This reduces friction for external users while ensuring their devices still meet compliance requirements.",
+    "addedComponent": [
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "label": "Select value",
+        "name": "standards.ExternalComplianceTrusted.state",
+        "options": [
+          { "label": "Enabled", "value": "true" },
+          { "label": "Disabled", "value": "false" }
+        ]
+      }
+    ],
+    "label": "Sets the Cross-tenant access setting to trust external compliant devices",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "addedDate": "2026-08-25",
+    "powershellEquivalent": "Update-MgBetaPolicyCrossTenantAccessPolicyDefault",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.DisableTenantCreation",
     "cat": "Entra (AAD) Standards",
     "tag": ["CIS M365 7.0.0 (5.1.2.3)", "CISA (MS.AAD.6.1v1)", "SMB1001 (2.8)"],


### PR DESCRIPTION
## Summary
- Add the `ExternalComplianceTrusted` standard for `inboundTrust.isCompliantDeviceAccepted`.
- Support both legacy standards and baseline definitions, preserving sibling inbound trust flags during remediation.
- Add focused Pester coverage and synchronize frontend/backend standards catalogs.

## Testing

- Focused baseline tests: 28 passed.
- New legacy standard tests: 2 passed.
- Baseline catalog tests: 16 passed.
- Full backend Pester suite: 2,338 passed; 1 unrelated pre-existing failure in `BaselineOddballs.Tests.ps1`.
- Local browser E2E:
  - Loaded `ListBaselineStandards`.
  - Found and added `ExternalComplianceTrusted`.
  - Expanded settings and toggled compliance trust both directions.
  - Required API calls returned `200`; no page errors occurred.
- Live Graph/Entra writes were not performed. The remediation `PATCH` payload and sibling trust-field preservation are covered by unit tests.