### PR TITLE
feat(halo): add psaTicketId field to wizards/api

### DIFF
--- a/backend/Config/openapi.json
+++ b/backend/Config/openapi.json
@@ -6964,6 +6964,9 @@
                   "PrimDomain": {
                     "$ref": "#/components/schemas/LabelValue"
                   },
+                  "PsaTicketId": {
+                    "type": "string"
+                  },
                   "reference": {
                     "type": "string"
                   },
@@ -27253,6 +27256,9 @@
                       }
                     }
                   },
+                  "PsaTicketId": {
+                    "type": "string"
+                  },
                   "reference": {
                     "type": "string"
                   },
@@ -44589,6 +44595,10 @@
                         "type": "string",
                         "x-cipp-field-source": "storage"
                       },
+                      "PsaTicketId": {
+                        "type": "string",
+                        "x-cipp-field-source": "storage"
+                      },
                       "PsaTicketStrategy": {
                         "type": "string",
                         "x-cipp-field-source": "storage"
@@ -50077,6 +50087,12 @@
                       "PartitionKey": {
                         "x-cipp-field-source": "storage"
                       },
+                      "PsaTicketId": {
+                        "x-cipp-field-source": "storage"
+                      },
+                      "Reference": {
+                        "x-cipp-field-source": "storage"
+                      },
                       "RowKey": {
                         "x-cipp-field-source": "storage"
                       },
@@ -52288,6 +52304,10 @@
                         "x-cipp-field-source": "storage"
                       },
                       "PostExecution": {
+                        "type": "string",
+                        "x-cipp-field-source": "storage"
+                      },
+                      "PsaTicketId": {
                         "type": "string",
                         "x-cipp-field-source": "storage"
                       },
@@ -59472,6 +59492,12 @@
                       "PartitionKey": {
                         "x-cipp-field-source": "storage"
                       },
+                      "PsaTicketId": {
+                        "x-cipp-field-source": "storage"
+                      },
+                      "Reference": {
+                        "x-cipp-field-source": "storage"
+                      },
                       "RowKey": {
                         "x-cipp-field-source": "storage"
                       },
