### PR TITLE
fix(table): keep split metadata in projected reads

### DIFF
--- a/backend/Modules/CIPPCore/Public/Get-CIPPAzDatatableEntity.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPAzDatatableEntity.ps1
@@ -35,6 +35,28 @@ function Get-CIPPAzDataTableEntity {
     $null = $Parameters.Remove('ErrorAction')
     $null = $Parameters.Remove('ErrorVariable')
 
+    # A projection must always carry the row-level split metadata. Reassembly groups an entity's
+    # rows by OriginalEntityId, identifies the master row by PartIndex and checks the set against
+    # PartCount, so a caller that selects none of them leaves the module unable to tell a complete
+    # entity from a truncated one - it reports every split entity as incomplete ("the first row of
+    # the entity (PartIndex 0) was not returned") even though every row is present, and skips it.
+    # Callers cannot act on entities they never see: Add-CIPPDbItem's orphan cleanup projects five
+    # columns, so it never received the stale rows it exists to delete, and one uncollectable
+    # generation accumulated per run.
+    #
+    # SplitOverProps is deliberately NOT added. It is the manifest for properties chunked across
+    # Data_PartN columns, and JoinSplitProperties returns early when it is absent. Adding it makes
+    # the module attempt the join, which throws IncompleteEntityException the moment a chunk column
+    # is missing - and a projection that wants identity, not payload, never selects those columns.
+    # That trades the row-level failure for a property-level one and skips the entity just the same.
+    # A caller that needs the joined value must select the chunk columns, or project nothing at all.
+    #
+    # Requesting a property a row does not carry is harmless, so this is added unconditionally.
+    if ($Parameters.ContainsKey('Property') -and $Parameters['Property']) {
+        $SplitMetadata = @('PartIndex', 'PartCount', 'OriginalEntityId')
+        $Parameters['Property'] = @(@($Parameters['Property']) + $SplitMetadata | Select-Object -Unique)
+    }
+
     $Results = Get-AzDataTableLargeEntity @Parameters -ErrorAction SilentlyContinue -ErrorVariable TableErrors
 
     # Do not pipe $null/$empty into Where-Object - PowerShell invokes the block once with $_ = $null.


### PR DESCRIPTION
`Get-CIPPAzDataTableEntity` passed the caller's `-Property` list straight through. Reassembly groups an entity's rows by `OriginalEntityId`, identifies the master row by `PartIndex` and validates the set against `PartCount`, so a projection selecting none of them makes the module report every split entity as incomplete — `the first row of the entity (PartIndex 0) was not returned` — even when every physical row is present, and skip it.

Skipped entities never reach the caller, so a caller that exists to act on them cannot. `Add-CIPPDbItem`'s orphan cleanup is the only projected read of `CippReportingDB`, and it projects five columns, so it never received the stale rows it exists to delete. One uncollectable generation accumulated per run.

Measured on our instance before the change:

- `ExoDlpSensitiveInfoTypes` had 11 generations per tenant over 10 days, ~191 rows for one report type
- Every generation was complete — 19 rows, `PartCount 19`, `PartIndex 0` present. Nothing was actually corrupt
- 165 skip errors per day, growing linearly from 17, all in the single hour the nightly cache runs

After: 0 errors, 20 rows per tenant, and the cleanup removed the ten stale generations itself.

`SplitOverProps` is deliberately not added — it is the manifest for chunked properties, and `JoinSplitProperties` returns early when absent but throws when present and a chunk column is missing, which a projection wanting identity rather than payload never selects. Including it just moves the failure from row level to property level.

`ee584cd37f` removes the only entity currently large enough to split, so the DLP symptom is gone either way. This fixes the mechanism, so the next cached type that grows past the row limit does not hit the same wall, and it lets the cleanup reclaim the rows already written.

Resolves #462
