### PR TITLE
fix: re-fire bulk requests on entity switch without unmount

### DIFF
--- a/frontend/src/pages/endpoint/MEM/devices/device/index.jsx
+++ b/frontend/src/pages/endpoint/MEM/devices/device/index.jsx
@@ -61,6 +61,7 @@ const Page = () => {
   const deviceBulkRequest = ApiPostCall({
     urlFromData: true,
   })
+  const bulkFetchedForId = useRef(null)
 
   // Handle response structure - ListGraphRequest may wrap single items in Results array
   // Try Results array first, then Results as object, then data directly
@@ -114,11 +115,12 @@ const Page = () => {
       })
     }
 
+    bulkFetchedForId.current = deviceId
     deviceBulkRequest.mutate({
       url: '/api/ListGraphBulkRequest',
       data: {
         Requests: requests,
-        tenantFilter: userSettingsDefaults.currentTenant,
+        tenantFilter: router.query.tenantFilter ?? userSettingsDefaults.currentTenant,
       },
     })
   }
@@ -129,7 +131,7 @@ const Page = () => {
       deviceId &&
       userSettingsDefaults.currentTenant &&
       deviceRequest.isSuccess &&
-      !deviceBulkRequest.isSuccess
+      bulkFetchedForId.current !== deviceId
     ) {
       refreshFunction()
     }
@@ -137,7 +139,6 @@ const Page = () => {
     deviceId,
     userSettingsDefaults.currentTenant,
     deviceRequest.isSuccess,
-    deviceBulkRequest.isSuccess,
   ])
 
   const bulkData = deviceBulkRequest?.data?.data ?? []

--- a/frontend/src/pages/identity/administration/groups/group/index.jsx
+++ b/frontend/src/pages/identity/administration/groups/group/index.jsx
@@ -27,7 +27,7 @@ import { Grid } from "@mui/system";
 import { SvgIcon, Typography, Card, CardHeader, Divider } from "@mui/material";
 import { CippBannerListCard } from "../../../../../components/CippCards/CippBannerListCard";
 import { CippTimeAgo } from "../../../../../components/CippComponents/CippTimeAgo";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { EyeIcon, PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { CippDataTable } from "../../../../../components/CippTable/CippDataTable";
 import { PropertyList } from "../../../../../components/property-list";
@@ -62,6 +62,7 @@ const Page = () => {
   const groupBulkRequest = ApiPostCall({
     urlFromData: true,
   });
+  const bulkFetchedForId = useRef(null);
 
   function refreshFunction() {
     if (!groupId) return;
@@ -83,11 +84,12 @@ const Page = () => {
       },
     ];
 
+    bulkFetchedForId.current = groupId;
     groupBulkRequest.mutate({
       url: "/api/ListGraphBulkRequest",
       data: {
         Requests: requests,
-        tenantFilter: userSettingsDefaults.currentTenant,
+        tenantFilter: router.query.tenantFilter ?? userSettingsDefaults.currentTenant,
       },
     });
   }
@@ -97,11 +99,11 @@ const Page = () => {
       groupId &&
       userSettingsDefaults.currentTenant &&
       groupRequest.isSuccess &&
-      !groupBulkRequest.isSuccess
+      bulkFetchedForId.current !== groupId
     ) {
       refreshFunction();
     }
-  }, [groupId, userSettingsDefaults.currentTenant, groupRequest.isSuccess, groupBulkRequest.isSuccess]);
+  }, [groupId, userSettingsDefaults.currentTenant, groupRequest.isSuccess]);
 
   // Handle response structure - ListGraphRequest may wrap single items in Results array
   let groupData = null;

--- a/frontend/src/pages/identity/administration/users/user/index.jsx
+++ b/frontend/src/pages/identity/administration/users/user/index.jsx
@@ -34,7 +34,7 @@ import { CippUserSwitcher } from '../../../../../components/CippComponents/CippU
 import { SvgIcon, Typography } from '@mui/material'
 import { CippBannerListCard } from '../../../../../components/CippCards/CippBannerListCard'
 import { CippTimeAgo } from '../../../../../components/CippComponents/CippTimeAgo'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useState, useRef } from 'react'
 import { useCippUserActions } from '../../../../../components/CippComponents/CippUserActions'
 import { EyeIcon, PencilIcon } from '@heroicons/react/24/outline'
 import { CippDataTable } from '../../../../../components/CippTable/CippDataTable'
@@ -287,6 +287,7 @@ const Page = () => {
   const userBulkRequest = ApiPostCall({
     urlFromData: true,
   })
+  const bulkFetchedForId = useRef(null)
 
   const userPrincipalName = userRequest.data?.[0]?.userPrincipalName
 
@@ -323,11 +324,12 @@ const Page = () => {
       })
     }
 
