### PR TITLE
feat(alerts): make APN/DEP/VPP expiry alert window configurable

### DIFF
--- a/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertApnCertExpiry.ps1
+++ b/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertApnCertExpiry.ps1
@@ -12,8 +12,18 @@ function Get-CIPPAlertApnCertExpiry {
     )
 
     try {
+        $expiryDays = 30
+        if ($InputValue -is [hashtable] -or $InputValue -is [pscustomobject]) {
+            if ($null -ne $InputValue.DaysUntilExpiry -and $InputValue.DaysUntilExpiry -ne '') {
+                $parsedDays = 0
+                if ([int]::TryParse($InputValue.DaysUntilExpiry.ToString(), [ref]$parsedDays) -and $parsedDays -gt 0) {
+                    $expiryDays = $parsedDays
+                }
+            }
+        }
+
         $Apn = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/deviceManagement/applePushNotificationCertificate' -tenantid $TenantFilter
-        $AlertData = if ($Apn.expirationDateTime -lt (Get-Date).AddDays(30) -and $Apn.expirationDateTime -gt (Get-Date).AddDays(-7)) {
+        $AlertData = if ($Apn.expirationDateTime -lt (Get-Date).AddDays($expiryDays) -and $Apn.expirationDateTime -gt (Get-Date).AddDays(-7)) {
             $Apn | Select-Object -Property appleIdentifier, expirationDateTime
         }
         if ($AlertData) {

--- a/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertDepTokenExpiry.ps1
+++ b/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertDepTokenExpiry.ps1
@@ -13,9 +13,19 @@ function Get-CIPPAlertDepTokenExpiry {
 
     try {
         try {
+            $expiryDays = 30
+            if ($InputValue -is [hashtable] -or $InputValue -is [pscustomobject]) {
+                if ($null -ne $InputValue.DaysUntilExpiry -and $InputValue.DaysUntilExpiry -ne '') {
+                    $parsedDays = 0
+                    if ([int]::TryParse($InputValue.DaysUntilExpiry.ToString(), [ref]$parsedDays) -and $parsedDays -gt 0) {
+                        $expiryDays = $parsedDays
+                    }
+                }
+            }
+
             $DepTokens = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/deviceManagement/depOnboardingSettings' -tenantid $TenantFilter
             $AlertData = foreach ($Dep in $DepTokens) {
-                if ($Dep.tokenExpirationDateTime -lt (Get-Date).AddDays(30) -and $Dep.tokenExpirationDateTime -gt (Get-Date).AddDays(-7)) {
+                if ($Dep.tokenExpirationDateTime -lt (Get-Date).AddDays($expiryDays) -and $Dep.tokenExpirationDateTime -gt (Get-Date).AddDays(-7)) {
                     $Message = 'Apple Device Enrollment Program token expiring on {0}' -f ([datetime]$Dep.tokenExpirationDateTime).ToString('yyyy-MM-dd')
                     $Dep | Select-Object -Property tokenName, @{Name = 'Message'; Expression = { $Message } }
                 }

--- a/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertVppTokenExpiry.ps1
+++ b/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertVppTokenExpiry.ps1
@@ -12,12 +12,22 @@ function Get-CIPPAlertVppTokenExpiry {
     )
     try {
         try {
+            $expiryDays = 30
+            if ($InputValue -is [hashtable] -or $InputValue -is [pscustomobject]) {
+                if ($null -ne $InputValue.DaysUntilExpiry -and $InputValue.DaysUntilExpiry -ne '') {
+                    $parsedDays = 0
+                    if ([int]::TryParse($InputValue.DaysUntilExpiry.ToString(), [ref]$parsedDays) -and $parsedDays -gt 0) {
+                        $expiryDays = $parsedDays
+                    }
+                }
+            }
+
             $VppTokens = New-GraphGetRequest -uri 'https://graph.microsoft.com/beta/deviceAppManagement/vppTokens' -tenantid $TenantFilter
             $AlertData = foreach ($Vpp in $VppTokens) {
                 if ($Vpp.state -ne 'valid') {
                     $Message = 'Apple Volume Purchase Program Token is not valid, new token required'
                     $Vpp | Select-Object -Property organizationName, appleId, vppTokenAccountType, @{Name = 'Message'; Expression = { $Message } }, @{Name = 'Tenant'; Expression = { $TenantFilter } }
-                } elseif ($Vpp.expirationDateTime -lt (Get-Date).AddDays(30).ToUniversalTime() -and $Vpp.expirationDateTime -gt (Get-Date).AddDays(-7).ToUniversalTime()) {
+                } elseif ($Vpp.expirationDateTime -lt (Get-Date).AddDays($expiryDays).ToUniversalTime() -and $Vpp.expirationDateTime -gt (Get-Date).AddDays(-7).ToUniversalTime()) {
                     $Message = 'Apple Volume Purchase Program token expiring on {0}' -f ([datetime]$Vpp.expirationDateTime).ToString('yyyy-MM-dd')
                     $Vpp | Select-Object -Property organizationName, appleId, vppTokenAccountType, @{Name = 'Message'; Expression = { $Message } }, @{Name = 'Tenant'; Expression = { $TenantFilter } }
                 }

--- a/frontend/src/data/alerts.json
+++ b/frontend/src/data/alerts.json
@@ -446,17 +446,29 @@
   {
     "name": "ApnCertExpiry",
     "label": "Alert on expiring APN certificates",
-    "recommendedRunInterval": "1d"
+    "recommendedRunInterval": "1d",
+    "requiresInput": true,
+    "inputType": "number",
+    "inputLabel": "Days until expiry to alert (default: 30)",
+    "inputName": "DaysUntilExpiry"
   },
   {
     "name": "VppTokenExpiry",
     "label": "Alert on expiring VPP tokens",
-    "recommendedRunInterval": "1d"
+    "recommendedRunInterval": "1d",
+    "requiresInput": true,
+    "inputType": "number",
+    "inputLabel": "Days until expiry to alert (default: 30)",
+    "inputName": "DaysUntilExpiry"
   },
   {
     "name": "DepTokenExpiry",
     "label": "Alert on expiring DEP tokens",
-    "recommendedRunInterval": "1d"
+    "recommendedRunInterval": "1d",
+    "requiresInput": true,
+    "inputType": "number",
+    "inputLabel": "Days until expiry to alert (default: 30)",
+    "inputName": "DaysUntilExpiry"
   },
   {
     "name": "IntuneApprovalRequests",


### PR DESCRIPTION
## Summary
- Replace the hardcoded 30-day advance-warning threshold in the APN certificate, DEP token, and VPP token expiry alerts with an optional `InputValue.DaysUntilExpiry` parameter, following the same `TryParse`-guarded default pattern used by `Get-CIPPAlertInactiveLicensedUsers`'s `DaysSinceLastLogin`.
- Expose the new field as a `number` input in `alerts.json` so it's editable from the Alert Configuration UI, matching the existing input-rendering pattern (no frontend JS changes needed).
- Defaults to 30 days when unset, so existing scheduled alerts are unaffected. The `-7` day post-expiry grace period stays hardcoded.

Fixes #436

## Test plan
- [x] Parsed all three modified `.ps1` files with the PowerShell AST parser to confirm no syntax errors.
- [x] Validated `alerts.json` still parses as valid JSON.
- [x] Manual verification in a running CIPP instance that the Alert Configuration UI renders and saves the new "Days until expiry to alert" field for APN/DEP/VPP alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)