### PR TITLE
fix(ca-policy): cast signInFrequency value to int

### DIFF
--- a/backend/Modules/CIPPCore/Public/Functions/Format-CIPPCAPolicy.ps1
+++ b/backend/Modules/CIPPCore/Public/Functions/Format-CIPPCAPolicy.ps1
@@ -24,6 +24,12 @@ function Format-CIPPCAPolicy {
            than being removed - null is accepted on a create and still clears on an update. Empty
            assignment arrays are deliberately KEPT: an explicit "includeGroups": [] is the only
            thing that strips a group off a policy that already has one.
+
+        3. sessionControls.signInFrequency - value is Int32 in Graph but has been saved as a
+           string by older editors, so a numeric string is cast. When frequencyInterval is
+           everyTime, value/type are forced explicitly null (added if absent) since Graph
+           requires both null there and a PATCH merge would otherwise let a stale value/type
+           survive from the tenant's existing policy.
     .PARAMETER Policy
         The parsed CA policy object. Mutated in place.
     .FUNCTIONALITY
@@ -134,6 +140,21 @@ function Format-CIPPCAPolicy {
     if ($Policy.PSObject.Properties.Name -contains 'sessionControls' -and $null -ne $Policy.sessionControls) {
         if (@($Policy.sessionControls.PSObject.Properties).Count -eq 0) {
             $Policy.sessionControls = $null
+        }
+    }
+
+    # signInFrequency.value is Int32 in Graph, but editors have saved it as a string - cast it.
+    # When frequencyInterval is everyTime, Graph requires value/type to be null rather than
+    # merely absent, and this is a PATCH merge, so a stale value/type from the tenant's existing
+    # policy would otherwise survive.
+    $SignInFrequency = $Policy.sessionControls.signInFrequency
+    if ($null -ne $SignInFrequency -and $SignInFrequency -is [PSCustomObject]) {
+        if ($SignInFrequency.PSObject.Properties.Name -contains 'value' -and $SignInFrequency.value -is [string] -and $SignInFrequency.value -match '^\d+$') {
+            $SignInFrequency.value = [int]$SignInFrequency.value
+        }
+        if ($SignInFrequency.frequencyInterval -eq 'everyTime') {
+            $SignInFrequency | Add-Member -NotePropertyName 'value' -NotePropertyValue $null -Force
+            $SignInFrequency | Add-Member -NotePropertyName 'type' -NotePropertyValue $null -Force
         }
     }
 }

--- a/backend/Tests/Private/Format-CIPPCAPolicy.Tests.ps1
+++ b/backend/Tests/Private/Format-CIPPCAPolicy.Tests.ps1
@@ -326,6 +326,60 @@ Describe 'Format-CIPPCAPolicy' {
         }
     }
 