+    bulkFetchedForId.current = userId
     userBulkRequest.mutate({
       url: '/api/ListGraphBulkRequest',
       data: {
         Requests: requests,
-        tenantFilter: userSettingsDefaults.currentTenant,
+        tenantFilter: router.query.tenantFilter ?? userSettingsDefaults.currentTenant,
         noPaginateIds: ['signInLogs', 'signInPreferences'],
       },
     })
@@ -338,7 +340,7 @@ const Page = () => {
       userId &&
       userSettingsDefaults.currentTenant &&
       userRequest.isSuccess &&
-      !userBulkRequest.isSuccess
+      bulkFetchedForId.current !== userId
     ) {
       refreshFunction()
     }
@@ -346,7 +348,6 @@ const Page = () => {
     userId,
     userSettingsDefaults.currentTenant,
     userRequest.isSuccess,
-    userBulkRequest.isSuccess,
   ])
 
   const bulkData = userBulkRequest?.data?.data ?? []

--- a/frontend/src/pages/tenant/administration/applications/app-registration/index.jsx
+++ b/frontend/src/pages/tenant/administration/applications/app-registration/index.jsx
@@ -22,7 +22,7 @@ import { Grid } from '@mui/system'
 import { Typography, Card, CardHeader, Divider, Button, SvgIcon } from '@mui/material'
 import { CippBannerListCard } from '../../../../../components/CippCards/CippBannerListCard'
 import { CippTimeAgo } from '../../../../../components/CippComponents/CippTimeAgo'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useRef } from 'react'
 import { PropertyList } from '../../../../../components/property-list'
 import { PropertyListItem } from '../../../../../components/property-list-item'
 import { CippHead } from '../../../../../components/CippComponents/CippHead'
@@ -85,6 +85,7 @@ const Page = () => {
   const appBulkRequest = ApiPostCall({
     urlFromData: true,
   })
+  const bulkFetchedForId = useRef(null)
 
   function refreshFunction() {
     if (!applicationClientId || !appData?.id) return
@@ -101,11 +102,12 @@ const Page = () => {
       },
     ]
 
+    bulkFetchedForId.current = applicationClientId
     appBulkRequest.mutate({
       url: '/api/ListGraphBulkRequest',
       data: {
         Requests: requests,
-        tenantFilter: userSettingsDefaults.currentTenant,
+        tenantFilter: router.query.tenantFilter ?? userSettingsDefaults.currentTenant,
       },
     })
   }
@@ -116,7 +118,7 @@ const Page = () => {
       userSettingsDefaults.currentTenant &&
       appRequest.isSuccess &&
       appData?.id &&
-      !appBulkRequest.isSuccess
+      bulkFetchedForId.current !== applicationClientId
     ) {
       refreshFunction()
     }
@@ -125,7 +127,6 @@ const Page = () => {
     userSettingsDefaults.currentTenant,
     appRequest.isSuccess,
     appData?.id,
-    appBulkRequest.isSuccess,
   ])
 
   const bulkData = getListGraphBulkRequestRows(appBulkRequest)

--- a/frontend/src/pages/tenant/administration/applications/enterprise-app/index.jsx
+++ b/frontend/src/pages/tenant/administration/applications/enterprise-app/index.jsx
@@ -14,7 +14,7 @@ import { Grid } from '@mui/system'
 import { Typography, Card, CardHeader, Divider, Button, SvgIcon } from '@mui/material'
 import { CippBannerListCard } from '../../../../../components/CippCards/CippBannerListCard'
 import { CippTimeAgo } from '../../../../../components/CippComponents/CippTimeAgo'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useRef } from 'react'
 import { PropertyList } from '../../../../../components/property-list'
 import { PropertyListItem } from '../../../../../components/property-list-item'
 import { CippHead } from '../../../../../components/CippComponents/CippHead'
