### PR TITLE
feat(templates): add install-as-system option to store app templates

### DIFF
--- a/frontend/src/components/CippComponents/CippAppTemplateDrawer.jsx
+++ b/frontend/src/components/CippComponents/CippAppTemplateDrawer.jsx
@@ -617,6 +617,13 @@ export const CippAppTemplateDrawer = ({
             <Grid size={{ xs: 12 }}>
               <CippFormComponent
                 type="switch"
+                label="Install as system"
+                name="InstallAsSystem"
+                formControl={formControl}
+                defaultValue={true}
+              />
+              <CippFormComponent
+                type="switch"
                 label="Mark for Uninstallation"
                 name="InstallationIntent"
                 formControl={formControl}


### PR DESCRIPTION
## Summary
- Adds the "Install as system" toggle to the Store/WinGet App section of the application template drawer, matching the option already present for Chocolatey and Win32 script app templates, and for manual Store App deployments.
- No backend changes needed — `Invoke-AddStoreApp.ps1` and `New-CIPPIntuneAppDeployment.ps1` already read `InstallAsSystem` for store apps and default to system-context when the field is absent, so existing saved templates keep their current behavior.

Closes #439

## Test plan
- [x] Lint passes on the changed file
- [x] Manually verified in a running CIPP instance: open the app template drawer, select Store App, confirm the switch appears (default on), save a template, reopen it and confirm the switch state persists