@@ -63529,6 +63555,12 @@
                       "x-cipp-field-source": "storage"
                     },
                     "PartitionKey": {
+                      "x-cipp-field-source": "storage"
+                    },
+                    "PsaTicketId": {
+                      "x-cipp-field-source": "storage"
+                    },
+                    "Reference": {
                       "x-cipp-field-source": "storage"
                     },
                     "Results": {

--- a/backend/Modules/CIPPCore/Public/Add-CIPPScheduledTask.ps1
+++ b/backend/Modules/CIPPCore/Public/Add-CIPPScheduledTask.ps1
@@ -243,6 +243,7 @@ function Add-CIPPScheduledTask {
                 AlertComment         = [string]$task.AlertComment
                 CustomSubject        = [string]$task.CustomSubject
                 PsaTicketStrategy    = [string]($task.PsaTicketStrategy.value ?? $task.PsaTicketStrategy)
+                PsaTicketId          = [string]($task.PsaTicketId.value ?? $task.PsaTicketId)
             }
 
 

--- a/backend/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
+++ b/backend/Modules/CIPPCore/Public/Send-CIPPAlert.ps1
@@ -17,6 +17,8 @@ function Send-CIPPAlert {
         $RowKey = [string][guid]::NewGuid(),
         $Attachments,
         $AffectedUser,
+        $PSAReference,
+        $PSATicketId,
         [switch]$UseStandardizedSchema
     )
     Write-Information 'Shipping Alert'
@@ -357,6 +359,15 @@ function Send-CIPPAlert {
                     TenantId   = $TenantFilter
                     AlertText  = "$HTMLContent"
                     AlertTitle = "$PsaTitle"
+                }
+                if ($PSAReference) {
+                    # Passed through verbatim - what a reference means is the PSA extension's call.
+                    $Alert.Reference = $PSAReference
+                    Write-Information "PSA alert reference: $PSAReference"
+                }
+                if ($PSATicketId) {
+                    $Alert.PsaTicketId = $PSATicketId
+                    Write-Information "PSA alert target ticket: $PSATicketId"
                 }
                 if ($AffectedUser) {
                     $Alert.AffectedUser = $AffectedUser

--- a/backend/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
+++ b/backend/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
@@ -215,6 +215,13 @@ function Send-CIPPScheduledTaskAlert {
             '*psa*' {
                 $PsaSplitSent = $false
                 $TaskAffectedUser = $null
+                # A task can name the ticket the work came from, either explicitly (PsaTicketId, set
+                # from the ticket box on the wizards) or inside its free-text reference. Both travel
+                # with the alert so a PSA that recognises them can add the result to that ticket
+                # rather than opening a new one; the extension decides which wins. Every PSA call
+                # below carries them, so a split task's per-user notes land on the same ticket.
+                $PsaReference = $TaskInfo.Reference
+                $PsaTicketId = $TaskInfo.PsaTicketId
                 try {
                     $ExtConfigTable = Get-CIPPTable -TableName Extensionsconfig
                     $ExtConfig = (Get-CIPPAzDataTableEntity @ExtConfigTable).config | ConvertFrom-Json -ErrorAction SilentlyContinue
@@ -302,7 +309,7 @@ function Send-CIPPScheduledTaskAlert {
                                     if ([string]::IsNullOrWhiteSpace($GroupKey)) {
                                         # Rows without a usable user identifier - fall back to the
                                         # task-level affected user if one was resolved.
-                                        $GroupParams = @{ Type = 'psa'; Title = $title; HTMLContent = $GroupHTML; TenantFilter = $TenantFilter }
+                                        $GroupParams = @{ Type = 'psa'; Title = $title; HTMLContent = $GroupHTML; TenantFilter = $TenantFilter; PSAReference = $PsaReference; PSATicketId = $PsaTicketId }
                                         if ($TaskAffectedUser) { $GroupParams.AffectedUser = $TaskAffectedUser }
                                         Send-CIPPAlert @GroupParams
                                     } else {
@@ -313,7 +320,7 @@ function Send-CIPPScheduledTaskAlert {
                                             UPN         = $GroupKey
                                             DisplayName = $GroupDisplayName
                                         }
-                                        Send-CIPPAlert -Type 'psa' -Title $UserTitle -HTMLContent $GroupHTML -TenantFilter $TenantFilter -AffectedUser $AffectedUser
+                                        Send-CIPPAlert -Type 'psa' -Title $UserTitle -HTMLContent $GroupHTML -TenantFilter $TenantFilter -AffectedUser $AffectedUser -PSAReference $PsaReference -PSATicketId $PsaTicketId
                                     }
                                 }
                                 $PsaSplitSent = $true
@@ -325,12 +332,16 @@ function Send-CIPPScheduledTaskAlert {
                 }
 
                 if (-not $PsaSplitSent) {
-                    $PsaParams = @{ Type = 'psa'; Title = $title; HTMLContent = (ConvertTo-PSAHtml -Html $HTML); TenantFilter = $TenantFilter }
+                    $PsaParams = @{ Type = 'psa'; Title = $title; HTMLContent = (ConvertTo-PSAHtml -Html $HTML); TenantFilter = $TenantFilter; PSAReference = $PsaReference; PSATicketId = $PsaTicketId }
                     if ($TaskAffectedUser) { $PsaParams.AffectedUser = $TaskAffectedUser }
                     Send-CIPPAlert @PsaParams
                 }
             }
             '*email*' {
+                # Deliberately untouched by PsaTicketId: that field drives the PSA note only. What a
+                # mail-ingesting PSA threads on is whatever the operator put in Reference, which is
+                # already carried into the title above - stamping a ticket token onto every subject
+                # would push CIPP's own convention onto recipients who never asked for it.
                 $EmailParams = @{
                     Type         = 'email'
                     Title        = $title

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUser.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-AddUser.ps1
@@ -39,6 +39,7 @@ function Invoke-AddUser {
                 Parameters    = [pscustomobject]@{ UserObj = $UserObj }
                 ScheduledTime = $UserObj.Scheduled.date
                 Reference     = $UserObj.reference ?? $null
+                PsaTicketId   = $UserObj.PsaTicketId ?? $null
                 PostExecution = @{
                     Webhook = [bool]$Request.Body.PostExecution.Webhook
                     Email   = [bool]$Request.Body.PostExecution.Email

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecOffboardUser.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecOffboardUser.ps1
@@ -42,6 +42,7 @@ function Invoke-ExecOffboardUser {
                     PSA     = [bool]$Request.Body.PostExecution.psa
                 }
                 Reference     = $Request.Body.reference
+                PsaTicketId   = $Request.Body.PsaTicketId
             }
             $Params = @{
                 Task    = $taskObject

--- a/backend/Modules/CippExtensions/Public/Halo/New-HaloPSATicket.ps1
+++ b/backend/Modules/CippExtensions/Public/Halo/New-HaloPSATicket.ps1
@@ -6,7 +6,8 @@ function New-HaloPSATicket {
     $client,
     [string]$UserUPN,
     [string]$AzureOID,
-    [string]$DisplayName
+    [string]$DisplayName,
+    [int]$TicketId
   )
   #Get HaloPSA Token based on the config we have.
   $Table = Get-CIPPTable -TableName Extensionsconfig
@@ -16,8 +17,12 @@ function New-HaloPSATicket {
 
   # Resolve affected user to a HaloPSA contact when the integration is configured for it.
   # Unmatched users fall through to userlookup.id = -1 (the client's General User contact).
+  # An explicit TicketId means the caller already knows which ticket the work belongs to, so there
+  # is nothing to resolve - the target ticket carries its own user. This is the case that matters
+  # for onboarding: a user created seconds ago is never a HaloPSA contact yet, so matching would
+  # always miss and stamp the ticket with the General User fallback.
   $MatchedUser = $null
-  $UserLinkActive = $Configuration.LinkTicketsToUsers -and ($UserUPN -or $AzureOID)
+  $UserLinkActive = $TicketId -le 0 -and $Configuration.LinkTicketsToUsers -and ($UserUPN -or $AzureOID)
   if ($UserLinkActive) {
     $MatchedUser = Get-HaloUser -AzureOID $AzureOID -Email $UserUPN -ClientId $client -Configuration $Configuration -Token $token
     if (-not $MatchedUser) {
@@ -37,67 +42,85 @@ function New-HaloPSATicket {
   # from the General User (id = -1).
   $SiteId = if ($MatchedUser) { $MatchedUser.site_id } else { $null }
 
-  if ($Configuration.ConsolidateTickets) {
+  # A caller-supplied TicketId targets a ticket CIPP did not open - a scheduled task carrying a PSA
+  # reference back to the request it came from - so it bypasses the consolidation table entirely.
+  # Otherwise fall back to the ticket CIPP opened for this title, when consolidation is enabled.
+  $TargetTicketId = $null
+  if ($TicketId -gt 0) {
+    $TargetTicketId = $TicketId
+    Write-Information "Targeting caller-supplied HaloPSA ticket: $TargetTicketId"
+  } elseif ($Configuration.ConsolidateTickets) {
     $ExistingTicket = Get-CIPPAzDataTableEntity @TicketTable -Filter "PartitionKey eq 'HaloPSA' and RowKey eq '$($client)-$($TitleHash)'"
     if ($ExistingTicket) {
       Write-Information "Ticket already exists in HaloPSA: $($ExistingTicket.TicketID)"
+      $TargetTicketId = $ExistingTicket.TicketID
+    }
+  }
 
-      $Ticket = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/Tickets/$($ExistingTicket.TicketID)?includedetails=true&includelastaction=false&nocache=undefined&includeusersassets=false&isdetailscreen=true" -ContentType 'application/json; charset=utf-8' -Method Get -Headers @{Authorization = "Bearer $($token.access_token)" } -SkipHttpErrorCheck
-      if ($Ticket.id) {
-        if (!$Ticket.hasbeenclosed) {
-          Write-Information 'Ticket is still open, adding new note'
-          # Halo won't take a note without an outcome - it answers "An Outcome must be entered
-          # for this Action" - so fall back to 7, the built-in Internal Note outcome, when the
-          # integration hasn't been given one. The failure this used to hit was the API user not
-          # having rights to the action, which is caught below and falls back to a new ticket so
-          # the alert still lands somewhere.
-          $Outcome = if ($Configuration.Outcome) {
-            $Configuration.Outcome.value ?? $Configuration.Outcome
+  if ($TargetTicketId) {
+    $Ticket = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/Tickets/$($TargetTicketId)?includedetails=true&includelastaction=false&nocache=undefined&includeusersassets=false&isdetailscreen=true" -ContentType 'application/json; charset=utf-8' -Method Get -Headers @{Authorization = "Bearer $($token.access_token)" } -SkipHttpErrorCheck
+    if ($Ticket.id) {
+      if (!$Ticket.hasbeenclosed) {
+        Write-Information 'Ticket is still open, adding new note'
+        # Halo won't take a note without an outcome - it answers "An Outcome must be entered
+        # for this Action" - so fall back to 7, the built-in Internal Note outcome, when the
+        # integration hasn't been given one. The failure this used to hit was the API user not
+        # having rights to the action, which is caught below and falls back to a new ticket so
+        # the alert still lands somewhere.
+        $Outcome = if ($Configuration.Outcome) {
+          $Configuration.Outcome.value ?? $Configuration.Outcome
+        } else {
+          7
+        }
+        $Object = [PSCustomObject]@{
+          ticket_id      = $TargetTicketId
+          outcome_id     = $Outcome
+          hiddenfromuser = $true
+          note_html      = $description
+        }
+
+        $body = ConvertTo-Json -Compress -Depth 10 -InputObject @($Object)
+        $NoteAdded = $false
+        try {
+          if ($PSCmdlet.ShouldProcess('Add note to HaloPSA ticket', 'Add note')) {
+            $Action = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/actions" -ContentType 'application/json; charset=utf-8' -Method Post -Body $body -Headers @{Authorization = "Bearer $($token.access_token)" }
+            Write-Information "Note added to ticket in HaloPSA: $TargetTicketId"
+            $NoteAdded = $true
+          }
+        }
+        catch {
+          $Message = if ($_.ErrorDetails.Message) {
+            Get-NormalizedError -Message $_.ErrorDetails.Message
+          }
+          else {
+            $_.Exception.message
+          }
+          # Don't return here - if appending a note failed (e.g. permissions on the action,
+          # invalid outcome_id) we still want to create a fresh ticket so the alert isn't lost.
+          $OutcomeHint = if ($Configuration.Outcome) {
+            "Outcome $Outcome is set for this integration - check the HaloPSA API user can run that action."
           } else {
-            7
+            "No Outcome is configured, so the built-in Internal Note action ($Outcome) was used. If it has been removed or the API user cannot run it, pick a different Outcome on the HaloPSA integration page."
           }
-          $Object = [PSCustomObject]@{
-            ticket_id      = $ExistingTicket.TicketID
-            outcome_id     = $Outcome
-            hiddenfromuser = $true
-            note_html      = $description
-          }
+          Write-LogMessage -message "Failed to add note to HaloPSA ticket $($TargetTicketId): $Message - falling back to creating a new ticket. $OutcomeHint" -API 'HaloPSATicket' -sev Warning -LogData (Get-CippException -Exception $_)
+          Write-Information "Failed to add note to HaloPSA ticket: $Message; creating a new ticket instead"
+          Write-Information "Body we tried to ship: $body"
+        }
 
-          $body = ConvertTo-Json -Compress -Depth 10 -InputObject @($Object)
-          $NoteAdded = $false
-          try {
-            if ($PSCmdlet.ShouldProcess('Add note to HaloPSA ticket', 'Add note')) {
-              $Action = Invoke-RestMethod -Uri "$($Configuration.ResourceURL)/actions" -ContentType 'application/json; charset=utf-8' -Method Post -Body $body -Headers @{Authorization = "Bearer $($token.access_token)" }
-              Write-Information "Note added to ticket in HaloPSA: $($ExistingTicket.TicketID)"
-              $NoteAdded = $true
-            }
-          }
-          catch {
-            $Message = if ($_.ErrorDetails.Message) {
-              Get-NormalizedError -Message $_.ErrorDetails.Message
-            }
-            else {
-              $_.Exception.message
-            }
-            # Don't return here - if appending a note failed (e.g. permissions on the action,
-            # invalid outcome_id) we still want to create a fresh ticket so the alert isn't lost.
-            $OutcomeHint = if ($Configuration.Outcome) {
-              "Outcome $Outcome is set for this integration - check the HaloPSA API user can run that action."
-            } else {
-              "No Outcome is configured, so the built-in Internal Note action ($Outcome) was used. If it has been removed or the API user cannot run it, pick a different Outcome on the HaloPSA integration page."
-            }
-            Write-LogMessage -message "Failed to add note to HaloPSA ticket $($ExistingTicket.TicketID): $Message - falling back to creating a new ticket. $OutcomeHint" -API 'HaloPSATicket' -sev Warning -LogData (Get-CippException -Exception $_)
-            Write-Information "Failed to add note to HaloPSA ticket: $Message; creating a new ticket instead"
-            Write-Information "Body we tried to ship: $body"
-          }
-
-          if ($NoteAdded) {
-            return "Note added to ticket in HaloPSA: $($ExistingTicket.TicketID)"
-          }
+        if ($NoteAdded) {
+          return "Note added to ticket in HaloPSA: $TargetTicketId"
         }
       }
       else {
-        Write-Information 'Existing ticket could not be found. Creating a new ticket instead.'
+        # Falling through to a new ticket keeps the result from being lost, but silently doing so
+        # reads as CIPP ignoring the reference, so say which ticket was skipped and why.
+        Write-LogMessage -message "HaloPSA ticket $TargetTicketId is closed - the update was raised as a new ticket instead." -API 'HaloPSATicket' -sev Warning
+      }
+    }
+    else {
+      Write-Information 'Existing ticket could not be found. Creating a new ticket instead.'
+      if ($TicketId -gt 0) {
+        Write-LogMessage -message "HaloPSA ticket $TargetTicketId could not be found - the update was raised as a new ticket instead. Check the reference on the scheduled task." -API 'HaloPSATicket' -sev Warning
       }
     }
   }

--- a/backend/Modules/CippExtensions/Public/New-CippExtAlert.ps1
+++ b/backend/Modules/CippExtensions/Public/New-CippExtAlert.ps1
@@ -27,7 +27,52 @@ function New-CippExtAlert {
                         Client      = $MappedId
                     }
 
-                    if ($Alert.AffectedUser -and $Configuration.HaloPSA.LinkTicketsToUsers) {
+                    # A task can name the ticket the work came from, so the PSA copy lands as a note
+                    # on that ticket instead of opening a second one. Two sources, in order:
+                    #
+                    #   PsaTicketId  - the ticket box on the user/offboarding/scheduler forms, shown
+                    #                  only when this integration is enabled. Unambiguous, so it wins.
+                    #   Reference    - free text, and only an [ID:nnnn] token in it counts. That is
+                    #                  HaloPSA's own subject token, which is also what makes the
+                    #                  emailed copy thread onto the same ticket. A bare number is
+                    #                  deliberately NOT accepted: the reference legitimately holds
+                    #                  order numbers, asset tags and change ids, and treating one as
+                    #                  a ticket id would append a starter's password to an unrelated
+                    #                  ticket.
+                    #
+                    # Reading both is this extension's job: the formats are Halo's, and the scheduler
+                    # passes the values through untouched.
+                    $ReferencedTicketId = 0
+                    $TicketCandidate = if ($Alert.PsaTicketId) {
+                        "$($Alert.PsaTicketId)".Trim()
+                    } elseif ("$($Alert.Reference)" -match '\[ID:(\d+)\]') {
+                        $Matches[1]
+                    } else {
+                        $null
+                    }
+                    if ($TicketCandidate) {
+                        # TryParse rather than a cast: a long run of digits is a valid match but an
+                        # invalid ticket id, and an overflow here would cost the alert entirely.
+                        $ParsedTicketId = 0
+                        if ([int]::TryParse($TicketCandidate, [ref]$ParsedTicketId) -and $ParsedTicketId -gt 0) {
+                            $ReferencedTicketId = $ParsedTicketId
+                            $TicketParams.TicketId = $ReferencedTicketId
+                            Write-Information "Alert targets HaloPSA ticket $ReferencedTicketId - adding a note to it instead of creating a ticket"
+                            # Setting both and disagreeing is easy to do by accident, and the effect is
+                            # confusing: the reference is what the notification title shows, so the note
+                            # lands on a ticket the title never mentions and it looks like nothing
+                            # happened. Say where it actually went.
+                            if ($Alert.PsaTicketId -and "$($Alert.Reference)" -match '\[ID:(\d+)\]' -and $Matches[1] -ne "$ReferencedTicketId") {
+                                Write-LogMessage -API 'HaloPSATicket' -tenant $Alert.TenantId -message "Task targets HaloPSA ticket $ReferencedTicketId from its ticket field, but its reference names ticket $($Matches[1]). The note was added to $ReferencedTicketId." -sev Warning
+                            }
+                        } else {
+                            Write-LogMessage -API 'HaloPSATicket' -tenant $Alert.TenantId -message "'$TicketCandidate' is not a usable HaloPSA ticket id - raising a new ticket instead." -sev Warning
+                        }
+                    }
+
+                    # A referenced ticket already carries its own end user, so skip the contact lookup
+                    # (and the Graph call under it) entirely.
+                    if ($ReferencedTicketId -le 0 -and $Alert.AffectedUser -and $Configuration.HaloPSA.LinkTicketsToUsers) {
                         $UPN = $Alert.AffectedUser.UPN
                         $OID = $Alert.AffectedUser.AzureOID
                         $Display = $Alert.AffectedUser.DisplayName

--- a/backend/Tests/Alerts/Send-CIPPScheduledTaskAlert.Tests.ps1
+++ b/backend/Tests/Alerts/Send-CIPPScheduledTaskAlert.Tests.ps1
@@ -70,12 +70,14 @@ Describe 'Send-CIPPScheduledTaskAlert - PSA snooze links' {
         }
 
         Mock -CommandName Send-CIPPAlert -MockWith {
-            param($Type, $Title, $HTMLContent, $JSONContent, $TenantFilter, $AffectedUser)
+            param($Type, $Title, $HTMLContent, $JSONContent, $TenantFilter, $AffectedUser, $PSAReference, $PSATicketId)
             $script:SentAlerts.Add([pscustomobject]@{
                     Type         = $Type
                     Title        = $Title
                     HTMLContent  = $HTMLContent
                     AffectedUser = $AffectedUser
+                    PSAReference = $PSAReference
+                    PSATicketId  = $PSATicketId
                 })
         }
     }
@@ -149,6 +151,66 @@ Describe 'Send-CIPPScheduledTaskAlert - PSA snooze links' {
 
             $script:SentAlerts.Count | Should -Be 1
             $script:SentAlerts[0].HTMLContent | Should -Match 'Snooze Individual Alerts'
+        }
+    }
+
+    # The task's reference is what lets a PSA add the result to the ticket the request came from
+    # rather than opening a second one, so every PSA call has to carry it - including the per-user
+    # split, or a split task's notes would land in new tickets while the consolidated one threads.
+    Context 'when the task carries a reference' {
+        BeforeEach {
+            $script:TaskInfo | Add-Member -NotePropertyName Reference -NotePropertyValue '[ID:1380] Starter Creation' -Force
+        }
+
+        It 'passes it on the consolidated ticket' {
+            $script:LinkTicketsToUsers = $false
+
+            Send-CIPPScheduledTaskAlert -Results $script:Results -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Alert'
+
+            $script:SentAlerts.Count | Should -Be 1
+            $script:SentAlerts[0].PSAReference | Should -Be '[ID:1380] Starter Creation'
+        }
+
+        It 'passes it on every split ticket' {
+            Send-CIPPScheduledTaskAlert -Results $script:Results -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Alert'
+
+            $script:SentAlerts.Count | Should -Be 2
+            foreach ($Alert in $script:SentAlerts) {
+                $Alert.PSAReference | Should -Be '[ID:1380] Starter Creation'
+            }
+        }
+
+        It 'passes an explicit PsaTicketId alongside it' {
+            $script:TaskInfo | Add-Member -NotePropertyName PsaTicketId -NotePropertyValue '1380' -Force
+            $script:LinkTicketsToUsers = $false
+
+            Send-CIPPScheduledTaskAlert -Results $script:Results -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Alert'
+
+            $script:SentAlerts[0].PSATicketId | Should -Be '1380'
+        }
+
+        It 'keeps the ticket id out of the email subject entirely' {
+            # PsaTicketId drives the PSA note and nothing else. A mail-ingesting PSA threads on
+            # whatever the operator chose to put in Reference, so the subject must not be stamped
+            # with a ticket token nobody asked for.
+            $script:TaskInfo | Add-Member -NotePropertyName PsaTicketId -NotePropertyValue '1380' -Force
+            $script:TaskInfo | Add-Member -NotePropertyName Reference -NotePropertyValue 'Starter Creation' -Force
+            $script:TaskInfo.PostExecution = 'email'
+
+            Send-CIPPScheduledTaskAlert -Results $script:Results -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Alert'
+
+            $script:SentAlerts[0].Type | Should -Be 'email'
+            $script:SentAlerts[0].Title | Should -Not -Match '\[ID:'
+            $script:SentAlerts[0].Title | Should -BeLike '*Reference: Starter Creation*'
+        }
+
+        It 'sends nothing extra when the task has no reference' {
+            $script:TaskInfo | Add-Member -NotePropertyName Reference -NotePropertyValue $null -Force
+            $script:LinkTicketsToUsers = $false
+
+            Send-CIPPScheduledTaskAlert -Results $script:Results -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Alert'
+
+            $script:SentAlerts[0].PSAReference | Should -BeNullOrEmpty
         }
     }
 }

--- a/backend/Tests/Extensions/New-CippExtAlert.TicketReference.Tests.ps1
+++ b/backend/Tests/Extensions/New-CippExtAlert.TicketReference.Tests.ps1
@@ -1,0 +1,193 @@
+# Pester tests for the ticket reference New-CippExtAlert hands to HaloPSA.
+# A scheduled task's reference travels with the alert untouched; reading it is this extension's job
+# because [ID:nnnn] is HaloPSA's own token - the same one it uses to thread emailed replies onto a
+# ticket. When one is present the alert becomes a note on that ticket, and the affected-user lookup
+# (plus the Graph call under it) is skipped, since the ticket already carries its end user.
+
+BeforeAll {
+    $BackendRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $BackendRoot 'Modules/CippExtensions/Public/New-CippExtAlert.ps1'
+
+    function Get-CIPPTable { param([string]$TableName) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Filter, $Property, $First) }
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function New-HaloPSATicket { param($Title, $Description, $Client, $UserUPN, $AzureOID, $DisplayName, $TicketId) }
+    function New-GradientAlert { param($Title, $Description, $Client) }
+    function New-GraphGetRequest { param($uri, $tenantid, $AsApp) }
+    function Write-LogMessage { param($API, $tenant, $message, $sev, $LogData, $headers) }
+
+    . $FunctionPath
+
+    function New-Alert {
+        param($Reference, $AffectedUser, $PsaTicketId)
+        $Alert = [pscustomobject]@{
+            TenantId   = 'contoso.onmicrosoft.com'
+            AlertTitle = '[CIPP] Scheduled Task - contoso - New user creation'
+            AlertText  = '<p>body</p>'
+        }
+        if ($Reference) { $Alert | Add-Member -NotePropertyName Reference -NotePropertyValue $Reference }
+        if ($PsaTicketId) { $Alert | Add-Member -NotePropertyName PsaTicketId -NotePropertyValue $PsaTicketId }
+        if ($AffectedUser) { $Alert | Add-Member -NotePropertyName AffectedUser -NotePropertyValue $AffectedUser }
+        $Alert
+    }
+
+    $script:NewStarter = [pscustomobject]@{ UPN = 'new.starter@contoso.com'; DisplayName = 'New Starter' }
+}
+
+Describe 'New-CippExtAlert - HaloPSA ticket reference' {
+    BeforeEach {
+        $script:TicketArgs = $null
+        Mock -CommandName Get-CIPPTable -MockWith { param([string]$TableName) @{ TableName = $TableName } }
+        Mock -CommandName Get-Tenants -MockWith { [pscustomobject]@{ customerId = 'customer-guid' } }
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName New-GraphGetRequest -MockWith { [pscustomobject]@{ id = 'oid-guid'; displayName = 'New Starter' } }
+        # An explicit param block is required: a Pester mock body without one leaves
+        # $PSBoundParameters empty, which silently passes every "was not passed" assertion.
+        Mock -CommandName New-HaloPSATicket -MockWith {
+            param($Title, $Description, $Client, $UserUPN, $AzureOID, $DisplayName, $TicketId)
+            $script:TicketArgs = [pscustomobject]@{
+                Title = $Title; Client = $Client; UserUPN = $UserUPN
+                AzureOID = $AzureOID; DisplayName = $DisplayName; TicketId = $TicketId
+            }
+        }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            param($TableName, $Filter)
+            if ($Filter -like '*HaloMapping*') { return [pscustomobject]@{ RowKey = 'customer-guid'; IntegrationId = 19 } }
+            [pscustomobject]@{
+                config = (@{ HaloPSA = @{ enabled = $true; LinkTicketsToUsers = $true } } | ConvertTo-Json -Depth 5)
+            }
+        }
+    }
+
+    Context 'The task carries an explicit ticket id' {
+        It 'uses PsaTicketId when it is set' {
+            # Set from the ticket box on the user / offboarding / scheduler forms.
+            New-CippExtAlert -Alert (New-Alert -PsaTicketId 1380)
+
+            $script:TicketArgs.TicketId | Should -Be 1380
+        }
+
+        It 'accepts it as a string, which is how the task row stores it' {
+            New-CippExtAlert -Alert (New-Alert -PsaTicketId '1380')
+
+            $script:TicketArgs.TicketId | Should -Be 1380
+        }
+
+        It 'wins over an [ID:] token in the reference' {
+            New-CippExtAlert -Alert (New-Alert -PsaTicketId 1380 -Reference '[ID:99] older reference')
+
+            $script:TicketArgs.TicketId | Should -Be 1380
+        }
+
+        It 'warns when the reference names a different ticket' {
+            # The reference is what the notification title shows, so a mismatch puts the note on a
+            # ticket the title never mentions - which reads as the feature not working at all.
+            New-CippExtAlert -Alert (New-Alert -PsaTicketId 1380 -Reference '[ID:1376] Starter Creation')
+
+            $script:TicketArgs.TicketId | Should -Be 1380
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter {
+                $sev -eq 'Warning' -and $message -like '*targets HaloPSA ticket 1380*' -and $message -like '*names ticket 1376*'
+            }
+        }
+
+        It 'stays quiet when both name the same ticket' {
+            New-CippExtAlert -Alert (New-Alert -PsaTicketId 1380 -Reference '[ID:1380] Starter Creation')
+
+            $script:TicketArgs.TicketId | Should -Be 1380
+            Should -Invoke Write-LogMessage -Times 0 -Exactly
+        }
+
+        It 'skips the contact lookup like any targeted ticket' {
+            New-CippExtAlert -Alert (New-Alert -PsaTicketId 1380 -AffectedUser $script:NewStarter)
+
+            Should -Invoke New-GraphGetRequest -Times 0 -Exactly
+            $script:TicketArgs.UserUPN | Should -BeNullOrEmpty
+        }
+
+        It 'warns and raises a new ticket when the value is not a usable id' {
+            New-CippExtAlert -Alert (New-Alert -PsaTicketId 'not-a-ticket')
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $sev -eq 'Warning' -and $message -like '*not a usable HaloPSA ticket id*' }
+        }
+    }
+
+    Context 'The reference names a ticket' {
+        It 'passes the ticket id through to HaloPSA' {
+            New-CippExtAlert -Alert (New-Alert -Reference '[ID:1380] Starter Creation of FirstName LastName')
+
+            $script:TicketArgs.TicketId | Should -Be 1380
+        }
+
+        It 'finds the token wherever it sits in the reference' {
+            New-CippExtAlert -Alert (New-Alert -Reference 'Starter Creation - see [ID:42] for detail')
+
+            $script:TicketArgs.TicketId | Should -Be 42
+        }
+
+        It 'refuses a digit run too large to be a ticket id, and warns' {
+            New-CippExtAlert -Alert (New-Alert -Reference '[ID:99999999999999999999]')
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $sev -eq 'Warning' -and $message -like '*not a usable HaloPSA ticket id*' }
+        }
+
+        It 'skips the contact lookup and its Graph call' {
+            New-CippExtAlert -Alert (New-Alert -Reference '[ID:1380] Starter' -AffectedUser $script:NewStarter)
+
+            Should -Invoke New-GraphGetRequest -Times 0 -Exactly
+            $script:TicketArgs.UserUPN | Should -BeNullOrEmpty
+            $script:TicketArgs.AzureOID | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'The reference names no ticket' {
+        It 'sends no ticket id for a free-text reference' {
+            New-CippExtAlert -Alert (New-Alert -Reference 'Starter Creation of FirstName LastName')
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+        }
+
+        It 'sends no ticket id when there is no reference at all' {
+            New-CippExtAlert -Alert (New-Alert)
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+        }
+
+        It 'still resolves the affected user' {
+            New-CippExtAlert -Alert (New-Alert -AffectedUser $script:NewStarter)
+
+            Should -Invoke New-GraphGetRequest -Times 1 -Exactly
+            $script:TicketArgs.UserUPN | Should -Be 'new.starter@contoso.com'
+            $script:TicketArgs.AzureOID | Should -Be 'oid-guid'
+        }
+
+        It 'ignores a reference that merely contains digits' {
+            # 'PO 1380' or 'INV-2024-1389' are free text, not a ticket number.
+            New-CippExtAlert -Alert (New-Alert -Reference 'PO 1380')
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+        }
+
+        It 'ignores a reference with digits embedded in an identifier' {
+            New-CippExtAlert -Alert (New-Alert -Reference 'INV-2024-1389')
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+        }
+
+        It 'ignores a bare number - a reference is free text, not a ticket id' {
+            # Deliberate: order numbers, asset tags and change ids all live in this field, and
+            # treating one as a ticket id would append a starter's password to an unrelated ticket.
+            # [ID:nnnn] is required, which is also what Halo's own email threading matches on.
+            New-CippExtAlert -Alert (New-Alert -Reference '1389')
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+        }
+
+        It 'ignores a bare number with surrounding whitespace' {
+            New-CippExtAlert -Alert (New-Alert -Reference '  1389  ')
+
+            $script:TicketArgs.TicketId | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/backend/Tests/Extensions/New-HaloPSATicket.TicketTarget.Tests.ps1
+++ b/backend/Tests/Extensions/New-HaloPSATicket.TicketTarget.Tests.ps1
@@ -1,0 +1,169 @@
+# Pester tests for targeting an existing HaloPSA ticket from New-HaloPSATicket.
+# A scheduled task raised from a Halo request carries that request's ticket in its reference, so the
+# result belongs on that ticket rather than in a second one. The emailed copy already threads onto it
+# via the [ID:nnnn] token in the subject; this is the PSA side of the same behaviour. It also sidesteps
+# contact matching: an onboarding task creates the user seconds before the ticket is raised, so
+# Get-HaloUser can never match and every ticket landed on the client's General User.
+
+BeforeAll {
+    $BackendRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $BackendRoot 'Modules/CippExtensions/Public/Halo/New-HaloPSATicket.ps1'
+
+    function Get-CIPPTable { param([string]$TableName) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Filter, $Property, $First) }
+    function Add-CIPPAzDataTableEntity { param($TableName, $Entity, [switch]$Force) }
+    function Get-HaloToken { param($configuration) }
+    function Get-HaloUser { param($AzureOID, $Email, $ClientId, $Configuration, $Token) }
+    function Get-StringHash { param($String) }
+    function Get-NormalizedError { param($Message) }
+    function Get-CippException { param($Exception) }
+    function Write-LogMessage { param($API, $tenant, $message, $sev, $LogData, $headers) }
+
+    . $FunctionPath
+
+    function New-HaloConfigRow {
+        param([bool]$ConsolidateTickets = $false, [bool]$LinkTicketsToUsers = $true)
+        [pscustomobject]@{
+            config = (@{
+                    HaloPSA = @{
+                        Enabled            = $true
+                        ResourceURL        = 'https://halo.example.com/api'
+                        TicketType         = 21
+                        ConsolidateTickets = $ConsolidateTickets
+                        LinkTicketsToUsers = $LinkTicketsToUsers
+                        Outcome            = @{ label = 'CIPP Update'; value = 155 }
+                    }
+                } | ConvertTo-Json -Depth 5)
+        }
+    }
+
+    # Records every call so a test can tell an /actions note from a /Tickets create. The mock body
+    # runs in Pester's own scope, not this function's, so the switches have to travel as script-scoped
+    # variables rather than closure captures.
+    function Set-RestMock {
+        param([bool]$TicketExists = $true, [bool]$Closed = $false, [switch]$NoteFails)
+        $script:Calls = [System.Collections.Generic.List[object]]::new()
+        $script:MockTicketExists = $TicketExists
+        $script:MockClosed = $Closed
+        $script:MockNoteFails = [bool]$NoteFails
+        Mock -CommandName Invoke-RestMethod -MockWith {
+            param($Uri, $ContentType, $Method, $Body, $Headers, [switch]$SkipHttpErrorCheck)
+            $script:Calls.Add([pscustomobject]@{ Uri = $Uri; Method = $Method; Body = $Body })
+            if ($Method -eq 'Get') {
+                if (-not $script:MockTicketExists) { return @{} }
+                return @{ id = 1380; hasbeenclosed = $script:MockClosed }
+            }
+            if ($Uri -like '*/actions') {
+                if ($script:MockNoteFails) { throw 'Access denied to this action' }
+                return @{ id = 5555 }
+            }
+            @{ id = 1382 }
+        }
+    }
+
+    function Get-NoteCall { $script:Calls | Where-Object { $_.Uri -like '*/actions' } | Select-Object -First 1 }
+    function Get-CreateCall { $script:Calls | Where-Object { $_.Uri -like '*/Tickets' -and $_.Method -eq 'Post' } | Select-Object -First 1 }
+}
+
+Describe 'New-HaloPSATicket - targeting a referenced ticket' {
+    BeforeEach {
+        Mock -CommandName Get-CIPPTable -MockWith { param([string]$TableName) @{ TableName = $TableName } }
+        Mock -CommandName Get-HaloToken -MockWith { @{ access_token = 'token' } }
+        Mock -CommandName Get-StringHash -MockWith { 'hash' }
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith { }
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Get-NormalizedError -MockWith { param($Message) $Message }
+        Mock -CommandName Get-CippException -MockWith { @{} }
+        Mock -CommandName Get-HaloUser -MockWith { $null }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { New-HaloConfigRow }
+    }
+
+    Context 'The referenced ticket is open' {
+        BeforeEach { Set-RestMock }
+
+        It 'adds a note to that ticket instead of creating one' {
+            $Result = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -TicketId 1380
+
+            $Result | Should -Be 'Note added to ticket in HaloPSA: 1380'
+            Get-CreateCall | Should -BeNullOrEmpty
+            $Note = @((Get-NoteCall).Body | ConvertFrom-Json)[0]
+            $Note.ticket_id | Should -Be 1380
+            $Note.note_html | Should -Be '<p>body</p>'
+        }
+
+        It 'uses the configured outcome for the note' {
+            $null = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -TicketId 1380
+
+            $Note = @((Get-NoteCall).Body | ConvertFrom-Json)[0]
+            $Note.outcome_id | Should -Be 155
+        }
+
+        It 'does not try to match a HaloPSA contact for the affected user' {
+            # The point of the feature: the ticket already has its user, and a just-created starter
+            # would never match anyway.
+            $null = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -TicketId 1380 -UserUPN 'new.starter@contoso.com'
+
+            Should -Invoke Get-HaloUser -Times 0 -Exactly
+        }
+
+        It 'ignores the consolidation table when a ticket is named' {
+            # Consolidation is keyed on a hash of the title; an explicit ticket must win over it.
+            Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+                param($TableName, $Filter)
+                if ($Filter) { return [pscustomobject]@{ TicketID = 999 } }
+                New-HaloConfigRow -ConsolidateTickets $true
+            }
+
+            $null = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -TicketId 1380
+
+            $Note = @((Get-NoteCall).Body | ConvertFrom-Json)[0]
+            $Note.ticket_id | Should -Be 1380
+        }
+    }
+
+    Context 'The referenced ticket cannot take the note' {
+        It 'creates a new ticket and warns when the ticket is closed' {
+            Set-RestMock -Closed $true
+
+            $null = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -TicketId 1380
+
+            Get-NoteCall | Should -BeNullOrEmpty
+            Get-CreateCall | Should -Not -BeNullOrEmpty
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $sev -eq 'Warning' -and $message -like '*1380 is closed*' }
+        }
+
+        It 'creates a new ticket and warns when the ticket does not exist' {
+            Set-RestMock -TicketExists $false
+
+            $null = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -TicketId 1380
+
+            Get-CreateCall | Should -Not -BeNullOrEmpty
+            Should -Invoke Write-LogMessage -Times 1 -Exactly -ParameterFilter { $sev -eq 'Warning' -and $message -like '*could not be found*' }
+        }
+
+        It 'creates a new ticket when the note is rejected' {
+            Set-RestMock -NoteFails
+
+            $null = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -TicketId 1380
+
+            Get-CreateCall | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'No ticket is referenced' {
+        BeforeEach { Set-RestMock }
+
+        It 'creates a ticket exactly as before' {
+            $Result = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19
+
+            $Result | Should -Be 'Ticket created in HaloPSA: 1382'
+            Get-NoteCall | Should -BeNullOrEmpty
+        }
+
+        It 'still resolves the affected user' {
+            $null = New-HaloPSATicket -title 'Test alert' -description '<p>body</p>' -client 19 -UserUPN 'existing@contoso.com'
+
+            Should -Invoke Get-HaloUser -Times 1 -Exactly
+        }
+    }
+}

--- a/frontend/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/frontend/src/components/CippFormPages/CippAddEditUser.jsx
@@ -1151,6 +1151,28 @@ const CippAddEditUser = (props) => {
                 formControl={formControl}
               />
             </Grid>
+            {integrationSettings?.data?.HaloPSA?.Enabled === true && (
+              <CippFormCondition
+                formControl={formControl}
+                field="postExecution.psa"
+                compareType="is"
+                compareValue={true}
+              >
+                {/* These Grids sit inside a plain Grid item, not the form's spacing={2} container,
+                    so the gap has to be set here or the box butts against Reference. */}
+                <Grid size={{ xs: 12 }} sx={{ mt: 2 }}>
+                  <CippFormComponent
+                    type="number"
+                    fullWidth
+                    label="HaloPSA Ticket"
+                    name="PsaTicketId"
+                    placeholder="Enter the related HaloPSA Ticket ID"
+                    helperText="The results are added to the associated ticket in HaloPSA as a note instead of raising a new ticket."
+                    formControl={formControl}
+                  />
+                </Grid>
+              </CippFormCondition>
+            )}
           </CippFormCondition>
         </Grid>
       </>

--- a/frontend/src/components/CippFormPages/CippSchedulerForm.jsx
+++ b/frontend/src/components/CippFormPages/CippSchedulerForm.jsx
@@ -697,6 +697,18 @@ const CippSchedulerForm = (props) => {
               options={psaStrategyDropdownOptions}
             />
           </Grid>
+          {integrationsConfig?.data?.HaloPSA?.Enabled === true && (
+            <Grid size={{ md: 12, xs: 12 }}>
+              <CippFormComponent
+                type="number"
+                name="PsaTicketId"
+                label="HaloPSA Ticket"
+                formControl={formControl}
+                placeholder="Enter the related HaloPSA Ticket ID"
+                helperText="The results are added to the associated ticket in HaloPSA as a note instead of raising a new ticket."
+              />
+            </Grid>
+          )}
         </CippFormCondition>
 
         <Grid size={{ md: 12, xs: 12 }}>

--- a/frontend/src/components/CippWizard/CippWizardOffboarding.jsx
+++ b/frontend/src/components/CippWizard/CippWizardOffboarding.jsx
@@ -31,6 +31,14 @@ export const CippWizardOffboarding = (props) => {
   const deleteUser = useWatch({ control: formControl.control, name: 'DeleteUser' })
   const convertToShared = useWatch({ control: formControl.control, name: 'ConvertToShared' })
 
+  // The HaloPSA ticket box is only meaningful when that integration is configured.
+  const integrationSettings = ApiGetCall({
+    url: '/api/ListExtensionsConfig',
+    queryKey: 'ListExtensionsConfig',
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  })
+
   // Pull cached mailbox sizes (storageUsedInBytes, keyed by UPN) only when relevant
   const mailboxUsage = ApiGetCall({
     url: '/api/ListMailboxes',
@@ -566,6 +574,27 @@ export const CippWizardOffboarding = (props) => {
                 formControl={formControl}
               />
             </Grid>
+
+            {integrationSettings?.data?.HaloPSA?.Enabled === true && (
+              <CippFormCondition
+                formControl={formControl}
+                field="postExecution.psa"
+                compareType="is"
+                compareValue={true}
+              >
+                <Grid size={{ sm: 12, xs: 12 }}>
+                  <CippFormComponent
+                    type="number"
+                    fullWidth
+                    label="HaloPSA Ticket"
+                    name="PsaTicketId"
+                    placeholder="Enter the related HaloPSA Ticket ID"
+                    helperText="The results are added to the associated ticket in HaloPSA as a note instead of raising a new ticket."
+                    formControl={formControl}
+                  />
+                </Grid>
+              </CippFormCondition>
+            )}
           </Grid>
         </CardContent>
       </Card>

--- a/frontend/src/pages/cipp/scheduler/index.js
+++ b/frontend/src/pages/cipp/scheduler/index.js
@@ -85,6 +85,7 @@ const Page = () => {
           "Parameters",
           "PostExecution",
           "Reference",
+          "PsaTicketId",
           "Recurrence",
           "Results",
         ]}


### PR DESCRIPTION
Puts scheduled-task results on the ticket the request came from instead of opening a new one.
- A HaloPSA Ticket box on the user creation, offboarding and scheduler forms - shown only when that integration is enabled and results are going to the PSA - stored as PsaTicketId, and surfaced as a column in the scheduler table.
- When set, the result is added to that ticket as a note.
- A bare number in the reference is deliberately ignored - that field could also hold order numbers/asset tags etc.
- Contact resolution is skipped for these alerts, since an onboarding task creates the user seconds before the alert fires so Get-HaloUser could never match, and every ticket was landing on the client's General User.
- The email subject is untouched: threading stays driven by whatever you put in Reference.
- A closed, missing or note-rejecting ticket falls back to a new ticket with a warning, so a result is never lost.