### PR TITLE
feat(templates): add Template Package Manager under Tools

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -407,6 +407,7 @@
   * [Template Library](user-documentation/tools/templatelib.md)
   * [Catalog](user-documentation/tools/community-repos/README.md)
     * [Browse All Templates](user-documentation/tools/community-repos/browse-all-templates.md)
+  * [Template Package Manager](user-documentation/tools/template-packages.md)
   * [Scheduler](user-documentation/tools/scheduler/README.md)
     * [View Scheduled Task Details](user-documentation/tools/scheduler/task.md)
 * [CIPP](user-documentation/cipp/README.md)

--- a/docs/user-documentation/tools/template-packages.md
+++ b/docs/user-documentation/tools/template-packages.md
@@ -1,0 +1,32 @@
+# Template Package Manager
+
+CA Templates and Policy (Intune) Templates can be grouped into a package - a shared tag that lets a single Standards Template pull in every template carrying that tag, instead of listing each template's GUID individually. The Template Package Manager is where those packages are viewed, renamed, and deleted, and where their members are managed, for both template types.
+
+{% hint style="info" %}
+A package is just a tag shared by its member templates. Deleting a package removes the tag from its members - the templates themselves are not deleted.
+{% endhint %}
+
+## Switching Template Type
+
+Use the toggle at the top of the page to switch between Conditional Access Templates and Policy Templates. Each package list is specific to the selected type.
+
+## Managing a Package
+
+Each package is shown with its member count. Expand a package to:
+
+| Action                        | Effect                                                                                     |
+| ------------------------------ | -------------------------------------------------------------------------------------------- |
+| Add an existing template       | Select any template of the current type that isn't already in this package and add it.       |
+| Remove a member                | Removes the tag from that template only. The template itself is unaffected.                  |
+| Rename package                 | Re-tags every current member with the new name. Renaming to an existing package's name merges the two. |
+| Delete package                 | Removes the tag from every current member. No templates are deleted.                          |
+
+{% hint style="warning" %}
+Renaming or deleting a package affects every one of its member templates at once.
+{% endhint %}
+
+## Adding a Template to a Package from the Template List
+
+The "Add to package" action on the CA Templates and Policy Templates lists now offers a dropdown of existing packages, in addition to typing a new package name. Picking an existing package from the list avoids mismatches from typing the name by hand.
+
+{% include "../../../.gitbook/includes/feature-request.md" %}