+    Context 'sessionControls.signInFrequency canonicalization' {
+        It 'casts a numeric string value to an int' {
+            $Policy = Convert-Policy '{
+                "displayName": "CA201",
+                "conditions": { "users": { "includeUsers": ["All"] } },
+                "sessionControls": { "signInFrequency": { "isEnabled": true, "frequencyInterval": "timeBased", "type": "hours", "value": "12" } }
+            }'
+            $Policy.sessionControls.signInFrequency.value | Should -Be 12
+            $Policy.sessionControls.signInFrequency.value | Should -BeOfType [int]
+        }
+
+        It 'sets value and type to explicit null when frequencyInterval is everyTime' {
+            $Policy = Convert-Policy '{
+                "displayName": "CA201",
+                "conditions": { "users": { "includeUsers": ["All"] } },
+                "sessionControls": { "signInFrequency": { "isEnabled": true, "frequencyInterval": "everyTime" } }
+            }'
+            $Policy.sessionControls.signInFrequency.PSObject.Properties.Name | Should -Contain 'value'
+            $Policy.sessionControls.signInFrequency.PSObject.Properties.Name | Should -Contain 'type'
+            $Policy.sessionControls.signInFrequency.value | Should -BeNullOrEmpty
+            $Policy.sessionControls.signInFrequency.type | Should -BeNullOrEmpty
+        }
+
+        It 'overrides a stale value/type with null even when everyTime carries leftovers' {
+            $Policy = Convert-Policy '{
+                "displayName": "CA201",
+                "conditions": { "users": { "includeUsers": ["All"] } },
+                "sessionControls": { "signInFrequency": { "isEnabled": true, "frequencyInterval": "everyTime", "type": "hours", "value": "12" } }
+            }'
+            $Policy.sessionControls.signInFrequency.value | Should -BeNullOrEmpty
+            $Policy.sessionControls.signInFrequency.type | Should -BeNullOrEmpty
+        }
+
+        It 'leaves an int value under timeBased unchanged' {
+            $Policy = Convert-Policy '{
+                "displayName": "CA201",
+                "conditions": { "users": { "includeUsers": ["All"] } },
+                "sessionControls": { "signInFrequency": { "isEnabled": true, "frequencyInterval": "timeBased", "type": "days", "value": 4 } }
+            }'
+            $Policy.sessionControls.signInFrequency.value | Should -Be 4
+            $Policy.sessionControls.signInFrequency.type | Should -Be 'days'
+        }
+
+        It 'casts a disabled signInFrequency with a string value too - Graph validates disabled sub-objects' {
+            $Policy = Convert-Policy '{
+                "displayName": "CA201",
+                "conditions": { "users": { "includeUsers": ["All"] } },
+                "sessionControls": { "signInFrequency": { "isEnabled": false, "frequencyInterval": "timeBased", "type": "hours", "value": "12" } }
+            }'
+            $Policy.sessionControls.signInFrequency.value | Should -Be 12
+            $Policy.sessionControls.signInFrequency.value | Should -BeOfType [int]
+        }
+    }
+
     Context 'edge cases' {
         It 'does nothing to a policy with no conditions at all' {
             { Convert-Policy '{"displayName":"CA201"}' } | Should -Not -Throw

--- a/frontend/src/components/CippComponents/CippCAPolicyBuilder.jsx
+++ b/frontend/src/components/CippComponents/CippCAPolicyBuilder.jsx
@@ -1657,6 +1657,24 @@ export function extractCAPolicyJSON(formValues) {
         delete cleaned.sessionControls[key];
       }
     }
+    // signInFrequency.value comes off the "number" form field as a string, but Graph types
+    // it Int32 — coerce it. When frequencyInterval is everyTime, Graph requires value/type to
+    // be null rather than merely absent; drop them here and let the backend canonicalizer
+    // supply the explicit nulls at deploy.
+    const signInFrequency = cleaned.sessionControls.signInFrequency;
+    if (signInFrequency) {
+      if (signInFrequency.value !== undefined && signInFrequency.value !== "") {
+        signInFrequency.value = Number(signInFrequency.value);
+      }
+      const frequencyInterval =
+        typeof signInFrequency.frequencyInterval === "object"
+          ? signInFrequency.frequencyInterval?.value
+          : signInFrequency.frequencyInterval;
+      if (frequencyInterval === "everyTime") {
+        delete signInFrequency.value;
+        delete signInFrequency.type;
+      }
+    }
     // `disableResilienceDefaults` defaults to false from the switch even when
     // untouched. Left in place it keeps `sessionControls` non-empty, so Graph
     // never persists it on read


### PR DESCRIPTION
Graph types signInFrequency.value as Int32, but older editors and form fields saved/submitted it as a string. Coerce the value to a number in both the frontend extractor and the backend canonicalizer.

When frequencyInterval is everyTime, Graph requires value and type to be explicitly null. The frontend drops them before submission; the backend forces explicit nulls to prevent stale values surviving a PATCH merge.

Adds Pester tests for all four cases.

Fixes #396