@@ -77,13 +77,15 @@ const Page = () => {
   const spBulkRequest = ApiPostCall({
     urlFromData: true,
   })
+  const bulkFetchedForId = useRef(null)
 
   function refreshFunction() {
     if (!spObjectId) return
+    bulkFetchedForId.current = spObjectId
     spBulkRequest.mutate({
       url: '/api/ListGraphBulkRequest',
       data: {
-        tenantFilter: userSettingsDefaults.currentTenant,
+        tenantFilter: router.query.tenantFilter ?? userSettingsDefaults.currentTenant,
         Requests: [
           {
             id: 'owners',
@@ -101,7 +103,7 @@ const Page = () => {
       userSettingsDefaults.currentTenant &&
       spRequest.isSuccess &&
       spData?.id &&
-      !spBulkRequest.isSuccess
+      bulkFetchedForId.current !== spObjectId
     ) {
       refreshFunction()
     }
@@ -110,7 +112,6 @@ const Page = () => {
     userSettingsDefaults.currentTenant,
     spRequest.isSuccess,
     spData?.id,
-    spBulkRequest.isSuccess,
   ])
 
   const bulkData = getListGraphBulkRequestRows(spBulkRequest)

--- a/frontend/tests/pages/GroupViewPage.bulkRefetch.test.jsx
+++ b/frontend/tests/pages/GroupViewPage.bulkRefetch.test.jsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material/styles'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTheme } from '../../src/theme'
+import { SettingsContext } from '../../src/contexts/settings-context'
+import { settingsWith } from '../test-utils'
+import router from '../mocks/next-router'
+
+const theme = createTheme({
+  colorPreset: 'orange',
+  direction: 'ltr',
+  paletteMode: 'light',
+  contrast: 'high',
+})
+const store = configureStore({ reducer: { toasts: (state = { toasts: [] }) => state } })
+const settings = settingsWith()
+
+// A stable Wrapper (rather than renderWithProviders' one-off tree) so RTL's `rerender`
+// re-applies the same providers instead of losing them - a rerender that drops the
+// ThemeProvider crashes MUI hooks that read the theme from context.
+function Wrapper({ children }) {
+  const queryClient = React.useRef(new QueryClient({ defaultOptions: { queries: { retry: false } } })).current
+  return (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <SettingsContext.Provider value={settings}>
+          <ThemeProvider theme={theme}>{children}</ThemeProvider>
+        </SettingsContext.Provider>
+      </QueryClientProvider>
+    </Provider>
+  )
+}
+
+vi.mock('../../src/api/ApiCall', async () => (await import('../mocks/api-call')).apiCallMock())
+import { api, getResult, postResult } from '../mocks/api-call'
+
+import Page from '../../src/pages/identity/administration/groups/group/index.jsx'
+
+// Stable per-id results so ApiGetCall doesn't hand back a fresh object identity every
+// render (that loops effects that key off it - see mocks/api-call.js).
+const groupResultCache = new Map()
+const groupResultFor = (id) => {
+  if (!groupResultCache.has(id)) {
+    groupResultCache.set(id, getResult({ data: { id, displayName: `Group ${id}` } }))
+  }
+  return groupResultCache.get(id)
+}
+const switcherListResult = getResult({ data: { Results: [] } })
+
+api.get = (opts) => {
+  const endpoint = opts?.data?.Endpoint
+  if (typeof endpoint === 'string' && endpoint.startsWith('groups/')) {
+    return groupResultFor(endpoint.slice('groups/'.length))
+  }
+  return switcherListResult
+}
+
+describe('Group view page - bulk request refetch on entity switch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // A mutation's isSuccess stays true forever once it fires - the same as real
+    // react-query - so a stale `!isSuccess` guard would only ever fire once per mount.
+    const bulkState = postResult()
+    bulkState.mutate = vi.fn(() => {
+      bulkState.isSuccess = true
+    })
+    api.post = bulkState
+    router.query = { groupId: 'group-1' }
+    router.pathname = '/identity/administration/groups/group'
+  })
+
+  it('re-fires the bulk request when groupId changes without an unmount', async () => {
+    const { rerender } = render(<Page />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(api.post.mutate).toHaveBeenCalledTimes(1)
+    })
+    expect(api.post.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/api/ListGraphBulkRequest',
+        data: expect.objectContaining({
+          Requests: expect.arrayContaining([
+            expect.objectContaining({ url: '/groups/group-1/members' }),
+          ]),
+        }),
+      })
+    )
+
+    // CippEntitySwitcher on the group page (or same-route navigation elsewhere) changes
+    // the id in the URL without unmounting the page - simulate that here.
+    router.query = { groupId: 'group-2' }
+    rerender(<Page />)
+
+    await waitFor(() => {
+      expect(api.post.mutate).toHaveBeenCalledTimes(2)
+    })
+    expect(api.post.mutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        url: '/api/ListGraphBulkRequest',
+        data: expect.objectContaining({
+          Requests: expect.arrayContaining([
+            expect.objectContaining({ url: '/groups/group-2/members' }),
+          ]),
+        }),
+      })
+    )
+  })
+})


### PR DESCRIPTION
Replace `!isSuccess` guards with a `useRef` tracking the last fetched entity ID. This ensures bulk Graph requests re-fire when navigating between entities via CippEntitySwitcher (same-route navigation that doesn't unmount the page). Also fixes tenant filter to prefer `router.query.tenantFilter` over the global default, matching the primary request behavior. Adds a regression test for the group view page.