--- a/frontend/src/components/CippComponents/CippTemplatePackageManager.jsx
+++ b/frontend/src/components/CippComponents/CippTemplatePackageManager.jsx
@@ -1,0 +1,332 @@
+import { useMemo, useState } from 'react'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Skeleton,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import {
+  Add,
+  Close,
+  Delete,
+  DriveFileRenameOutline,
+  ExpandMore,
+  LocalOffer,
+} from '@mui/icons-material'
+import { ApiGetCall, ApiPostCall } from '../../api/ApiCall'
+import { CippAutoComplete } from './CippAutocomplete'
+import { CippApiResults } from './CippApiResults'
+
+// Both template types store "package" as a free-text tag on the template row, and both list
+// endpoints already expose the same ?mode=Tag shape (label/value/templateCount/templates) that
+// the Standards Template builder uses for its "select a package" pickers. One component reused
+// across both types avoids building two near-identical package management screens.
+const TEMPLATE_TYPES = {
+  CA: {
+    label: 'Conditional Access Templates',
+    listUrl: '/api/ListCATemplates',
+    queryKeyBase: 'ListCATemplates',
+    displayField: 'displayName',
+  },
+  Intune: {
+    label: 'Policy Templates',
+    listUrl: '/api/ListIntuneTemplates',
+    queryKeyBase: 'ListIntuneTemplates',
+    displayField: 'Displayname',
+  },
+}
+
+const getDisplayName = (tpl, typeConfig) =>
+  tpl?.[typeConfig.displayField] || tpl?.displayName || tpl?.Displayname || tpl?.GUID
+
+export const CippTemplatePackageManager = () => {
+  const [activeTypeKey, setActiveTypeKey] = useState('CA')
+  const typeConfig = TEMPLATE_TYPES[activeTypeKey]
+
+  const [renameTarget, setRenameTarget] = useState(null) // { value, templates }
+  const [renameValue, setRenameValue] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState(null) // { value, templates }
+  const [addMemberTarget, setAddMemberTarget] = useState(null) // package value
+  const [addMemberSelection, setAddMemberSelection] = useState(null)
+
+  const relatedQueryKeys = [
+    `${typeConfig.queryKeyBase}-tag-packagemanager`,
+    `${typeConfig.queryKeyBase}-packagemanager-all`,
+  ]
+
+  const packages = ApiGetCall({
+    url: `${typeConfig.listUrl}${typeConfig.listUrl.includes('?') ? '&' : '?'}mode=Tag`,
+    queryKey: `${typeConfig.queryKeyBase}-tag-packagemanager`,
+  })
+
+  const allTemplates = ApiGetCall({
+    url: typeConfig.listUrl,
+    queryKey: `${typeConfig.queryKeyBase}-packagemanager-all`,
+  })
+
+  const renameMutation = ApiPostCall({ urlFromData: true, relatedQueryKeys })
+  const deleteMutation = ApiPostCall({ urlFromData: true, relatedQueryKeys })
+  const addMemberMutation = ApiPostCall({ urlFromData: true, relatedQueryKeys })
+  const removeMemberMutation = ApiPostCall({ urlFromData: true, relatedQueryKeys })
+
+  const packageList = Array.isArray(packages.data) ? packages.data : []
+
+  const allTemplateOptions = useMemo(() => {
+    if (!Array.isArray(allTemplates.data)) return []
+    return allTemplates.data.map((tpl) => ({
+      label: getDisplayName(tpl, typeConfig),
+      value: tpl.GUID,
+      package: tpl.package,
+    }))
+  }, [allTemplates.data, typeConfig])
+
+  const getAddMemberOptions = (pkgValue) =>
+    allTemplateOptions.filter((option) => option.package !== pkgValue)
+
+  const handleTypeChange = (event, newType) => {
+    if (!newType) return
+    setActiveTypeKey(newType)
+  }
+
+  return (
+    <Stack spacing={2}>
+      <ToggleButtonGroup
+        color="primary"
+        exclusive
+        value={activeTypeKey}
+        onChange={handleTypeChange}
+        size="small"
+      >
+        {Object.entries(TEMPLATE_TYPES).map(([key, cfg]) => (
+          <ToggleButton key={key} value={key}>
+            {cfg.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+
+      {packages.isLoading && (
+        <Stack spacing={1}>
+          <Skeleton variant="rounded" height={56} />
+          <Skeleton variant="rounded" height={56} />
+          <Skeleton variant="rounded" height={56} />
+        </Stack>
+      )}
+
+      {packages.isSuccess && packageList.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          No packages yet for {typeConfig.label.toLowerCase()}. Use the "Add to package" action on
+          the template list to create one.
+        </Typography>
+      )}
+
+      {packages.isSuccess &&
+        packageList.map((pkg) => (
+          <Accordion key={pkg.value} disableGutters>
+            <AccordionSummary expandIcon={<ExpandMore />}>
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                sx={{ width: '100%', pr: 1 }}
+                justifyContent="space-between"
+              >
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <LocalOffer fontSize="small" color="action" />
+                  <Typography variant="subtitle1">{pkg.value}</Typography>
+                  <Chip size="small" label={`${pkg.templateCount} templates`} />
+                </Stack>
+                <Stack direction="row" spacing={0.5} onClick={(e) => e.stopPropagation()}>
+                  <Tooltip title="Rename package">
+                    <IconButton
+                      size="small"
+                      onClick={() => {
+                        setRenameTarget(pkg)
+                        setRenameValue(pkg.value)
+                      }}
+                    >
+                      <DriveFileRenameOutline fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete package">
+                    <IconButton size="small" color="error" onClick={() => setDeleteTarget(pkg)}>
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+              </Stack>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Stack spacing={2}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Box sx={{ flexGrow: 1 }}>
+                    <CippAutoComplete
+                      size="small"
+                      multiple={false}
+                      creatable={false}
+                      label="Add an existing template to this package"
+                      placeholder="Select a template"
+                      value={addMemberTarget === pkg.value ? addMemberSelection : null}
+                      onChange={(value) => {
+                        setAddMemberTarget(pkg.value)
+                        setAddMemberSelection(value)
+                      }}
+                      options={getAddMemberOptions(pkg.value)}
+                      isFetching={allTemplates.isFetching}
+                    />
+                  </Box>
+                  <Button
+                    variant="outlined"
+                    startIcon={<Add />}
+                    disabled={
+                      addMemberTarget !== pkg.value ||
+                      !addMemberSelection?.value ||
+                      addMemberMutation.isPending
+                    }
+                    onClick={() =>
+                      addMemberMutation.mutate(
+                        {
+                          url: '/api/ExecSetPackageTag',
+                          data: { GUID: [addMemberSelection.value], Package: pkg.value },
+                        },
+                        { onSuccess: () => setAddMemberSelection(null) }
+                      )
+                    }
+                  >
+                    Add
+                  </Button>
+                </Stack>
+
+                <Divider />
+
+                <Stack spacing={1}>
+                  {pkg.templates.map((tpl) => (
+                    <Stack
+                      key={tpl.GUID}
+                      direction="row"
+                      alignItems="center"
+                      justifyContent="space-between"
+                    >
+                      <Typography variant="body2">{getDisplayName(tpl, typeConfig)}</Typography>
+                      <Tooltip title="Remove from package">
+                        <IconButton
+                          size="small"
+                          onClick={() =>
+                            removeMemberMutation.mutate({
+                              url: '/api/ExecSetPackageTag',
+                              data: { GUID: [tpl.GUID], Remove: true },
+                            })
+                          }
+                        >
+                          <Close fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Stack>
+                  ))}
+                </Stack>
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+
+      <CippApiResults apiObject={addMemberMutation} />
+      <CippApiResults apiObject={removeMemberMutation} />
+
+      {/* Rename package dialog */}
+      <Dialog fullWidth maxWidth="sm" open={!!renameTarget} onClose={() => setRenameTarget(null)}>
+        <DialogTitle>Rename Package</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Renames the package tag on all {renameTarget?.templateCount} member template(s).
+            </Typography>
+            <CippAutoComplete
+              size="small"
+              multiple={false}
+              creatable={true}
+              label="New package name"
+              placeholder="Type a new name, or pick an existing package to merge into it"
+              value={{ label: renameValue, value: renameValue }}
+              onChange={(value) => setRenameValue(value?.value ?? '')}
+              options={packageList
+                .filter((p) => p.value !== renameTarget?.value)
+                .map((p) => ({ label: p.value, value: p.value }))}
+            />
+          </Stack>
+          <CippApiResults apiObject={renameMutation} />
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={() => setRenameTarget(null)} startIcon={<Close />}>
+            Close
+          </Button>
+          <Button
+            variant="contained"
+            disabled={
+              !renameValue ||
+              renameValue === renameTarget?.value ||
+              renameMutation.isPending
+            }
+            onClick={() =>
+              renameMutation.mutate({
+                url: '/api/ExecSetPackageTag',
+                data: {
+                  GUID: renameTarget.templates.map((tpl) => tpl.GUID),
+                  Package: renameValue,
+                },
+              })
+            }
+          >
+            Rename
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete package dialog */}
+      <Dialog fullWidth maxWidth="sm" open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Delete Package</DialogTitle>
+        <DialogContent>
+          <Typography variant="body1">
+            Are you sure you want to delete the package '{deleteTarget?.value}'? Its{' '}
+            {deleteTarget?.templateCount} member template(s) are not deleted — they are just
+            removed from the package.
+          </Typography>
+          <CippApiResults apiObject={deleteMutation} />
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={() => setDeleteTarget(null)} startIcon={<Close />}>
+            Close
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            disabled={deleteMutation.isPending}
+            onClick={() =>
+              deleteMutation.mutate({
+                url: '/api/ExecSetPackageTag',
+                data: {
+                  GUID: deleteTarget.templates.map((tpl) => tpl.GUID),
+                  Remove: true,
+                },
+              })
+            }
+          >
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  )
+}

--- a/frontend/src/layouts/config.js
+++ b/frontend/src/layouts/config.js
@@ -1184,6 +1184,13 @@ export const nativeMenuItems = [
         scope: 'global',
       },
       {
+        title: 'Template Package Manager',
+        path: '/tools/template-packages',
+        roles: ['editor', 'admin', 'superadmin'],
+        permissions: ['Tenant.ConditionalAccess.*', 'Endpoint.MEM.*'],
+        scope: 'global',
+      },
+      {
         title: 'Scheduler',
         path: '/cipp/scheduler',
         docsPath: 'tools/scheduler',

--- a/frontend/src/pages/endpoint/MEM/list-templates/index.js
+++ b/frontend/src/pages/endpoint/MEM/list-templates/index.js
@@ -85,16 +85,23 @@ const Page = () => {
       data: { GUID: 'GUID' },
       fields: [
         {
-          type: 'textField',
+          type: 'select',
           name: 'Package',
           label: 'Package Name',
           required: true,
+          creatable: true,
           validators: {
             required: { value: true, message: 'Package name is required' },
           },
+          api: {
+            url: '/api/ListIntuneTemplates?mode=Tag',
+            queryKey: 'ListIntuneTemplates-tag-autcomplete',
+            labelField: 'label',
+            valueField: 'value',
+          },
         },
       ],
-      confirmText: 'Enter the package name to assign to the selected template(s).',
+      confirmText: 'Select an existing package, or type a new package name.',
       multiPost: true,
       icon: <LocalOffer />,
       color: 'info',

--- a/frontend/src/pages/tenant/conditional/list-template/index.js
+++ b/frontend/src/pages/tenant/conditional/list-template/index.js
@@ -51,16 +51,23 @@ const Page = () => {
       data: { GUID: "GUID" },
       fields: [
         {
-          type: "textField",
+          type: "select",
           name: "Package",
           label: "Package Name",
           required: true,
+          creatable: true,
           validators: {
             required: { value: true, message: "Package name is required" },
           },
+          api: {
+            url: "/api/ListCATemplates?mode=Tag",
+            queryKey: "ListCATemplates-tag-autocomplete",
+            labelField: "label",
+            valueField: "value",
+          },
         },
       ],
-      confirmText: "Enter the package name to assign to the selected template(s).",
+      confirmText: "Select an existing package, or type a new package name.",
       multiPost: true,
       icon: <LocalOffer />,
       color: "info",

--- a/frontend/src/pages/tools/template-packages/index.js
+++ b/frontend/src/pages/tools/template-packages/index.js
@@ -1,0 +1,25 @@
+import { Box, Container, Stack, Typography } from '@mui/material'
+import { Layout as DashboardLayout } from '../../../layouts/index.js'
+import { CippHead } from '../../../components/CippComponents/CippHead'
+import { CippTemplatePackageManager } from '../../../components/CippComponents/CippTemplatePackageManager'
+
+const Page = () => {
+  return (
+    <Box sx={{ flexGrow: 1, py: 4 }}>
+      <CippHead title="Template Package Manager" noTenant={true} />
+      <Container maxWidth="xl">
+        <Stack spacing={2}>
+          <Typography variant="h4">Template Package Manager</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Rename, delete, and manage the members of Conditional Access and Policy (Intune)
+            template packages.
+          </Typography>
+          <CippTemplatePackageManager />
+        </Stack>
+      </Container>
+    </Box>
+  )
+}
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
+export default Page


### PR DESCRIPTION
## Summary
- Add a shared Template Package Manager page (Tools > Template Package Manager) covering both CA Templates and Policy (Intune) Templates, since both already store "package" as the same free-text tag and expose the same `?mode=Tag` shape.
- Supports renaming a package (re-tags all members in one call, including merging into an existing package), deleting a package (untags members without deleting the templates), and adding/removing members — all via the existing `ExecSetPackageTag` endpoint.
- Swap the row-level "Add to package" free-text field on both template list pages for a dropdown sourced from `?mode=Tag`, so assigning to an existing package no longer relies on typing the exact name from memory.
- No backend changes — everything runs through existing endpoints.

Closes #443

## Test plan
- [ ] On CA Templates: use "Add to package" and confirm the dropdown lists existing packages, and typing a new name still creates one
- [ ] On Policy Templates: same check
- [ ] Tools > Template Package Manager: toggle between CA and Policy, expand a package, add an existing template, remove a member
- [ ] Rename a package and confirm all members show the new name; rename into an existing package's name and confirm it merges
- [ ] Delete a package and confirm its member templates remain in the regular template list, just untagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)