### PR TITLE
feat(mfa): add OTP verification and fix connector token caching

### DIFF
--- a/backend/Config/openapi.json
+++ b/backend/Config/openapi.json
@@ -16569,9 +16569,14 @@
                       "x-cipp-field-source": "backend"
                     },
                     "RowKey": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "SASUrl": {
+                      "x-cipp-field-source": "storage"
+                    },
+                    "SecretValue": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "severity": {
@@ -24189,6 +24194,7 @@
                       "x-cipp-field-source": "graph-entity"
                     },
                     "RowKey": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "samlMetadataUrl": {
@@ -24196,6 +24202,10 @@
                       "x-cipp-field-source": "graph-entity"
                     },
                     "SASUrl": {
+                      "x-cipp-field-source": "storage"
+                    },
+                    "SecretValue": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "serviceManagementReference": {
@@ -31917,7 +31927,7 @@
         "tags": [
           "Identity > Administration > Users"
         ],
-        "description": "Sends a test MFA push notification to a user's authenticator app and reports whether it was approved. Used to confirm a user's MFA registration works. This causes a real prompt on the user's device.",
+        "description": "Sends a test MFA push notification to a user's authenticator app and reports whether it was approved, or - when an OTP code is supplied - verifies that typed code without sending a push. Used to confirm a user's MFA registration works. The push path causes a real prompt on the user's device.",
         "requestBody": {
           "required": true,
           "content": {
@@ -31925,6 +31935,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "OTP": {
+                    "type": "string",
+                    "description": "When an OTP code is supplied we verify that code instead of sending a push notification."
+                  },
                   "TenantFilter": {
                     "type": "string"
                   },
@@ -31946,10 +31960,366 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "description": "Derived from the fields the endpoint selects onto each record. The response may carry more; these are the ones known to exist.",
+                  "description": "Derived from the Microsoft Graph entity it queries, and the fields the endpoint selects onto each record. This endpoint returns the Graph response as-is without selecting fields, so these are the properties the entity CAN carry (x-cipp-field-source: graph-entity) rather than a proven projection - Graph returns a default subset unless asked otherwise.",
                   "properties": {
+                    "aboutMe": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "accountEnabled": {
+                      "type": "boolean",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "ageGroup": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "assignedLicenses": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "assignedPlans": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "authorizationInfo": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "birthday": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "businessPhones": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "city": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "cloudLicensing": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "cloudRealtimeCommunicationInfo": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "companyName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "consentProvidedForMinor": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "country": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "createdDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "creationType": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "customSecurityAttributes": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "deletedDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "department": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "deviceEnrollmentLimit": {
+                      "type": "integer",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "deviceKeys": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "employeeHireDate": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "employeeId": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "employeeLeaveDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "employeeOrgData": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "employeeType": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "externalUserState": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "externalUserStateChangeDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "faxNumber": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "givenName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "hireDate": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "id": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "identities": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "identityGovernance": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "identityParentId": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "imAddresses": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "infoCatalogs": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "interests": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "isLicenseReconciliationNeeded": {
+                      "type": "boolean",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "isManagementRestricted": {
+                      "type": "boolean",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "isResourceAccount": {
+                      "type": "boolean",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "jobTitle": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "lastPasswordChangeDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "legalAgeGroupClassification": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "licenseAssignmentStates": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "mail": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "mailboxSettings": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "mailNickname": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "mobilePhone": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "mySite": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "officeLocation": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesDistinguishedName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesDomainName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesExtensionAttributes": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesImmutableId": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesLastSyncDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesProvisioningErrors": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesSamAccountName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesSecurityIdentifier": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesSipInfo": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesSyncEnabled": {
+                      "type": "boolean",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "onPremisesUserPrincipalName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "otherMails": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "passwordPolicies": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "passwordProfile": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "pastProjects": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "postalCode": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "preferredDataLocation": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "preferredLanguage": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "preferredName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "print": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "provisionedPlans": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "proxyAddresses": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "refreshTokensValidFromDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "responsibilities": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
                     "Results": {
                       "x-cipp-field-source": "backend"
+                    },
+                    "schools": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "securityIdentifier": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "serviceProvisioningErrors": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "showInAddressList": {
+                      "type": "boolean",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "signInActivity": {
+                      "type": "object",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "signInSessionsValidFromDateTime": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "skills": {
+                      "type": "array",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "state": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "streetAddress": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "surname": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "usageLocation": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "userPrincipalName": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
+                    },
+                    "userType": {
+                      "type": "string",
+                      "x-cipp-field-source": "graph-entity"
                     }
                   }
                 }
@@ -35994,9 +36364,14 @@
                       "x-cipp-field-source": "storage"
                     },
                     "RowKey": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "SASUrl": {
+                      "x-cipp-field-source": "storage"
+                    },
+                    "SecretValue": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "TenantId": {
@@ -36421,9 +36796,14 @@
                       "x-cipp-field-source": "backend"
                     },
                     "RowKey": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "SASUrl": {
+                      "x-cipp-field-source": "storage"
+                    },
+                    "SecretValue": {
+                      "type": "string",
                       "x-cipp-field-source": "storage"
                     },
                     "TenantId": {

--- a/backend/Modules/CIPPCore/Public/GraphHelper/New-CIPPMFAConnectorToken.ps1
+++ b/backend/Modules/CIPPCore/Public/GraphHelper/New-CIPPMFAConnectorToken.ps1
@@ -1,0 +1,132 @@
+function New-CIPPMFAConnectorToken {
+    <#
+    .SYNOPSIS
+        Returns an access token for the Azure MFA StrongAuthenticationService connector.
+
+    .DESCRIPTION
+        The connector token is minted from a client secret on the tenant's "Azure Multi-Factor Auth Client"
+        service principal. Provisioning that secret is expensive (it may adjust the tenant's app management
+        policy and add a credential), so a long-lived secret is cached per tenant - in Key Vault in
+        production, in the DevSecrets table in local development - and reused. A cached secret is only
+        reprovisioned when it is missing or the token exchange fails (e.g. it has expired). The provisioned
+        secret is capped at 180 days; refresh happens automatically on the next call after it lapses.
+
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'The connector secret must be written to Key Vault as a SecureString and is encrypted at rest.')]
+    param(
+        [Parameter(Mandatory = $true)]
+        $TenantFilter,
+        $Headers,
+        [switch]$ForceProvision
+    )
+
+    $MFAAppID = '981f26a1-7f43-403b-a875-f8b09b8cd720'
+    $ConnectorResource = 'https://adnotifications.windowsazure.com/StrongAuthenticationService.svc/Connector'
+    $TokenUri = "https://login.microsoftonline.com/$TenantFilter/oauth2/token"
+
+    # Stable, Key-Vault-safe secret name keyed on the tenant GUID (domains contain dots, which KV rejects).
+    $GuidPattern = '^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$'
+    $TenantId = if ($TenantFilter -match $GuidPattern) { $TenantFilter } else { (Get-Tenants -TenantFilter $TenantFilter).customerId }
+    if (-not $TenantId) { $TenantId = $TenantFilter }
+    $SecretName = "NPS-$TenantId"
+    $IsDevMode = $env:AzureWebJobsStorage -eq 'UseDevelopmentStorage=true' -or $env:NonLocalHostAzurite -eq 'true'
+
+    # --- dev-aware cached-secret storage -----------------------------------------------------------
+    function Get-StoredSecret {
+        if ($IsDevMode) {
+            $Table = Get-CIPPTable -tablename 'DevSecrets'
+            $Row = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq 'NPSSecret' and RowKey eq '$TenantId'"
+            return $Row.SecretValue
+        }
+        return Get-CippKeyVaultSecret -Name $SecretName -AsPlainText -ErrorAction SilentlyContinue
+    }
+    function Set-StoredSecret {
+        param($Value)
+        if ($IsDevMode) {
+            $Table = Get-CIPPTable -tablename 'DevSecrets'
+            $Entity = @{ PartitionKey = 'NPSSecret'; RowKey = [string]$TenantId; SecretValue = [string]$Value }
+            Add-CIPPAzDataTableEntity @Table -Entity $Entity -Force
+        } else {
+            $null = Set-CippKeyVaultSecret -Name $SecretName -SecretValue (ConvertTo-SecureString -String $Value -AsPlainText -Force)
+        }
+    }
+
+    # Keep retrying the token exchange while Microsoft finishes provisioning a freshly added secret.
+    function Get-ConnectorToken {
+        param($Secret, [int]$MaxAttempts = 1)
+        $ClientBody = @{
+            resource      = $ConnectorResource
+            client_id     = $MFAAppID
+            client_secret = $Secret
+            grant_type    = 'client_credentials'
+            scope         = 'openid'
+        }
+        for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+            try {
+                return (Invoke-RestMethod -Method Post -Uri $TokenUri -Body $ClientBody -ErrorAction Stop).access_token
+            } catch {
+                if ($Attempt -ge $MaxAttempts) { throw }
+                Start-Sleep 1
+            }
+        }
+    }
+
+    # 1. Reuse the cached secret when present (single token attempt - it is already active).
+    if (-not $ForceProvision) {
+        $CachedSecret = Get-StoredSecret
+        if ($CachedSecret) {
+            try {
+                return [pscustomobject]@{ AccessToken = (Get-ConnectorToken -Secret $CachedSecret) }
+            } catch {
+                # Cached secret is expired or revoked - fall through and reprovision.
+                Write-Information "Cached MFA connector secret for $TenantId failed token exchange; reprovisioning."
+            }
+        }
+    }
+
+    # 2. Provision a fresh long-lived secret on the MFA client service principal.
+    $SPResult = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/servicePrincipals?`$top=999&`$select=id,appId" -tenantid $TenantFilter -AsApp $true
+    $SPID = ($SPResult | Where-Object { $_.appId -eq $MFAAppID }).id
+    if (!$SPID) {
+        $SPBody = [pscustomobject]@{ appId = $MFAAppID } | ConvertTo-Json -Depth 5
+        $SPID = (New-GraphPostRequest -uri 'https://graph.microsoft.com/v1.0/servicePrincipals' -tenantid $TenantFilter -type POST -body $SPBody -AsApp $true).id
+    }
+
+    try {
+        $PolicyUpdate = Update-AppManagementPolicy -TenantFilter $TenantFilter -ApplicationId $MFAAppID -ServicePrincipal
+        Write-Information $PolicyUpdate.PolicyAction
+    } catch {
+        Write-Information "Failed to update app management policy: $($_.Exception.Message)"
+    }
+
+    $PassReqBody = @{
+        'passwordCredential' = @{
+            'displayName'   = 'CIPP MFA Connector'
+            'endDateTime'   = $((Get-Date).AddDays(180))
+            'startDateTime' = $((Get-Date).AddMinutes(-5))
+        }
+    } | ConvertTo-Json -Depth 5
+
+    $NewSecret = $null
+    $AddSecretError = $null
+    for ($Attempt = 1; $Attempt -le 5; $Attempt++) {
+        try {
+            $NewSecret = (New-GraphPostRequest -uri "https://graph.microsoft.com/v1.0/servicePrincipals/$SPID/addPassword" -tenantid $TenantFilter -type POST -body $PassReqBody -AsApp $true).secretText
+            break
+        } catch {
+            $AddSecretError = $_.Exception.Message
+            if ($Attempt -lt 5) { Start-Sleep -Seconds 4 }
+        }
+    }
+    if (-not $NewSecret) {
+        throw "Failed to add a credential to the MFA service principal. The tenant's app management policy may be blocking credential creation for this app. Error: $AddSecretError"
+    }
+
+    $AccessToken = Get-ConnectorToken -Secret $NewSecret -MaxAttempts 20
+    Set-StoredSecret -Value $NewSecret
+
+    return [pscustomobject]@{ AccessToken = $AccessToken }
+}

--- a/backend/Modules/CIPPCore/Public/GraphHelper/Update-AppManagementPolicy.ps1
+++ b/backend/Modules/CIPPCore/Public/GraphHelper/Update-AppManagementPolicy.ps1
@@ -19,8 +19,14 @@ function Update-AppManagementPolicy {
         $headers,
         # Skip the password-addition exemption (leave secrets blocked, exempt only the SAM certificate).
         # Defaults on only for the SAM app in certificate mode; other apps still get the password exemption.
-        [bool]$CertificateOnly = ([bool]$env:CertificateAuthMode -and ($ApplicationId -eq $env:ApplicationID))
+        [bool]$CertificateOnly = ([bool]$env:CertificateAuthMode -and ($ApplicationId -eq $env:ApplicationID)),
+        # Target a service principal instead of an application registration. First-party apps (e.g. the
+        # Azure MFA client) exist only as a service principal in the tenant, so the exemption must be
+        # resolved and assigned via servicePrincipals rather than applications.
+        [switch]$ServicePrincipal
     )
+
+    $TargetResource = if ($ServicePrincipal) { 'servicePrincipals' } else { 'applications' }
 
     try {
         # Create bulk request to fetch both policies at once
@@ -38,7 +44,7 @@ function Update-AppManagementPolicy {
             @{
                 id     = 'appRegistration'
                 method = 'GET'
-                url    = "applications(appId='$ApplicationId')?`$select=id,appId,displayName"
+                url    = "$TargetResource(appId='$ApplicationId')?`$select=id,appId,displayName"
             }
         )
 
@@ -171,23 +177,13 @@ function Update-AppManagementPolicy {
             if (-not $CIPPHasExemption) {
                 # Need to create or update a policy for CIPP
                 try {
-                    # Key restrictions are always disabled so the SAM certificate can register. Password
-                    # restrictions are disabled only for secret installs; certificate mode leaves them blocked.
-                    $Restrictions = @{
-                        keyCredentials = @(
-                            @{
-                                restrictionType                     = 'asymmetricKeyLifetime'
-                                state                               = 'disabled'
-                                restrictForAppsCreatedAfterDateTime = '0001-01-01T00:00:00Z'
-                            }
-                            @{
-                                restrictionType                     = 'trustedCertificateAuthority'
-                                state                               = 'disabled'
-                                restrictForAppsCreatedAfterDateTime = '0001-01-01T00:00:00Z'
-                            }
-                        )
-                    }
-                    if (-not $CertificateOnly) {
+                    # Only exempt the restriction types the default policy actually enforces, so the
+                    # exemption body never carries a restriction Graph would reject as unneeded or malformed.
+                    $Restrictions = @{}
+
+                    # Password restrictions are disabled only for secret installs; certificate mode leaves
+                    # them blocked so secrets stay disallowed.
+                    if (-not $CertificateOnly -and $DefaultPolicyBlocksCredentials) {
                         $Restrictions.passwordCredentials = @(
                             @{
                                 restrictionType                     = 'passwordAddition'
@@ -196,6 +192,29 @@ function Update-AppManagementPolicy {
                             }
                             @{
                                 restrictionType                     = 'symmetricKeyAddition'
+                                state                               = 'disabled'
+                                restrictForAppsCreatedAfterDateTime = '0001-01-01T00:00:00Z'
+                            }
+                        )
+                    }
+
+                    # Key restrictions are disabled so the SAM certificate can register. asymmetricKeyLifetime
+                    # is a lifetime-type restriction; Graph rejects the whole policy body unless it carries a
+                    # valid maxLifetime duration, even when the restriction is disabled. Echo the tenant
+                    # default's value when present, otherwise fall back to a conservative duration.
+                    if ($DefaultPolicyBlocksKeyCredentials) {
+                        $AsymmetricKeyMaxLifetime = ($DefaultKeyRestrictions | Where-Object { $_.restrictionType -eq 'asymmetricKeyLifetime' } | Select-Object -First 1).maxLifetime
+                        if (-not $AsymmetricKeyMaxLifetime) { $AsymmetricKeyMaxLifetime = 'P730D' }
+
+                        $Restrictions.keyCredentials = @(
+                            @{
+                                restrictionType                     = 'asymmetricKeyLifetime'
+                                state                               = 'disabled'
+                                restrictForAppsCreatedAfterDateTime = '0001-01-01T00:00:00Z'
+                                maxLifetime                         = $AsymmetricKeyMaxLifetime
+                            }
+                            @{
+                                restrictionType                     = 'trustedCertificateAuthority'
                                 state                               = 'disabled'
                                 restrictForAppsCreatedAfterDateTime = '0001-01-01T00:00:00Z'
                             }
@@ -217,12 +236,21 @@ function Update-AppManagementPolicy {
                         $null = New-GraphPostRequest -uri "https://graph.microsoft.com/v1.0/policies/appManagementPolicies/$($ExistingExemptionPolicy.id)" -type PATCH -body ($PolicyBody | ConvertTo-Json -Depth 10) -asapp $true -NoAuthCheck $true -tenantid $TenantFilter -headers $headers
 
                         if ($CIPPApp.id) {
-                            # Assign existing policy to CIPP-SAM application
+                            # Assign existing policy to the target app registration or service principal
                             $AssignBody = @{
                                 '@odata.id' = "https://graph.microsoft.com/beta/policies/appManagementPolicies/$($ExistingExemptionPolicy.id)"
                             }
-                            $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/applications/$($CIPPApp.id)/appManagementPolicies/`$ref" -type POST -body ($AssignBody | ConvertTo-Json) -asapp $true -NoAuthCheck $true -tenantid $TenantFilter -headers $headers
-                            $PolicyAction = "Updated and assigned existing policy $($ExistingExemptionPolicy.id) to CIPP-SAM"
+                            try {
+                                $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/$TargetResource/$($CIPPApp.id)/appManagementPolicies/`$ref" -type POST -body ($AssignBody | ConvertTo-Json) -asapp $true -NoAuthCheck $true -tenantid $TenantFilter -headers $headers
+                                $PolicyAction = "Updated and assigned existing policy $($ExistingExemptionPolicy.id) to CIPP-SAM"
+                            } catch {
+                                # A duplicate reference means the policy is already assigned - that is the desired end state, not a failure.
+                                if ($_.Exception.Message -match 'already exist') {
+                                    $PolicyAction = "Existing policy $($ExistingExemptionPolicy.id) already assigned to CIPP-SAM"
+                                } else {
+                                    throw
+                                }
+                            }
                             $CIPPAppPolicyId = $ExistingExemptionPolicy.id
                             $CIPPAppTargeted = $true
                         } else {
@@ -233,12 +261,21 @@ function Update-AppManagementPolicy {
                         $CreatedPolicy = New-GraphPostRequest -uri 'https://graph.microsoft.com/v1.0/policies/appManagementPolicies' -type POST -body ($PolicyBody | ConvertTo-Json -Depth 10) -asapp $true -NoAuthCheck $true -tenantid $TenantFilter -headers $headers
 
                         if ($CIPPApp.id) {
-                            # Assign policy to CIPP-SAM application using beta endpoint
+                            # Assign policy to the target app registration or service principal using beta endpoint
                             $AssignBody = @{
                                 '@odata.id' = "https://graph.microsoft.com/beta/policies/appManagementPolicies/$($CreatedPolicy.id)"
                             }
-                            $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/applications/$($CIPPApp.id)/appManagementPolicies/`$ref" -type POST -body ($AssignBody | ConvertTo-Json) -asapp $true -NoAuthCheck $true -tenantid $TenantFilter -headers $headers
-                            $PolicyAction = "Created new policy $($CreatedPolicy.id) and assigned to CIPP-SAM"
+                            try {
+                                $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/$TargetResource/$($CIPPApp.id)/appManagementPolicies/`$ref" -type POST -body ($AssignBody | ConvertTo-Json) -asapp $true -NoAuthCheck $true -tenantid $TenantFilter -headers $headers
+                                $PolicyAction = "Created new policy $($CreatedPolicy.id) and assigned to CIPP-SAM"
+                            } catch {
+                                # A duplicate reference means the policy is already assigned - that is the desired end state, not a failure.
+                                if ($_.Exception.Message -match 'already exist') {
+                                    $PolicyAction = "Created new policy $($CreatedPolicy.id); already assigned to CIPP-SAM"
+                                } else {
+                                    throw
+                                }
+                            }
                             $CIPPAppPolicyId = $CreatedPolicy.id
                             $CIPPAppTargeted = $true
                         } else {

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecSendPush.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ExecSendPush.ps1
@@ -5,7 +5,7 @@ function Invoke-ExecSendPush {
     .ROLE
         Identity.User.Read
     .DESCRIPTION
-        Sends a test MFA push notification to a user's authenticator app and reports whether it was approved. Used to confirm a user's MFA registration works. This causes a real prompt on the user's device.
+        Sends a test MFA push notification to a user's authenticator app and reports whether it was approved, or - when an OTP code is supplied - verifies that typed code without sending a push. Used to confirm a user's MFA registration works. The push path causes a real prompt on the user's device.
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
@@ -13,117 +13,113 @@ function Invoke-ExecSendPush {
     $APIName = $Request.Params.CIPPEndpoint
     $TenantFilter = $Request.body.TenantFilter
     $UserEmail = $Request.body.UserEmail
-    $MFAAppID = '981f26a1-7f43-403b-a875-f8b09b8cd720'
+    # When an OTP code is supplied we verify that code instead of sending a push notification.
+    $OTP = $Request.body.OTP
+    $VerifyOtp = -not [string]::IsNullOrWhiteSpace($OTP)
 
-    # Function to keep trying to get the access token while we wait for MS to actually set the temp password
-    function Get-ClientAccess {
-        param(
-            $uri,
-            $body,
-            $count = 1
-        )
-        try {
-            $ClientToken = Invoke-RestMethod -Method post -Uri $uri -Body $body -ea stop
-        } catch {
-            if ($count -lt 20) {
+    # Defaults so every path returns a well-formed state, even when an early step fails.
+    $State = 'error'
+    $Body = 'An unknown error occurred while processing the MFA request.'
+    $obj = $null
+    $ResultValue = $null
 
-                $count++
-                Start-Sleep 1
-                $ClientToken = Get-ClientAccess -uri $uri -body $body -count $count
-            } else {
-                throw "Could not get Client Token: $_"
-            }
-        }
-        return $ClientToken
-    }
-
-
-    # Get all service principals
-    $SPResult = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/servicePrincipals?`$top=999&`$select=id,appId" -tenantid $TenantFilter -AsApp $true
-
-    # Check if we have one for the MFA App
-    $SPID = ($SPResult | Where-Object { $_.appId -eq $MFAAppID }).id
-
-    # Create a service principal if needed
-    if (!$SPID) {
-
-        $SPBody = [pscustomobject]@{
-            appId = $MFAAppID
-        } | ConvertTo-Json -Depth 5
-        $SPID = (New-GraphPostRequest -uri 'https://graph.microsoft.com/v1.0/servicePrincipals' -tenantid $TenantFilter -type POST -body $SPBody -AsApp $true).id
-    }
-
+    # Mint a connector token (this provisions a temporary secret on the MFA client service principal).
     try {
-        $PolicyUpdate = Update-AppManagementPolicy -TenantFilter $TenantFilter -ApplicationId $MFAAppID
-        Write-Information $PolicyUpdate.PolicyAction
+        $Connector = New-CIPPMFAConnectorToken -TenantFilter $TenantFilter -Headers $Request.Headers
     } catch {
-        Write-Information "Failed to update app management policy: $($_.Exception.Message)"
+        $Body = $_.Exception.Message
+        Write-LogMessage -headers $Request.Headers -API $APINAME -message "Failed MFA request for $UserEmail - $Body" -Sev 'Error'
+        return ([HttpResponseContext]@{
+                StatusCode = [HttpStatusCode]::OK
+                Body       = [pscustomobject]@{'Results' = @{ resultText = $Body; state = 'error' } }
+            })
     }
 
-    $PassReqBody = @{
-        'passwordCredential' = @{
-            'displayName'   = 'MFA Temporary Password'
-            'endDateTime'   = $((Get-Date).AddMinutes(5))
-            'startDateTime' = $((Get-Date).AddMinutes(-5))
-        }
-    } | ConvertTo-Json -Depth 5
+    $ClientHeaders = @{ 'Authorization' = "Bearer $($Connector.AccessToken)" }
 
-    $TempPass = (New-GraphPostRequest -uri "https://graph.microsoft.com/v1.0/servicePrincipals/$SPID/addPassword" -tenantid $TenantFilter -type POST -body $PassReqBody -AsApp $true).secretText
+    # Policy: a typed code is only accepted when the user has no Microsoft Authenticator registered. When the
+    # Authenticator is present the stronger interactive push is required, so a TOTP code is refused.
+    $HasAuthenticator = $false
+    if ($VerifyOtp) {
+        $UserMethods = New-GraphGetRequest -uri "https://graph.microsoft.com/beta/users/$UserEmail/authentication/methods" -tenantid $TenantFilter
+        $HasAuthenticator = @($UserMethods).'@odata.type' -contains '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
+    }
 
-    # Give it a chance to apply
-    #Start-Sleep 5
-
-    # Generate the XML for the push request
-    $XML = @"
+    if ($VerifyOtp -and $HasAuthenticator) {
+        $Body = 'This user has Microsoft Authenticator registered, so a push notification is required instead of a typed code.'
+        $State = 'error'
+    } elseif ($VerifyOtp) {
+        # OTP verification is a two-call handshake against the modernized StrongAuthenticationService host
+        # (the adnotifications host only supports push): Begin with SyncCall=false so no push is sent, then
+        # End with the typed code in AdditionalAuthData, keyed to the returned SessionId.
+        $StrongAuthUri = 'https://strongauthenticationservice.auth.microsoft.com/StrongAuthenticationService.svc/Connector'
+        $ContextId = (New-Guid).Guid
+        $BeginXML = @"
 <BeginTwoWayAuthenticationRequest>
 <Version>1.0</Version>
 <UserPrincipalName>$UserEmail</UserPrincipalName>
-<Lcid>en-us</Lcid><AuthenticationMethodProperties xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:KeyValueOfstringstring><a:Key>OverrideVoiceOtp</a:Key><a:Value>false</a:Value></a:KeyValueOfstringstring></AuthenticationMethodProperties><ContextId>69ff05bf-eb61-47f7-a70e-e7d77b6d47d0</ContextId>
-<SyncCall>true</SyncCall><RequireUserMatch>true</RequireUserMatch><CallerName>radius</CallerName><CallerIP>UNKNOWN:</CallerIP></BeginTwoWayAuthenticationRequest>
+<Lcid>en-us</Lcid><AuthenticationMethodProperties xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:KeyValueOfstringstring><a:Key>OverrideVoiceOtp</a:Key><a:Value>false</a:Value></a:KeyValueOfstringstring></AuthenticationMethodProperties><ContextId>$ContextId</ContextId>
+<SyncCall>false</SyncCall><RequireUserMatch>true</RequireUserMatch><CallerName>radius</CallerName><CallerIP>UNKNOWN:</CallerIP></BeginTwoWayAuthenticationRequest>
 "@
+        $BeginResp = Invoke-RestMethod -Uri "$StrongAuthUri/BeginTwoWayAuthentication" -Method POST -Headers $ClientHeaders -Body $BeginXML -ContentType 'application/xml'
+        $SessionId = $BeginResp.BeginTwoWayAuthenticationResponse.SessionId
 
-    # Request to get client token
-    $body = @{
-        'resource'      = 'https://adnotifications.windowsazure.com/StrongAuthenticationService.svc/Connector'
-        'client_id'     = $MFAAppID
-        'client_secret' = $TempPass
-        'grant_type'    = 'client_credentials'
-        'scope'         = 'openid'
-    }
+        if ($SessionId) {
+            $EndXML = @"
+<EndTwoWayAuthenticationRequest>
+<Version>1.0</Version>
+<SessionId>$SessionId</SessionId>
+<AdditionalAuthData>$OTP</AdditionalAuthData>
+</EndTwoWayAuthenticationRequest>
+"@
+            $obj = Invoke-RestMethod -Uri "$StrongAuthUri/EndTwoWayAuthentication" -Method POST -Headers $ClientHeaders -Body $EndXML -ContentType 'application/xml'
+            $ResultValue = $obj.EndTwoWayAuthenticationResponse.Result.Value
 
-    # Attempt to get a token using the temp password
-    $ClientUri = "https://login.microsoftonline.com/$TenantFilter/oauth2/token"
-    try {
-        $ClientToken = Get-ClientAccess -Uri $ClientUri -Body $body
-    } catch {
-        $Body = 'Failed to create temporary token for MFA Application. Error: ' + $_.Exception.Message
-    }
-
-    # If we got a token send a push
-    if ($ClientToken) {
-
-        $ClientHeaders = @{ 'Authorization' = "Bearer $($ClientToken.access_token)" }
-
-        $obj = Invoke-RestMethod -Uri 'https://adnotifications.windowsazure.com/StrongAuthenticationService.svc/Connector//BeginTwoWayAuthentication' -Method POST -Headers $ClientHeaders -Body $XML -ContentType 'application/xml'
-
-        if ($obj.BeginTwoWayAuthenticationResponse.result) {
-            $Body = "Received an MFA confirmation: $($obj.BeginTwoWayAuthenticationResponse.result.value | Out-String)"
-            $State = 'success'
-        }
-        if ($obj.BeginTwoWayAuthenticationResponse.AuthenticationResult -ne $true) {
-            $Body = "Authentication Failed! Does the user have Push/Phone call MFA configured? ErrorCode: $($obj.BeginTwoWayAuthenticationResponse.result.value | Out-String)"
+            if ($obj.EndTwoWayAuthenticationResponse.AuthenticationResult -eq $true -and $ResultValue -eq 'Success') {
+                $Body = 'The MFA code was verified successfully.'
+                $State = 'success'
+            } elseif ($ResultValue -eq 'OathCodeIncorrect') {
+                $Body = 'The MFA code was incorrect. Please check the code and try again.'
+                $State = 'error'
+            } else {
+                $Body = "MFA code verification failed: $ResultValue"
+                $State = 'error'
+            }
+        } else {
+            $Body = 'Could not start an MFA verification session. Does the user have an authenticator (OTP) method registered?'
             $State = 'error'
         }
+    } else {
+        # Push notification: SyncCall=true blocks until the user approves or denies on their device.
+        # AuthenticationMethodId forces the Authenticator push so it prompts even when the user's default
+        # method is something else (e.g. an OATH code); otherwise the connector targets the default and
+        # returns immediately without a prompt.
+        $ContextId = (New-Guid).Guid
+        $XML = @"
+<BeginTwoWayAuthenticationRequest>
+<Version>1.0</Version>
+<UserPrincipalName>$UserEmail</UserPrincipalName>
+<Lcid>en-us</Lcid><AuthenticationMethodId>PhoneAppNotification</AuthenticationMethodId><AuthenticationMethodProperties xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"><a:KeyValueOfstringstring><a:Key>OverrideVoiceOtp</a:Key><a:Value>false</a:Value></a:KeyValueOfstringstring></AuthenticationMethodProperties><ContextId>$ContextId</ContextId>
+<SyncCall>true</SyncCall><RequireUserMatch>true</RequireUserMatch><CallerName>radius</CallerName><CallerIP>UNKNOWN:</CallerIP></BeginTwoWayAuthenticationRequest>
+"@
+        $obj = Invoke-RestMethod -Uri 'https://adnotifications.windowsazure.com/StrongAuthenticationService.svc/Connector//BeginTwoWayAuthentication' -Method POST -Headers $ClientHeaders -Body $XML -ContentType 'application/xml'
+        $ResultValue = $obj.BeginTwoWayAuthenticationResponse.result.value
 
+        if ($obj.BeginTwoWayAuthenticationResponse.AuthenticationResult -eq $true) {
+            $Body = "Received an MFA confirmation: $($ResultValue | Out-String)"
+            $State = 'success'
+        } else {
+            $Body = "Authentication Failed! Does the user have Push/Phone call MFA configured? ErrorCode: $($ResultValue | Out-String)"
+            $State = 'error'
+        }
     }
 
     $Results = [pscustomobject]@{'Results' = @{ resultText = $Body; state = $State } }
-    Write-LogMessage -headers $Request.Headers -API $APINAME -message "Sent push request to $UserEmail - Result: $($obj.BeginTwoWayAuthenticationResponse.result.value | Out-String)" -Sev 'Info'
+    $LogAction = if ($VerifyOtp) { 'Verified MFA code' } else { 'Sent push request' }
+    Write-LogMessage -headers $Request.Headers -API $APINAME -message "$LogAction for $UserEmail - Result: $($ResultValue | Out-String)" -Sev 'Info'
 
     return ([HttpResponseContext]@{
             StatusCode = [HttpStatusCode]::OK
             Body       = $Results
         })
-
-
 }

--- a/backend/Tests/GraphHelper/New-CIPPMFAConnectorToken.Tests.ps1
+++ b/backend/Tests/GraphHelper/New-CIPPMFAConnectorToken.Tests.ps1
@@ -1,0 +1,63 @@
+# New-CIPPMFAConnectorToken caches a long-lived connector secret per tenant so the expensive provisioning
+# (adding a credential to the MFA client SP) only runs when no usable cached secret exists. These tests pin
+# that a cached secret is reused without provisioning, and that a cache miss provisions and stores one.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    function New-GraphGetRequest { param($uri, $tenantid, $AsApp) }
+    function New-GraphPostRequest { param($uri, $tenantid, $type, $body, $AsApp) }
+    function Update-AppManagementPolicy { param($TenantFilter, $ApplicationId, [switch]$ServicePrincipal) }
+    function Get-CIPPTable { param($tablename) }
+    function Get-CIPPAzDataTableEntity { param($Filter) }
+    function Add-CIPPAzDataTableEntity { param($Entity, [switch]$Force) }
+    function Get-Tenants { param($TenantFilter) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/GraphHelper/New-CIPPMFAConnectorToken.ps1')
+
+    $script:TenantGuid = '11111111-1111-1111-1111-111111111111'
+    $script:MFAAppID = '981f26a1-7f43-403b-a875-f8b09b8cd720'
+}
+
+Describe 'New-CIPPMFAConnectorToken secret caching' {
+    BeforeEach {
+        # Force the dev (DevSecrets table) storage path so the assertions are deterministic.
+        $env:NonLocalHostAzurite = 'true'
+        Mock Get-CIPPTable { @{ Context = 'stub' } }
+        Mock Add-CIPPAzDataTableEntity {}
+        Mock Update-AppManagementPolicy {}
+        # Token exchange
+        Mock Invoke-RestMethod { [pscustomobject]@{ access_token = 'TOKEN123' } }
+        # SP lookup returns the MFA client SP so provisioning finds it (no SP create)
+        Mock New-GraphGetRequest { @([pscustomobject]@{ id = 'mfa-sp-id'; appId = $script:MFAAppID }) }
+        # addPassword returns a fresh secret
+        Mock New-GraphPostRequest { [pscustomobject]@{ secretText = 'NEWSECRET' } }
+    }
+
+    AfterEach {
+        Remove-Item env:NonLocalHostAzurite -ErrorAction SilentlyContinue
+    }
+
+    It 'reuses a cached secret without provisioning' {
+        Mock Get-CIPPAzDataTableEntity { [pscustomobject]@{ SecretValue = 'CACHEDSECRET' } }
+
+        $result = New-CIPPMFAConnectorToken -TenantFilter $script:TenantGuid
+
+        $result.AccessToken | Should -Be 'TOKEN123'
+        # No provisioning: neither the SP lookup nor addPassword should run on a cache hit.
+        Should -Not -Invoke New-GraphGetRequest
+        Should -Not -Invoke New-GraphPostRequest
+        Should -Not -Invoke Add-CIPPAzDataTableEntity
+    }
+
+    It 'provisions and stores a new secret on a cache miss' {
+        Mock Get-CIPPAzDataTableEntity { $null }
+
+        $result = New-CIPPMFAConnectorToken -TenantFilter $script:TenantGuid
+
+        $result.AccessToken | Should -Be 'TOKEN123'
+        # addPassword is the only New-GraphPostRequest here (the SP already exists), and the new secret is cached.
+        Should -Invoke New-GraphPostRequest -Times 1 -Exactly
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -Exactly
+    }
+}

--- a/backend/Tests/GraphHelper/Update-AppManagementPolicy.ExemptionBody.Tests.ps1
+++ b/backend/Tests/GraphHelper/Update-AppManagementPolicy.ExemptionBody.Tests.ps1
@@ -1,0 +1,136 @@
+# Update-AppManagementPolicy builds the "CIPP Exemption Policy" body that Graph must accept. Graph
+# rejects the whole appManagementPolicy create when it carries a restriction type it does not need, or
+# a lifetime-type restriction (asymmetricKeyLifetime) without a valid maxLifetime. These tests pin the
+# emitted body so a hardened tenant's default policy no longer blocks the exemption.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    function New-GraphBulkRequest { param($Requests, $NoAuthCheck, $asapp, $tenantid, $headers) }
+    function New-GraphPostRequest { param($uri, $type, $body, $asapp, $NoAuthCheck, $tenantid, $headers) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/GraphHelper/Update-AppManagementPolicy.ps1')
+
+    $script:AppId = '981f26a1-7f43-403b-a875-f8b09b8cd720'
+
+    # Builds the three-item bulk response the function expects, with the caller-supplied default policy
+    # restrictions and an empty app-policy list (no existing exemption, app not yet targeted).
+    function New-BulkResponse {
+        param($PasswordRestrictions = @(), $KeyRestrictions = @())
+        @(
+            [PSCustomObject]@{ id = 'defaultPolicy'; body = [PSCustomObject]@{
+                    applicationRestrictions = [PSCustomObject]@{
+                        passwordCredentials = $PasswordRestrictions
+                        keyCredentials      = $KeyRestrictions
+                    }
+                }
+            }
+            [PSCustomObject]@{ id = 'appPolicies'; body = [PSCustomObject]@{ value = @() } }
+            [PSCustomObject]@{ id = 'appRegistration'; body = [PSCustomObject]@{ id = 'mfa-app-object-id'; appId = $script:AppId; displayName = 'Azure Multi-Factor Auth Client' } }
+        )
+    }
+}
+
+Describe 'Update-AppManagementPolicy exemption body' {
+    BeforeEach {
+        $script:CreateBody = $null
+        $script:AssignUri = $null
+        # Certificate-only mode is exercised in the sibling CertificateOnly suite; pin it off here so the
+        # body-shape assertions do not depend on the host's CertificateAuthMode environment variable.
+        $script:SavedCertMode = [Environment]::GetEnvironmentVariable('CertificateAuthMode')
+        Remove-Item env:CertificateAuthMode -ErrorAction SilentlyContinue
+
+        Mock New-GraphPostRequest {
+            if ($uri -match 'policies/appManagementPolicies$') {
+                $script:CreateBody = $body | ConvertFrom-Json
+            }
+            if ($uri -match 'appManagementPolicies/\$ref$') {
+                $script:AssignUri = $uri
+            }
+            [PSCustomObject]@{ id = 'created-policy-id' }
+        }
+    }
+
+    AfterEach {
+        if ($null -eq $script:SavedCertMode) { Remove-Item env:CertificateAuthMode -ErrorAction SilentlyContinue }
+        else { $env:CertificateAuthMode = $script:SavedCertMode }
+    }
+
+    It 'emits only the passwordCredentials block when the default policy blocks password addition' {
+        Mock New-GraphBulkRequest {
+            New-BulkResponse -PasswordRestrictions @([PSCustomObject]@{ restrictionType = 'passwordAddition'; state = 'enabled' })
+        }
+
+        $null = Update-AppManagementPolicy -TenantFilter 'contoso.onmicrosoft.com' -ApplicationId $script:AppId -CertificateOnly $false
+
+        $script:CreateBody | Should -Not -BeNullOrEmpty
+        $script:CreateBody.restrictions.passwordCredentials | Should -Not -BeNullOrEmpty
+        # No key credentials are blocked, so the body must not drag in a keyCredentials restriction Graph would reject.
+        $script:CreateBody.restrictions.PSObject.Properties.Name | Should -Not -Contain 'keyCredentials'
+    }
+
+    It 'emits an asymmetricKeyLifetime restriction with a non-null maxLifetime when key credentials are blocked' {
+        Mock New-GraphBulkRequest {
+            New-BulkResponse -KeyRestrictions @([PSCustomObject]@{ restrictionType = 'asymmetricKeyLifetime'; state = 'enabled'; maxLifetime = 'P90D' })
+        }
+
+        $null = Update-AppManagementPolicy -TenantFilter 'contoso.onmicrosoft.com' -ApplicationId $script:AppId -CertificateOnly $false
+
+        $script:CreateBody | Should -Not -BeNullOrEmpty
+        $Lifetime = $script:CreateBody.restrictions.keyCredentials | Where-Object { $_.restrictionType -eq 'asymmetricKeyLifetime' }
+        $Lifetime | Should -Not -BeNullOrEmpty
+        $Lifetime.maxLifetime | Should -Not -BeNullOrEmpty
+        # It echoes the tenant default's value when the default exposes one.
+        $Lifetime.maxLifetime | Should -Be 'P90D'
+    }
+
+    It 'falls back to a conservative maxLifetime when the default policy does not expose one' {
+        Mock New-GraphBulkRequest {
+            New-BulkResponse -KeyRestrictions @([PSCustomObject]@{ restrictionType = 'asymmetricKeyLifetime'; state = 'enabled' })
+        }
+
+        $null = Update-AppManagementPolicy -TenantFilter 'contoso.onmicrosoft.com' -ApplicationId $script:AppId -CertificateOnly $false
+
+        $Lifetime = $script:CreateBody.restrictions.keyCredentials | Where-Object { $_.restrictionType -eq 'asymmetricKeyLifetime' }
+        $Lifetime.maxLifetime | Should -Be 'P730D'
+    }
+
+    It 'assigns the exemption to the application registration by default' {
+        Mock New-GraphBulkRequest {
+            New-BulkResponse -PasswordRestrictions @([PSCustomObject]@{ restrictionType = 'passwordAddition'; state = 'enabled' })
+        }
+
+        $null = Update-AppManagementPolicy -TenantFilter 'contoso.onmicrosoft.com' -ApplicationId $script:AppId -CertificateOnly $false
+
+        $script:AssignUri | Should -Not -BeNullOrEmpty
+        $script:AssignUri | Should -Match '/applications/'
+        $script:AssignUri | Should -Not -Match '/servicePrincipals/'
+    }
+
+    It 'assigns the exemption to the service principal when -ServicePrincipal is set' {
+        Mock New-GraphBulkRequest {
+            New-BulkResponse -PasswordRestrictions @([PSCustomObject]@{ restrictionType = 'passwordAddition'; state = 'enabled' })
+        }
+
+        $null = Update-AppManagementPolicy -TenantFilter 'contoso.onmicrosoft.com' -ApplicationId $script:AppId -CertificateOnly $false -ServicePrincipal
+
+        $script:AssignUri | Should -Not -BeNullOrEmpty
+        $script:AssignUri | Should -Match '/servicePrincipals/'
+        $script:AssignUri | Should -Not -Match '/applications/'
+    }
+
+    It 'treats an already-assigned policy reference as success, not a failure' {
+        Mock New-GraphBulkRequest {
+            New-BulkResponse -PasswordRestrictions @([PSCustomObject]@{ restrictionType = 'passwordAddition'; state = 'enabled' })
+        }
+        # The target already has the policy assigned, so the $ref POST returns a duplicate-reference error.
+        Mock New-GraphPostRequest -ParameterFilter { $uri -match 'appManagementPolicies/\$ref$' } {
+            throw "One or more added object references already exist for the following modified properties: 'appManagementPolicies'."
+        }
+
+        # A throw here would surface as a test error, which is the failure we are guarding against.
+        $result = Update-AppManagementPolicy -TenantFilter 'contoso.onmicrosoft.com' -ApplicationId $script:AppId -CertificateOnly $false -ServicePrincipal
+        $result.PolicyAction | Should -Not -Match 'Failed'
+        $result.PolicyAction | Should -Match 'assigned'
+    }
+}

--- a/frontend/src/components/CippComponents/CippExchangeActions.jsx
+++ b/frontend/src/components/CippComponents/CippExchangeActions.jsx
@@ -19,6 +19,7 @@ import {
 } from "@mui/icons-material";
 import { useSettings } from "../../hooks/use-settings.js";
 import { useMemo } from "react";
+import { MfaVerifyForm } from "./CippMfaVerifyForm";
 
 export const CippExchangeActions = () => {
   const tenant = useSettings().currentTenant;
@@ -162,7 +163,8 @@ export const CippExchangeActions = () => {
       data: {
         UserEmail: "UPN",
       },
-      confirmText: "Are you sure you want to send an MFA request to [UPN]?",
+      children: ({ formHook, row }) => <MfaVerifyForm formControl={formHook} row={row} />,
+      confirmText: "Send an MFA request to [UPN]?",
       icon: <PhonelinkLock />,
     },
     {

--- a/frontend/src/components/CippComponents/CippMfaVerifyForm.jsx
+++ b/frontend/src/components/CippComponents/CippMfaVerifyForm.jsx
@@ -1,0 +1,155 @@
+import { useEffect } from 'react'
+import { Box, Typography, Alert, Skeleton, Chip } from '@mui/material'
+import { ApiGetCall } from '../../api/ApiCall'
+import { useSettings } from '../../hooks/use-settings.js'
+import CippFormComponent from './CippFormComponent'
+
+// Maps a Graph authentication-method @odata.type to a friendly label and its MFA capabilities. The MFA
+// connector verifies typed codes (software OATH or the Authenticator app's own code) and pushes to the
+// Microsoft Authenticator app.
+const MFA_METHOD_MAP = {
+  '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod': {
+    label: 'Microsoft Authenticator (push and code)',
+    push: true,
+    otp: true,
+  },
+  '#microsoft.graph.softwareOathAuthenticationMethod': {
+    label: 'Authenticator app / software OATH code',
+    push: false,
+    otp: true,
+  },
+  '#microsoft.graph.phoneAuthenticationMethod': { label: 'Phone (SMS or call)' },
+  '#microsoft.graph.fido2AuthenticationMethod': { label: 'FIDO2 security key' },
+  '#microsoft.graph.windowsHelloForBusinessAuthenticationMethod': {
+    label: 'Windows Hello for Business',
+  },
+  '#microsoft.graph.emailAuthenticationMethod': { label: 'Email' },
+}
+
+// Maps a Graph preferred-method value to the registered method @odata.type(s) it corresponds to, most
+// specific first, so the matching registered chip can be flagged as the default.
+const PREFERRED_TO_TYPE = {
+  push: ['#microsoft.graph.microsoftAuthenticatorAuthenticationMethod'],
+  oath: [
+    '#microsoft.graph.softwareOathAuthenticationMethod',
+    '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod',
+  ],
+  sms: ['#microsoft.graph.phoneAuthenticationMethod'],
+  voiceMobile: ['#microsoft.graph.phoneAuthenticationMethod'],
+  voiceAlternateMobile: ['#microsoft.graph.phoneAuthenticationMethod'],
+  voiceOffice: ['#microsoft.graph.phoneAuthenticationMethod'],
+}
+
+// Renders inside the Send MFA Push dialog (via the action's children render-prop). Fetches the user's
+// registered MFA methods and preferred method from Graph, shows them as chips (default first), and either
+// lets the admin send a push (default) or, as a last resort for users without the Authenticator, verify a
+// typed code. Blocks the dialog's Confirm when the user has no method that can be pushed or verified.
+export const MfaVerifyForm = ({ formControl, row }) => {
+  const tenantFilter = useSettings().currentTenant
+  const rowData = Array.isArray(row) ? row[0] : row
+  const tenant = tenantFilter === 'AllTenants' && rowData?.Tenant ? rowData.Tenant : tenantFilter
+  const upn = rowData?.userPrincipalName ?? rowData?.UPN
+
+  const methods = ApiGetCall({
+    url: '/api/ListGraphRequest',
+    data: {
+      Endpoint: `users/${upn}/authentication/methods`,
+      tenantFilter: tenant,
+    },
+    queryKey: `MFAMethods-${tenant}-${upn}`,
+  })
+  const preferences = ApiGetCall({
+    url: '/api/ListGraphRequest',
+    data: {
+      Endpoint: `users/${upn}/authentication/signInPreferences`,
+      tenantFilter: tenant,
+    },
+    queryKey: `MFAPreferred-${tenant}-${upn}`,
+  })
+
+  const registered = (methods.data?.Results ?? [])
+    .map((m) => ({ type: m['@odata.type'], ...MFA_METHOD_MAP[m['@odata.type']] }))
+    .filter((m) => m.label)
+  const hasPush = registered.some((m) => m.push)
+  const hasOtp = registered.some((m) => m.otp)
+
+  const preferred = preferences.data?.Results?.[0]?.userPreferredMethodForSecondaryAuthentication
+  const defaultType = (PREFERRED_TO_TYPE[preferred] ?? []).find((t) =>
+    registered.some((m) => m.type === t)
+  )
+  const sortedMethods = [...registered].sort((a, b) =>
+    a.type === defaultType ? -1 : b.type === defaultType ? 1 : 0
+  )
+
+  // Block the dialog's Confirm when there is no method to push or verify: register a field that never
+  // validates so the form stays invalid (CippApiDialog disables Confirm while !isValid).
+  const blockConfirm = methods.isSuccess && !hasPush && !hasOtp
+  useEffect(() => {
+    if (blockConfirm) {
+      formControl.register('mfaMethodGuard', { validate: () => false })
+      formControl.trigger('mfaMethodGuard')
+    } else {
+      formControl.unregister('mfaMethodGuard')
+    }
+    return () => formControl.unregister('mfaMethodGuard')
+  }, [blockConfirm])
+
+  if (methods.isLoading || preferences.isLoading) {
+    return <Skeleton variant="rounded" height={80} />
+  }
+
+  return (
+    <>
+      {registered.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            Registered MFA methods
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {sortedMethods.map((m) => (
+              <Chip
+                key={m.type}
+                label={m.type === defaultType ? `${m.label} (default)` : m.label}
+                size="small"
+                color={m.type === defaultType ? 'primary' : undefined}
+                variant={m.type === defaultType ? 'filled' : 'outlined'}
+              />
+            ))}
+          </Box>
+        </Box>
+      )}
+      {hasPush && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          A push will be sent to the user&apos;s Microsoft Authenticator when you confirm.
+        </Alert>
+      )}
+      {!hasPush && hasOtp && (
+        <>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            This user has no Microsoft Authenticator push method, so a push can&apos;t be sent. As a last
+            resort, enter a code from their authenticator to verify it.
+          </Alert>
+          <CippFormComponent
+            type="textField"
+            name="OTP"
+            label="OTP code from the user's authenticator"
+            formControl={formControl}
+            validators={{ required: 'Enter the OTP code to verify this user' }}
+          />
+        </>
+      )}
+      {methods.isSuccess && !hasPush && !hasOtp && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          This user has no app-based MFA (push or authenticator OTP) registered, so a test push or code
+          verification isn&apos;t possible.
+        </Alert>
+      )}
+      {methods.isError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Could not retrieve the user&apos;s registered MFA methods. You can still send a push by
+          confirming.
+        </Alert>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/CippComponents/CippUserActions.jsx
+++ b/frontend/src/components/CippComponents/CippUserActions.jsx
@@ -29,6 +29,7 @@ import { useSettings } from '../../hooks/use-settings.js'
 import { usePermissions } from '../../hooks/use-permissions'
 import { Tooltip, Box, Divider, Typography, Alert, Skeleton, Link, IconButton } from '@mui/material'
 import CippFormComponent from './CippFormComponent'
+import { MfaVerifyForm } from './CippMfaVerifyForm'
 import { CippFormCondition } from './CippFormCondition'
 import { useWatch } from 'react-hook-form'
 import { ApiGetCall } from '../../api/ApiCall'
@@ -649,7 +650,8 @@ export const useCippUserActions = () => {
       icon: <PhonelinkLock />,
       url: '/api/ExecSendPush',
       data: { UserEmail: 'userPrincipalName' },
-      confirmText: 'Are you sure you want to send an MFA request to [userPrincipalName]?',
+      children: ({ formHook, row }) => <MfaVerifyForm formControl={formHook} row={row} />,
+      confirmText: 'Send an MFA request to [userPrincipalName]?',
       multiPost: false,
     },
     {


### PR DESCRIPTION
Refactor the MFA push flow to support both push notifications and OTP code verification:

- Add `New-CIPPMFAConnectorToken` to cache a long-lived connector secret per tenant in Key Vault (or DevSecrets in dev), avoiding expensive reprovisioning on every request
- Update `Invoke-ExecSendPush` to accept an optional OTP code; when supplied (and the user lacks Authenticator), verifies the typed code via the StrongAuthenticationService EndTwoWayAuthentication call instead of sending a push
- Fix `Update-AppManagementPolicy` to support service principal targets, only emit restriction types the default policy enforces, and include a valid `maxLifetime` on `asymmetricKeyLifetime` restrictions
- Add `CippMfaVerifyForm` frontend component that fetches the user's registered MFA methods, shows them as chips, and conditionally renders an OTP input for users without Authenticator push
- Wire the new form into both `CippUserActions` and `CippExchangeActions`
- Add Pester tests for `New-CIPPMFAConnectorToken` and `Update-AppManagementPolicy` exemption body