### PR TITLE
fix(scheduler): poorly formatted post-execution results

### DIFF
--- a/backend/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
+++ b/backend/Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1
@@ -149,12 +149,44 @@ function Send-CIPPScheduledTaskAlert {
         $EncodedTaskName = [System.Web.HttpUtility]::HtmlEncode($TaskInfo.Name)
         $EncodedTenantName = [System.Web.HttpUtility]::HtmlEncode($TenantFilter)
         $AlertHeader = "<div style=`"margin:0 0 14px;`"><p style=`"margin:0 0 2px;font-size:15px;font-weight:600;`">$EncodedTaskName</p><p style=`"margin:0;font-size:13px;opacity:0.75;`">Tenant: <strong>$EncodedTenantName</strong></p></div>"
-        $FinalResults = if ($Results -is [array] -and $Results[0] -is [string]) {
+        # Commands that also serve an HTTP caller return a single row carrying the result lines plus
+        # the extras that caller needs - New-CIPPUserTask hands back Results alongside Username,
+        # Password, CopyFrom and the whole Graph user object. Rendered as one row that becomes a
+        # column per key, so the readable lines end up squeezed beside a flattened Graph object.
+        # Split it instead: the result lines become the table, the rest follows underneath. Nothing
+        # is dropped, and $Results itself is untouched so the webhook payload and the stored task
+        # results keep the exact shape they have always had.
+        $EnvelopeRow = $null
+        if (@($Results).Count -eq 1) {
+            $SingleRow = @($Results)[0]
+            if ($null -ne $SingleRow -and $SingleRow -isnot [string]) {
+                $RowProps = @($SingleRow.PSObject.Properties)
+                if ($RowProps.Count -gt 1 -and $RowProps.Name -contains 'Results') { $EnvelopeRow = $SingleRow }
+            }
+        }
+
+        $FinalResults = if ($EnvelopeRow) {
+            @($EnvelopeRow.Results) | ConvertTo-Html -Fragment -Property @{ l = 'Results'; e = { $_ } }
+        } elseif ($Results -is [array] -and $Results[0] -is [string]) {
             $Results | ConvertTo-Html -Fragment -Property @{ l = 'Text'; e = { $_ } }
         } else {
             $Results | ForEach-Object { ConvertTo-AlertDisplayRow -Row $_ } | ConvertTo-Html -Fragment
         }
         $HTML = $FinalResults -replace '\[\[BR\]\]', '<br />' -replace '<table>', "$AlertHeader $TableDesign<table class=adaptiveTable>" | Out-String
+
+        # Everything the envelope carried besides the result lines, as field/value rows below the
+        # table rather than as extra columns beside it.
+        if ($EnvelopeRow) {
+            $ExtraRows = foreach ($Prop in $EnvelopeRow.PSObject.Properties) {
+                if ($Prop.Name -eq 'Results') { continue }
+                [pscustomobject]@{ Field = $Prop.Name; Value = (Format-AlertCellValue -Value $Prop.Value -Depth 1) }
+            }
+            if ($ExtraRows) {
+                $ExtraHtml = @($ExtraRows) | ConvertTo-Html -Fragment
+                $ExtraHtml = $ExtraHtml -replace '\[\[BR\]\]', '<br />' -replace '<table>', '<table class=adaptiveTable>' | Out-String
+                $HTML += "<p style=`"margin:16px 0 4px;font-size:13px;font-weight:600;opacity:0.75;`">Additional detail</p>$ExtraHtml"
+            }
+        }
 
         # For alert tasks, add per-row snooze links. The resolved URL is kept in scope so the
         # per-user PSA split below can build the same block from each user's own rows.

--- a/backend/Tests/Alerts/Send-CIPPScheduledTaskAlert.ResultEnvelope.Tests.ps1
+++ b/backend/Tests/Alerts/Send-CIPPScheduledTaskAlert.ResultEnvelope.Tests.ps1
@@ -1,0 +1,162 @@
+# Pester tests for how Send-CIPPScheduledTaskAlert renders a result envelope.
+# Commands that also serve an HTTP caller return one row carrying the result lines plus the extras
+# that caller needs: New-CIPPUserTask hands back Results alongside Username, Password, CopyFrom and
+# the whole Graph user object. ConvertTo-Html turns that single row into a column per key, so the
+# readable lines ended up squeezed into one cell beside a flattened 78-property Graph object - the
+# notification email and the PSA ticket were a single unreadable row.
+#
+# The split is deliberately a rendering change only: $Results is not modified, so the webhook payload
+# and the stored task results keep the shape they have always had, and nothing is dropped from the
+# email or ticket either - the extras move below the table instead of beside it.
+
+BeforeAll {
+    Add-Type -AssemblyName System.Web -ErrorAction SilentlyContinue
+
+    $BackendRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $BackendRoot 'Modules/CIPPCore/Public/Send-CIPPScheduledTaskAlert.ps1'
+
+    function Get-CippTable { param([string]$TableName) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Filter, $Property, $First) }
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function Get-CIPPTextReplacement { param($Text, $TenantFilter, [switch]$EscapeForJson) }
+    function Send-CIPPAlert {
+        param($Type, $Title, $HTMLContent, $JSONContent, $TenantFilter, $altEmail, $altWebhook,
+            $APIName, $SchemaSource, $InvokingCommand, $Headers, $TableName, $RowKey,
+            $Attachments, $AffectedUser, [switch]$UseStandardizedSchema)
+    }
+    function Write-LogMessage { param($API, $tenant, $message, $sev, $LogData, $headers) }
+
+    . (Join-Path $BackendRoot 'Modules/CIPPCore/Public/ConvertTo-PSAHtml.ps1')
+    . (Join-Path $BackendRoot 'Modules/CIPPCore/Public/GraphHelper/Get-AlertContentHash.ps1')
+    . $FunctionPath
+
+    # The shape Push-ExecScheduledCommand hands over for a New-CIPPUserTask run: one row, because
+    # Select-Object * promotes the returned hashtable's keys to properties.
+    function New-EnvelopeResult {
+        $Lines = [System.Collections.Generic.List[string]]::new()
+        @(
+            'Created New User.'
+            'Username: starter@contoso.com'
+            'Password: https://pwpush.example/p/abc'
+            'Successfully added Starter to group Retail'
+        ) | ForEach-Object { $Lines.Add($_) }
+
+        , @([pscustomobject]@{
+                Results  = $Lines
+                Username = 'starter@contoso.com'
+                Password = 'https://pwpush.example/p/abc'
+                CopyFrom = [pscustomobject]@{ Success = @('group A'); Error = @(); Skipped = @('group B') }
+                User     = [pscustomobject]@{
+                    id                = '00000000-0000-0000-0000-000000000001'
+                    displayName       = 'New Starter'
+                    userPrincipalName = 'starter@contoso.com'
+                    businessPhones    = @('01603 888888')
+                }
+            })
+    }
+
+    function Get-TableColumns {
+        # ConvertTo-PSAHtml rewrites <th> with inline styles on the PSA path, so the header cells
+        # cannot be matched as a bare tag.
+        param([string]$Html, [int]$TableIndex = 0)
+        $Tables = [regex]::Matches($Html, '(?s)<table[^>]*>.*?</table>')
+        if ($Tables.Count -le $TableIndex) { return @() }
+        @([regex]::Matches($Tables[$TableIndex].Value, '<th[^>]*>(.*?)</th>') | ForEach-Object { $_.Groups[1].Value })
+    }
+    function Get-TableRowCount {
+        param([string]$Html, [int]$TableIndex = 0)
+        $Tables = [regex]::Matches($Html, '(?s)<table[^>]*>.*?</table>')
+        if ($Tables.Count -le $TableIndex) { return 0 }
+        ([regex]::Matches($Tables[$TableIndex].Value, '<tr>')).Count - 1
+    }
+}
+
+Describe 'Send-CIPPScheduledTaskAlert - result envelope rendering' {
+    BeforeEach {
+        $script:SentAlerts = [System.Collections.Generic.List[object]]::new()
+        $script:TaskInfo = [pscustomobject]@{
+            RowKey        = 'task-1'
+            Name          = 'New user creation: starter@contoso.com'
+            Command       = 'New-CIPPUserTask'
+            PostExecution = 'psa'
+            Parameters    = '{}'
+        }
+
+        Mock -CommandName Get-CippTable -MockWith { param([string]$TableName) @{ TableName = $TableName } }
+        Mock -CommandName Get-Tenants -MockWith { [pscustomobject]@{ customerId = 'customer-guid' } }
+        Mock -CommandName Get-CIPPTextReplacement -MockWith { param($Text, $TenantFilter) $Text }
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            param($TableName, $Filter)
+            if ($TableName -eq 'Extensionsconfig') {
+                return [pscustomobject]@{ config = (@{ HaloPSA = @{ Enabled = $false } } | ConvertTo-Json -Depth 5) }
+            }
+            $null
+        }
+        Mock -CommandName Send-CIPPAlert -MockWith {
+            param($Type, $Title, $HTMLContent)
+            $script:SentAlerts.Add([pscustomobject]@{ Type = $Type; HTMLContent = $HTMLContent })
+        }
+    }
+
+    Context 'a New-CIPPUserTask style envelope' {
+        BeforeEach {
+            Send-CIPPScheduledTaskAlert -Results (New-EnvelopeResult) -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Scheduled Task'
+            $script:Html = $script:SentAlerts[0].HTMLContent
+        }
+
+        It 'renders the result lines as the table, one row each' {
+            Get-TableColumns -Html $script:Html -TableIndex 0 | Should -Be @('Results')
+            Get-TableRowCount -Html $script:Html -TableIndex 0 | Should -Be 4
+        }
+
+        It 'keeps the Graph user object rather than dropping it' {
+            # The whole point of rendering the extras below instead of unwrapping upstream.
+            $script:Html | Should -Match 'Additional detail'
+            $script:Html | Should -Match 'displayName: New Starter'
+            $script:Html | Should -Match '00000000-0000-0000-0000-000000000001'
+        }
+
+        It 'keeps the other envelope fields too' {
+            foreach ($Field in 'Username', 'Password', 'CopyFrom', 'User') {
+                $script:Html | Should -Match ">$Field<"
+            }
+        }
+
+        It 'puts the extras in their own table below the results' {
+            Get-TableColumns -Html $script:Html -TableIndex 1 | Should -Be @('Field', 'Value')
+            $script:Html.IndexOf('Additional detail') | Should -BeGreaterThan $script:Html.IndexOf('Created New User.')
+        }
+    }
+
+    Context 'result shapes that are not envelopes' {
+        It 'renders an array of strings as before' {
+            Send-CIPPScheduledTaskAlert -Results @('First line', 'Second line') -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Scheduled Task'
+
+            $Html = $script:SentAlerts[0].HTMLContent
+            Get-TableColumns -Html $Html -TableIndex 0 | Should -Be @('Text')
+            $Html | Should -Not -Match 'Additional detail'
+        }
+
+        It 'renders a normal multi-row result set as before' {
+            $Rows = @(
+                [pscustomobject]@{ UserPrincipalName = 'a@contoso.com'; MFA = 'Disabled' }
+                [pscustomobject]@{ UserPrincipalName = 'b@contoso.com'; MFA = 'Disabled' }
+            )
+            Send-CIPPScheduledTaskAlert -Results $Rows -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Scheduled Task'
+
+            $Html = $script:SentAlerts[0].HTMLContent
+            Get-TableColumns -Html $Html -TableIndex 0 | Should -Be @('UserPrincipalName', 'MFA')
+            $Html | Should -Not -Match 'Additional detail'
+        }
+
+        It 'leaves a single row that has no Results member alone' {
+            $Row = @([pscustomobject]@{ UserPrincipalName = 'a@contoso.com'; MFA = 'Disabled' })
+            Send-CIPPScheduledTaskAlert -Results $Row -TaskInfo $script:TaskInfo -TenantFilter 'contoso.com' -TaskType 'Scheduled Task'
+
+            $Html = $script:SentAlerts[0].HTMLContent
+            Get-TableColumns -Html $Html -TableIndex 0 | Should -Be @('UserPrincipalName', 'MFA')
+            $Html | Should -Not -Match 'Additional detail'
+        }
+    }
+}


### PR DESCRIPTION
Fixes the unreadable table in post-execution emails and PSA tickets. 
Now the result lines render as the table and the extras go underneath as Field/Value. 
Rendering only - $Results is untouched, so the webhook payload and stored task results keep their exact shape and nothing is dropped.