### PR TITLE
feat(perf): server side paging

### DIFF
--- a/backend/Config/openapi.json
+++ b/backend/Config/openapi.json
@@ -41639,8 +41639,34 @@
         "tags": [
           "Tenant > Conditional"
         ],
-        "description": "Lists Conditional Access policies for a tenant with resolved display names for users, groups, applications, and locations.",
+        "description": "Lists Conditional Access policies for a tenant with resolved display names for users, groups, applications, and locations. When manualPagination is set on an AllTenants read, one page is returned per request with a continuation token in Metadata.nextLink.",
         "parameters": [
+          {
+            "name": "manualPagination",
+            "in": "query",
+            "description": "Return one page per request with a continuation token in Metadata.nextLink; AllTenants reads only.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nextLink",
+            "in": "query",
+            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
           {
             "$ref": "#/components/parameters/tenantFilter"
           }

--- a/backend/Config/openapi.json
+++ b/backend/Config/openapi.json
@@ -279,6 +279,14 @@
                   "logbook": {
                     "$ref": "#/components/schemas/LabelValue"
                   },
+                  "PsaTicketPriority": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/LabelValue"
+                      }
+                    ],
+                    "description": "The audit form posts the raw form values, so an autocomplete selection arrives as a {label, value} object - unwrap it to the bare Halo priority id before storing."
+                  },
                   "RowKey": {
                     "type": "string"
                   },
@@ -2176,6 +2184,87 @@
           }
         ],
         "x-cipp-role": "Tenant.Administration.ReadWrite"
+      }
+    },
+    "/api/AddEdgeApp": {
+      "post": {
+        "summary": "AddEdgeApp",
+        "operationId": "AddEdgeApp",
+        "tags": [
+          "Endpoint > Applications"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "AssignTo": {
+                    "type": "string"
+                  },
+                  "CustomGroup": {
+                    "type": "string"
+                  },
+                  "displayLanguageLocale": {
+                    "$ref": "#/components/schemas/LabelValue"
+                  },
+                  "edgeChannel": {
+                    "$ref": "#/components/schemas/LabelValue"
+                  },
+                  "excludeGroup": {
+                    "type": "string"
+                  },
+                  "IntuneBody": {
+                    "type": "string"
+                  },
+                  "selectedTenants": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "customerId": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": true,
+                "x-cipp-passthrough": true,
+                "description": "This endpoint forwards the request body onward rather than reading a fixed set of fields. The properties listed here are the ones it is known to read; others may be accepted."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResults"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing bearer token"
+          },
+          "403": {
+            "description": "Forbidden - caller lacks the required RBAC role"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-cipp-role": "Endpoint.Application.ReadWrite",
+        "x-cipp-any-tenant": true,
+        "x-cipp-reads-via": [
+          "Get-CIPPEdgeAppBody"
+        ]
       }
     },
     "/api/AddEditTransportRule": {
@@ -5373,21 +5462,21 @@
                   },
                   "Name": {
                     "type": "string",
-                    "description": "Validate required fields"
+                    "description": "Validate required fields. The \"create template from policy\" row action posts the policy row, which carries Name/PolicyName but no TemplateName."
                   },
                   "PolicyName": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Set name and comments - prioritize template-specific fields, falling back to the policy name so a template made from a policy is not listed with a blank name."
                   },
                   "TemplateDescription": {
                     "type": "string"
                   },
                   "TemplateName": {
                     "type": "string",
-                    "description": "Set name and comments - prioritize template-specific fields"
+                    "description": "Validate required fields. The \"create template from policy\" row action posts the policy row, which carries Name/PolicyName but no TemplateName."
                   }
                 },
                 "required": [
-                  "Name",
                   "PolicyName"
                 ]
               }
@@ -16852,7 +16941,7 @@
                       },
                       "standardsTemplateId": {
                         "type": "string",
-                        "description": "Without this the comparison would report the policy as missing while remediation would happily overwrite an existing, similarly named one. Mirrors the candidate selection Set-CIPPIntunePolicy performs at deployment time."
+                        "description": "tenantFilter is optional here - supplying it resolves the template the way the standard would for that tenant instead of comparing the stored template verbatim."
                       },
                       "templateGuid": {
                         "type": "string",
@@ -16893,7 +16982,7 @@
                       },
                       "standardsTemplateId": {
                         "type": "string",
-                        "description": "Without this the comparison would report the policy as missing while remediation would happily overwrite an existing, similarly named one. Mirrors the candidate selection Set-CIPPIntunePolicy performs at deployment time."
+                        "description": "tenantFilter is optional here - supplying it resolves the template the way the standard would for that tenant instead of comparing the stored template verbatim."
                       },
                       "templateGuid": {
                         "type": "string",
@@ -20958,7 +21047,7 @@
           {
             "name": "TicketType",
             "in": "query",
-            "description": "Outcomes and priorities are scoped to a ticket type. The settings page sends the ticket type currently selected in the form so the lists follow the dropdown; without it both fall back to whatever ticket type was last saved.",
+            "description": "Outcomes and priorities are scoped to a ticket type. The settings page sends the ticket type currently selected in the form so the lists follow the dropdown; without it both fall back to whatever ticket type was last saved. @() on each: PowerShell unrolls single-element output, so a ticket type with one outcome (or a lookup that answers with a single explanatory row) would otherwise serialise as a bare object and break callers that expect a list.",
             "required": false,
             "schema": {
               "type": "string"
@@ -27469,6 +27558,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request - missing required field or invalid input"
           },
           "401": {
             "description": "Unauthorized - invalid or missing bearer token"
@@ -40965,7 +41057,7 @@
                         "x-cipp-field-source": "storage"
                       },
                       "source": {
-                        "x-cipp-field-source": "storage"
+                        "x-cipp-field-source": "storage,frontend"
                       },
                       "templateCount": {
                         "x-cipp-field-source": "backend"
@@ -45742,6 +45834,10 @@
                         "type": "string",
                         "x-cipp-field-source": "storage"
                       },
+                      "PsaTicketPriority": {
+                        "type": "string",
+                        "x-cipp-field-source": "storage"
+                      },
                       "PsaTicketStrategy": {
                         "type": "string",
                         "x-cipp-field-source": "storage"
@@ -48988,7 +49084,7 @@
                         "x-cipp-field-source": "storage"
                       },
                       "source": {
-                        "x-cipp-field-source": "storage,backend"
+                        "x-cipp-field-source": "storage,backend,frontend"
                       },
                       "templateCount": {
                         "x-cipp-field-source": "backend"
@@ -49848,6 +49944,15 @@
             }
           },
           {
+            "name": "Days",
+            "in": "query",
+            "description": "Days=N widens a filtered query to the last N calendar days (in the instance timezone), so the scoped drawers still show a run that finished last night. Ignored when dates are given.",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
             "name": "EndDate",
             "in": "query",
             "required": false,
@@ -50162,6 +50267,15 @@
             "required": false,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "Minimal",
+            "in": "query",
+            "description": "Picker mode: address autocompletes only need the address + name, so skip the heavy field set, the per-mailbox computed properties, and the extra Get-OrganizationConfig call.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             }
           },
           {
@@ -51885,6 +51999,9 @@
                         "x-cipp-field-source": "storage"
                       },
                       "PsaTicketId": {
+                        "x-cipp-field-source": "storage"
+                      },
+                      "PsaTicketPriority": {
                         "x-cipp-field-source": "storage"
                       },
                       "Reference": {
@@ -54428,6 +54545,10 @@
                         "x-cipp-field-source": "storage"
                       },
                       "PsaTicketId": {
+                        "type": "string",
+                        "x-cipp-field-source": "storage"
+                      },
+                      "PsaTicketPriority": {
                         "type": "string",
                         "x-cipp-field-source": "storage"
                       },
@@ -62207,6 +62328,9 @@
                       "PsaTicketId": {
                         "x-cipp-field-source": "storage"
                       },
+                      "PsaTicketPriority": {
+                        "x-cipp-field-source": "storage"
+                      },
                       "Reference": {
                         "x-cipp-field-source": "storage"
                       },
@@ -66407,6 +66531,9 @@
                       "x-cipp-field-source": "storage"
                     },
                     "PsaTicketId": {
+                      "x-cipp-field-source": "storage"
+                    },
+                    "PsaTicketPriority": {
                       "x-cipp-field-source": "storage"
                     },
                     "Reference": {

--- a/backend/Config/openapi.json
+++ b/backend/Config/openapi.json
@@ -47494,7 +47494,7 @@
           {
             "name": "nextLink",
             "in": "query",
-            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers.",
+            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers. Stream the cached blobs as raw JSON so member arrays are never re-parsed here.",
             "required": false,
             "schema": {
               "type": "string"

--- a/backend/Config/openapi.json
+++ b/backend/Config/openapi.json
@@ -279,14 +279,6 @@
                   "logbook": {
                     "$ref": "#/components/schemas/LabelValue"
                   },
-                  "PsaTicketPriority": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/LabelValue"
-                      }
-                    ],
-                    "description": "The audit form posts the raw form values, so an autocomplete selection arrives as a {label, value} object - unwrap it to the bare Halo priority id before storing."
-                  },
                   "RowKey": {
                     "type": "string"
                   },
@@ -2184,87 +2176,6 @@
           }
         ],
         "x-cipp-role": "Tenant.Administration.ReadWrite"
-      }
-    },
-    "/api/AddEdgeApp": {
-      "post": {
-        "summary": "AddEdgeApp",
-        "operationId": "AddEdgeApp",
-        "tags": [
-          "Endpoint > Applications"
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "AssignTo": {
-                    "type": "string"
-                  },
-                  "CustomGroup": {
-                    "type": "string"
-                  },
-                  "displayLanguageLocale": {
-                    "$ref": "#/components/schemas/LabelValue"
-                  },
-                  "edgeChannel": {
-                    "$ref": "#/components/schemas/LabelValue"
-                  },
-                  "excludeGroup": {
-                    "type": "string"
-                  },
-                  "IntuneBody": {
-                    "type": "string"
-                  },
-                  "selectedTenants": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "customerId": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "additionalProperties": true,
-                "x-cipp-passthrough": true,
-                "description": "This endpoint forwards the request body onward rather than reading a fixed set of fields. The properties listed here are the ones it is known to read; others may be accepted."
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StandardResults"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized - invalid or missing bearer token"
-          },
-          "403": {
-            "description": "Forbidden - caller lacks the required RBAC role"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "x-cipp-role": "Endpoint.Application.ReadWrite",
-        "x-cipp-any-tenant": true,
-        "x-cipp-reads-via": [
-          "Get-CIPPEdgeAppBody"
-        ]
       }
     },
     "/api/AddEditTransportRule": {
@@ -5462,21 +5373,21 @@
                   },
                   "Name": {
                     "type": "string",
-                    "description": "Validate required fields. The \"create template from policy\" row action posts the policy row, which carries Name/PolicyName but no TemplateName."
+                    "description": "Validate required fields"
                   },
                   "PolicyName": {
-                    "type": "string",
-                    "description": "Set name and comments - prioritize template-specific fields, falling back to the policy name so a template made from a policy is not listed with a blank name."
+                    "type": "string"
                   },
                   "TemplateDescription": {
                     "type": "string"
                   },
                   "TemplateName": {
                     "type": "string",
-                    "description": "Validate required fields. The \"create template from policy\" row action posts the policy row, which carries Name/PolicyName but no TemplateName."
+                    "description": "Set name and comments - prioritize template-specific fields"
                   }
                 },
                 "required": [
+                  "Name",
                   "PolicyName"
                 ]
               }
@@ -16941,7 +16852,7 @@
                       },
                       "standardsTemplateId": {
                         "type": "string",
-                        "description": "tenantFilter is optional here - supplying it resolves the template the way the standard would for that tenant instead of comparing the stored template verbatim."
+                        "description": "Without this the comparison would report the policy as missing while remediation would happily overwrite an existing, similarly named one. Mirrors the candidate selection Set-CIPPIntunePolicy performs at deployment time."
                       },
                       "templateGuid": {
                         "type": "string",
@@ -16982,7 +16893,7 @@
                       },
                       "standardsTemplateId": {
                         "type": "string",
-                        "description": "tenantFilter is optional here - supplying it resolves the template the way the standard would for that tenant instead of comparing the stored template verbatim."
+                        "description": "Without this the comparison would report the policy as missing while remediation would happily overwrite an existing, similarly named one. Mirrors the candidate selection Set-CIPPIntunePolicy performs at deployment time."
                       },
                       "templateGuid": {
                         "type": "string",
@@ -21047,7 +20958,7 @@
           {
             "name": "TicketType",
             "in": "query",
-            "description": "Outcomes and priorities are scoped to a ticket type. The settings page sends the ticket type currently selected in the form so the lists follow the dropdown; without it both fall back to whatever ticket type was last saved. @() on each: PowerShell unrolls single-element output, so a ticket type with one outcome (or a lookup that answers with a single explanatory row) would otherwise serialise as a bare object and break callers that expect a list.",
+            "description": "Outcomes and priorities are scoped to a ticket type. The settings page sends the ticket type currently selected in the form so the lists follow the dropdown; without it both fall back to whatever ticket type was last saved.",
             "required": false,
             "schema": {
               "type": "string"
@@ -27558,9 +27469,6 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "Bad request - missing required field or invalid input"
           },
           "401": {
             "description": "Unauthorized - invalid or missing bearer token"
@@ -41057,7 +40965,7 @@
                         "x-cipp-field-source": "storage"
                       },
                       "source": {
-                        "x-cipp-field-source": "storage,frontend"
+                        "x-cipp-field-source": "storage"
                       },
                       "templateCount": {
                         "x-cipp-field-source": "backend"
@@ -45808,10 +45716,6 @@
                         "type": "string",
                         "x-cipp-field-source": "storage"
                       },
-                      "PsaTicketPriority": {
-                        "type": "string",
-                        "x-cipp-field-source": "storage"
-                      },
                       "PsaTicketStrategy": {
                         "type": "string",
                         "x-cipp-field-source": "storage"
@@ -47308,6 +47212,15 @@
             }
           },
           {
+            "name": "maxPageBytes",
+            "in": "query",
+            "description": "Paged AllTenants cache reads only: target page size in bytes of raw JSON, clamped between 262144 and 8388608 (default 4000000). Pages always hold at least one whole tenant.",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
             "name": "nextLink",
             "in": "query",
             "description": "Continue a manualPagination walk: pass back the @odata.nextLink returned with the previous page. Endpoint is still required, and the other query options are already encoded in the link.",
@@ -47981,8 +47894,34 @@
         "tags": [
           "Identity > Administration > Users"
         ],
-        "description": "Lists all guest accounts in a tenant with a computed lifecycle status (Active, Pending Acceptance, Stale, Never Signed In or Disabled) based on the invitation state and sign-in activity. Supports UseReportDB=true to serve cached data from the reporting database; AllTenants always uses the cache.",
+        "description": "Lists all guest accounts in a tenant with a computed lifecycle status (Active, Pending Acceptance, Stale, Never Signed In or Disabled) based on the invitation state and sign-in activity. Supports UseReportDB=true to serve cached data from the reporting database; AllTenants always uses the cache. When manualPagination is set on a cached read, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.",
         "parameters": [
+          {
+            "name": "manualPagination",
+            "in": "query",
+            "description": "Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nextLink",
+            "in": "query",
+            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
           {
             "name": "staleDays",
             "in": "query",
@@ -48997,7 +48936,7 @@
                         "x-cipp-field-source": "storage"
                       },
                       "source": {
-                        "x-cipp-field-source": "storage,backend,frontend"
+                        "x-cipp-field-source": "storage,backend"
                       },
                       "templateCount": {
                         "x-cipp-field-source": "backend"
@@ -49830,7 +49769,7 @@
         "tags": [
           "CIPP > Core"
         ],
-        "description": "Lists CIPP platform audit logs with filtering by severity, date range, tenant, and user. Supports listing available log categories.",
+        "description": "Lists CIPP platform audit logs with filtering by severity, date range, tenant, and user. Supports listing available log categories, fetching a single entry, and server-side pagination via manualPagination/nextLink.",
         "parameters": [
           {
             "name": "API",
@@ -49857,15 +49796,6 @@
             }
           },
           {
-            "name": "Days",
-            "in": "query",
-            "description": "Days=N widens a filtered query to the last N calendar days (in the instance timezone). The scoped drawers (standard template, scheduled task, baseline run) use this: a run that finished last night otherwise shows an empty log early the next day, because the default window is \"today\" only.",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
             "name": "EndDate",
             "in": "query",
             "required": false,
@@ -49876,6 +49806,7 @@
           {
             "name": "Filter",
             "in": "query",
+            "description": "When true, the Severity/User/Tenant/API/StartDate/EndDate query filters are applied; otherwise the current day is returned unfiltered.",
             "required": false,
             "schema": {
               "type": "boolean"
@@ -49892,9 +49823,37 @@
           {
             "name": "logentryid",
             "in": "query",
+            "description": "Return single log entry by RowKey. RowKeys are either legacy GUIDs or the inverted-ticks format Write-LogMessage writes; both use only hex digits and hyphens.",
             "required": false,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "manualPagination",
+            "in": "query",
+            "description": "Return one page per request plus a continuation token in Metadata.nextLink, which the frontend passes back as nextLink to fetch the next page. Pages walk the requested date range newest-day-first and, within a day, in RowKey order (newest-first for entries written with the inverted-ticks RowKey scheme).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nextLink",
+            "in": "query",
+            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Rows to return per page, clamped between 50 and 1000. Defaults to 400.",
+            "required": false,
+            "schema": {
+              "type": "integer"
             }
           },
           {
@@ -50142,15 +50101,32 @@
         "tags": [
           "Email-Exchange > Administration"
         ],
-        "description": "Lists Exchange Online mailboxes for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants.",
+        "description": "Lists Exchange Online mailboxes for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants. When manualPagination is also set, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.",
         "parameters": [
           {
-            "name": "Minimal",
+            "name": "manualPagination",
             "in": "query",
-            "description": "Picker mode: address autocompletes only need the address + name, so skip the heavy field set, the per-mailbox computed properties, and the extra Get-OrganizationConfig call.",
+            "description": "Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.",
             "required": false,
             "schema": {
-              "type": "boolean"
+              "type": "string"
+            }
+          },
+          {
+            "name": "nextLink",
+            "in": "query",
+            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
             }
           },
           {
@@ -51493,8 +51469,34 @@
         "tags": [
           "Identity > Reports"
         ],
-        "description": "Lists users and their MFA registration status for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants.",
+        "description": "Lists users and their MFA registration status for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants. When manualPagination is also set, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.",
         "parameters": [
+          {
+            "name": "manualPagination",
+            "in": "query",
+            "description": "Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nextLink",
+            "in": "query",
+            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
           {
             "$ref": "#/components/parameters/tenantFilter"
           },
@@ -51831,9 +51833,6 @@
                         "x-cipp-field-source": "storage"
                       },
                       "PsaTicketId": {
-                        "x-cipp-field-source": "storage"
-                      },
-                      "PsaTicketPriority": {
                         "x-cipp-field-source": "storage"
                       },
                       "Reference": {
@@ -54377,10 +54376,6 @@
                         "x-cipp-field-source": "storage"
                       },
                       "PsaTicketId": {
-                        "type": "string",
-                        "x-cipp-field-source": "storage"
-                      },
-                      "PsaTicketPriority": {
                         "type": "string",
                         "x-cipp-field-source": "storage"
                       },
@@ -62160,9 +62155,6 @@
                       "PsaTicketId": {
                         "x-cipp-field-source": "storage"
                       },
-                      "PsaTicketPriority": {
-                        "x-cipp-field-source": "storage"
-                      },
                       "Reference": {
                         "x-cipp-field-source": "storage"
                       },
@@ -66363,9 +66355,6 @@
                       "x-cipp-field-source": "storage"
                     },
                     "PsaTicketId": {
-                      "x-cipp-field-source": "storage"
-                    },
-                    "PsaTicketPriority": {
                       "x-cipp-field-source": "storage"
                     },
                     "Reference": {

--- a/backend/Config/openapi.json
+++ b/backend/Config/openapi.json
@@ -47436,7 +47436,7 @@
         "tags": [
           "Identity > Administration > Groups"
         ],
-        "description": "Lists Entra ID groups for a tenant, including group members and owners. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants.",
+        "description": "Lists Entra ID groups for a tenant, including group members and owners. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants. When manualPagination is also set on a cached read, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.",
         "parameters": [
           {
             "name": "expandMembers",
@@ -47474,6 +47474,15 @@
             }
           },
           {
+            "name": "manualPagination",
+            "in": "query",
+            "description": "Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "members",
             "in": "query",
             "description": "Return the members of the group named by groupID instead of the group list. Requires groupID.",
@@ -47483,12 +47492,29 @@
             }
           },
           {
+            "name": "nextLink",
+            "in": "query",
+            "description": "Continuation token from the previous page's Metadata.nextLink; opaque to callers.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "owners",
             "in": "query",
             "description": "Return the owners of the group named by groupID instead of the group list. Requires groupID.",
             "required": false,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
             }
           },
           {

--- a/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-ListConditionalAccessPoliciesAllTenants.ps1
+++ b/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-ListConditionalAccessPoliciesAllTenants.ps1
@@ -103,7 +103,8 @@
         $AllServicePrincipals = ($BulkResults | Where-Object { $_.id -eq 'servicePrincipals' }).body.value
 
         foreach ($cap in $ConditionalAccessPolicyOutput) {
-            $GUID = (New-Guid).Guid
+            # Deterministic key so overlapping fan-outs upsert instead of appending duplicates.
+            $RowKey = ('{0}-{1}' -f $domainName, $cap.id) -replace '[\\/#?]', '_' -replace '[\x00-\x1F\x7F]', ''
             $PolicyData = @{
                 id                                          = $cap.id
                 displayName                                 = $cap.displayName
@@ -136,7 +137,7 @@
 
             $Entity = @{
                 Policy       = [string]($PolicyData | ConvertTo-Json -Depth 10 -Compress)
-                RowKey       = [string]$GUID
+                RowKey       = [string]$RowKey
                 PartitionKey = 'CAPolicy'
                 Tenant       = [string]$domainName
             }
@@ -144,7 +145,6 @@
         }
 
     } catch {
-        $GUID = (New-Guid).Guid
         $ErrorPolicy = ConvertTo-Json -InputObject @{
             Tenant           = $domainName
             displayName      = "Could not connect to Tenant: $($_.Exception.Message)"
@@ -156,7 +156,7 @@
         } -Compress
         $Entity = @{
             Policy       = [string]$ErrorPolicy
-            RowKey       = [string]$GUID
+            RowKey       = [string]('{0}-Error' -f $domainName) -replace '[\\/#?]', '_'
             PartitionKey = 'CAPolicy'
             Tenant       = [string]$domainName
         }

--- a/backend/Modules/CIPPCore/Public/Get-CIPPDbItemPage.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPDbItemPage.ps1
@@ -1,0 +1,61 @@
+function Get-CIPPDbItemPage {
+    <#
+    .FUNCTIONALITY
+    Internal
+    .SYNOPSIS
+    Reads one page of items of a type from the CIPP Reporting database.
+    .DESCRIPTION
+    Continuation-token pager over CippReportingDB (PartitionKey = tenant, RowKey = '<Type>-<id>').
+    AllTenants walks every managed tenant that has a '<Type>-Count' row; a single tenant walks
+    its own partition. Returns raw entities minus the count markers; callers parse Data and
+    read the tenant from PartitionKey. A null NextToken means the walk is complete.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantFilter,
+        [Parameter(Mandatory = $true)]
+        [string]$Type,
+        [ValidateRange(1, 10000)]
+        [int]$PageSize = 5000,
+        [string]$ContinuationToken
+    )
+
+    # Enforce tenant lock when running inside custom script execution (parity with Get-CIPPDbItem)
+    if ($script:CIPPLockedTenant) {
+        $TenantFilter = $script:CIPPLockedTenant
+    }
+
+    $Table = Get-CippTable -tablename 'CippReportingDB'
+
+    if ($TenantFilter -eq 'AllTenants') {
+        $CountRows = Get-CIPPDbItem -TenantFilter 'allTenants' -Type $Type -CountsOnly
+        $TenantList = Get-Tenants -IncludeErrors
+        $Known = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($Domain in $TenantList.defaultDomainName) {
+            if ($Domain) { $null = $Known.Add([string]$Domain) }
+        }
+        # Ordinal ascending, to match the walker's range-scan order.
+        $Unique = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+        foreach ($Partition in $CountRows.PartitionKey) {
+            if ($Partition -and $Known.Contains([string]$Partition)) { $null = $Unique.Add([string]$Partition) }
+        }
+        $Partitions = [string[]]@($Unique)
+        [System.Array]::Sort($Partitions, [System.Collections.IComparer][StringComparer]::Ordinal)
+    } else {
+        $Tenant = Get-Tenants -TenantFilter $TenantFilter
+        if (-not $Tenant) {
+            throw "Tenant '$TenantFilter' not found"
+        }
+        $Partitions = @($Tenant.defaultDomainName)
+    }
+
+    $Page = Get-CIPPPagedTableRows -Table $Table -PartitionKeys $Partitions -RowKeyGe "$Type-" -RowKeyLt "$Type." -PageSize $PageSize -ContinuationToken $ContinuationToken
+    # Drop the count marker, which sorts inside the range.
+    $Items = @($Page.Rows | Where-Object { $_.RowKey -ne "$Type-Count" })
+
+    return [PSCustomObject]@{
+        Items     = $Items
+        NextToken = $Page.NextToken
+    }
+}

--- a/backend/Modules/CIPPCore/Public/Get-CIPPGroupsReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPGroupsReport.ps1
@@ -5,12 +5,51 @@ function Get-CIPPGroupsReport {
 
     .PARAMETER TenantFilter
         The tenant to generate the report for, or 'AllTenants' for all tenants
+
+    .PARAMETER PageSize
+        When set, returns one page of at most this many rows as @{ Items; NextToken }, in table walk order.
+
+    .PARAMETER ContinuationToken
+        NextToken from the previous page. Only meaningful together with PageSize.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$TenantFilter
+        [string]$TenantFilter,
+        [int]$PageSize,
+        [string]$ContinuationToken
     )
+
+    if ($PageSize -gt 0) {
+        $Page = Get-CIPPDbItemPage -TenantFilter $TenantFilter -Type 'Groups' -PageSize $PageSize -ContinuationToken $ContinuationToken
+        if ($TenantFilter -ne 'AllTenants' -and -not $ContinuationToken -and @($Page.Items).Count -eq 0 -and -not $Page.NextToken) {
+            throw "No groups data found in reporting database for $TenantFilter. Sync the report data first."
+        }
+        $Results = [System.Collections.Generic.List[PSCustomObject]]::new()
+        foreach ($Item in $Page.Items) {
+            try {
+                $Group = $Item.Data | ConvertFrom-Json -Depth 10 -ErrorAction Stop
+                if ($Group.members -and -not $Group.membersCsv) {
+                    $Group | Add-Member -NotePropertyName 'membersCsv' -NotePropertyValue ($Group.members.userPrincipalName -join ',') -Force
+                }
+                if ($Group.owners -and -not $Group.ownersCsv) {
+                    $Group | Add-Member -NotePropertyName 'ownersCsv' -NotePropertyValue ($Group.owners.userPrincipalName -join ',') -Force
+                }
+                # Per-item timestamp: a page may span tenants.
+                $Group | Add-Member -NotePropertyName 'CacheTimestamp' -NotePropertyValue $Item.Timestamp -Force
+                if ($TenantFilter -eq 'AllTenants') {
+                    $Group | Add-Member -NotePropertyName 'Tenant' -NotePropertyValue $Item.PartitionKey -Force
+                }
+                $Results.Add($Group)
+            } catch {
+                Write-LogMessage -API 'GroupsReport' -tenant $Item.PartitionKey -message "Failed to parse group item: $($_.Exception.Message)" -sev Warning
+            }
+        }
+        return [PSCustomObject]@{
+            Items     = $Results
+            NextToken = $Page.NextToken
+        }
+    }
 
     if ($TenantFilter -eq 'AllTenants') {
         $AnyItems = Get-CIPPDbItem -TenantFilter 'allTenants' -Type 'Groups'

--- a/backend/Modules/CIPPCore/Public/Get-CIPPGroupsReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPGroupsReport.ps1
@@ -17,7 +17,11 @@ function Get-CIPPGroupsReport {
         [Parameter(Mandatory = $true)]
         [string]$TenantFilter,
         [int]$PageSize,
-        [string]$ContinuationToken
+        [string]$ContinuationToken,
+        # Return one page as { CippPagedJson; NextToken }: the stored blobs stitched into a
+        # JSON array verbatim, with per-row CacheTimestamp/Tenant spliced in. No member array
+        # is ever deserialized on the read path.
+        [switch]$AsRawJson
     )
 
     if ($PageSize -gt 0) {
@@ -25,6 +29,35 @@ function Get-CIPPGroupsReport {
         if ($TenantFilter -ne 'AllTenants' -and -not $ContinuationToken -and @($Page.Items).Count -eq 0 -and -not $Page.NextToken) {
             throw "No groups data found in reporting database for $TenantFilter. Sync the report data first."
         }
+
+        if ($AsRawJson) {
+            $IsAllTenants = $TenantFilter -eq 'AllTenants'
+            $Builder = [System.Text.StringBuilder]::new()
+            $null = $Builder.Append('[')
+            $First = $true
+            foreach ($Item in $Page.Items) {
+                $Blob = [string]$Item.Data
+                if ([string]::IsNullOrWhiteSpace($Blob)) { continue }
+                $Blob = $Blob.Trim()
+                if ($Blob[0] -ne '{') { continue }
+                if (-not $First) { $null = $Builder.Append(',') }
+                $First = $false
+                # Emit the blob verbatim, then splice the two row-level fields onto its closing
+                # brace. membersCsv/ownersCsv already live in the blob (written at cache time).
+                $null = $Builder.Append($Blob, 0, $Blob.Length - 1)
+                $null = $Builder.Append(',"CacheTimestamp":').Append((ConvertTo-Json -InputObject $Item.Timestamp -Compress))
+                if ($IsAllTenants) {
+                    $null = $Builder.Append(',"Tenant":').Append((ConvertTo-Json -InputObject ([string]$Item.PartitionKey) -Compress))
+                }
+                $null = $Builder.Append('}')
+            }
+            $null = $Builder.Append(']')
+            return [PSCustomObject]@{
+                CippPagedJson = $Builder.ToString()
+                NextToken     = $Page.NextToken
+            }
+        }
+
         $Results = [System.Collections.Generic.List[PSCustomObject]]::new()
         foreach ($Item in $Page.Items) {
             try {

--- a/backend/Modules/CIPPCore/Public/Get-CIPPGuestUsersReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPGuestUsersReport.ps1
@@ -10,12 +10,43 @@ function Get-CIPPGuestUsersReport {
 
     .PARAMETER TenantFilter
         The tenant to read cached guest users for, or 'AllTenants' for all tenants
+
+    .PARAMETER PageSize
+        When set, returns one page of at most this many rows as @{ Items; NextToken }, in table walk order.    .PARAMETER ContinuationToken
+        NextToken from the previous page. Only meaningful together with PageSize.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$TenantFilter
+        [string]$TenantFilter,
+        [int]$PageSize,
+        [string]$ContinuationToken
     )
+
+    if ($PageSize -gt 0) {
+        $Page = Get-CIPPDbItemPage -TenantFilter $TenantFilter -Type 'Guests' -PageSize $PageSize -ContinuationToken $ContinuationToken
+        if ($TenantFilter -ne 'AllTenants' -and -not $ContinuationToken -and @($Page.Items).Count -eq 0 -and -not $Page.NextToken) {
+            throw "No guest user data found in reporting database for $TenantFilter. Sync the report data first."
+        }
+        $Results = [System.Collections.Generic.List[PSCustomObject]]::new()
+        foreach ($Item in $Page.Items) {
+            try {
+                $Guest = $Item.Data | ConvertFrom-Json -Depth 10 -ErrorAction Stop
+                # Per-item timestamp: a page may span tenants.
+                $Guest | Add-Member -NotePropertyName 'CacheTimestamp' -NotePropertyValue $Item.Timestamp -Force
+                if ($TenantFilter -eq 'AllTenants') {
+                    $Guest | Add-Member -NotePropertyName 'Tenant' -NotePropertyValue $Item.PartitionKey -Force
+                }
+                $Results.Add($Guest)
+            } catch {
+                Write-LogMessage -API 'GuestUsersReport' -tenant $Item.PartitionKey -message "Failed to parse guest user item: $($_.Exception.Message)" -sev Warning
+            }
+        }
+        return [PSCustomObject]@{
+            Items     = $Results
+            NextToken = $Page.NextToken
+        }
+    }
 
     if ($TenantFilter -eq 'AllTenants') {
         $AnyItems = Get-CIPPDbItem -TenantFilter 'allTenants' -Type 'Guests'

--- a/backend/Modules/CIPPCore/Public/Get-CIPPLicenseOverview.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPLicenseOverview.ps1
@@ -73,7 +73,7 @@ function Get-CIPPLicenseOverview {
             $null -eq $_.ExcludedEverywhere -or $_.ExcludedEverywhere -eq $true
         } | ForEach-Object { $_.GUID })
     }
-    $DropdownVisibleGuids = @($ExcludedSkuList | Where-Object { $_.ShowInLicenseDropdown -eq $true } | ForEach-Object { $_.GUID })
+    $HiddenFromDropdownGuids = @($ExcludedSkuList | Where-Object { $_.ShowInLicenseDropdown -eq $false } | ForEach-Object { $_.GUID })
 
     $AllLicensedUsers = @(($Results | Where-Object { $_.id -eq 'licensedUsers' }).body.value) | Sort-Object -Property displayName
     $UsersBySku = @{}
@@ -123,7 +123,7 @@ function Get-CIPPLicenseOverview {
         $skuId = $singleReq.Licenses
         foreach ($sku in $skuId) {
             if ($sku.skuId -in $EffectiveExcludedGuids) {
-                if (!$IncludeExcluded -or $sku.skuId -notin $DropdownVisibleGuids) { continue }
+                if (!$IncludeExcluded -or $sku.skuId -in $HiddenFromDropdownGuids) { continue }
             }
             $PrettyNameAdmin = $AdminPortalLicenses | Where-Object { $_.aadSkuId -eq $sku.skuId } | Select-Object -ExpandProperty displayName -First 1
             $PrettyNameCSV = ($ConvertTable | Where-Object { $_.guid -eq $sku.skuid }).'Product_Display_Name' | Select-Object -Last 1

--- a/backend/Modules/CIPPCore/Public/Get-CIPPMFAStateReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPMFAStateReport.ps1
@@ -26,6 +26,10 @@ function Get-CIPPMFAStateReport {
     .PARAMETER TenantFilter
         The tenant to generate the report for
 
+    .PARAMETER PageSize
+        When set, returns one page of at most this many rows as @{ Items; NextToken }, in table walk order.    .PARAMETER ContinuationToken
+        NextToken from the previous page. Only meaningful together with PageSize.
+
     .EXAMPLE
         Get-CIPPMFAStateReport -TenantFilter 'contoso.onmicrosoft.com'
         Gets MFA state for all users in the tenant
@@ -33,10 +37,41 @@ function Get-CIPPMFAStateReport {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$TenantFilter
+        [string]$TenantFilter,
+        [int]$PageSize,
+        [string]$ContinuationToken
     )
 
     try {
+        if ($PageSize -gt 0) {
+            $Page = Get-CIPPDbItemPage -TenantFilter $TenantFilter -Type 'MFAState' -PageSize $PageSize -ContinuationToken $ContinuationToken
+            if ($TenantFilter -ne 'AllTenants' -and -not $ContinuationToken -and @($Page.Items).Count -eq 0 -and -not $Page.NextToken) {
+                throw 'No MFA state data found in reporting database. Sync the report data first.'
+            }
+            # Same memory discipline as the unpaged path below: hashtables, no Add-Member.
+            $Results = [System.Collections.Generic.List[object]]::new()
+            foreach ($Item in $Page.Items) {
+                $MFAUser = $Item.Data | ConvertFrom-Json -AsHashtable
+
+                # Legacy rows stored these as embedded JSON strings rather than as objects.
+                if ($MFAUser['CAPolicies'] -is [string]) {
+                    $MFAUser['CAPolicies'] = try { $MFAUser['CAPolicies'] | ConvertFrom-Json -AsHashtable } catch { $MFAUser['CAPolicies'] }
+                }
+                if ($MFAUser['MFAMethods'] -is [string]) {
+                    $MFAUser['MFAMethods'] = try { $MFAUser['MFAMethods'] | ConvertFrom-Json -AsHashtable } catch { $MFAUser['MFAMethods'] }
+                }
+
+                $MFAUser['CacheTimestamp'] = $Item.Timestamp
+                # Tenant is already stored on every row by Get-CIPPMFAState; only fill it
+                # in for older rows that predate that.
+                if (-not $MFAUser['Tenant']) { $MFAUser['Tenant'] = $Item.PartitionKey }
+                $Results.Add($MFAUser)
+            }
+            return [PSCustomObject]@{
+                Items     = $Results
+                NextToken = $Page.NextToken
+            }
+        }
 
         # Handle AllTenants
         if ($TenantFilter -eq 'AllTenants') {

--- a/backend/Modules/CIPPCore/Public/Get-CIPPMailboxesReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPMailboxesReport.ps1
@@ -9,6 +9,10 @@ function Get-CIPPMailboxesReport {
     .PARAMETER TenantFilter
         The tenant to generate the report for
 
+    .PARAMETER PageSize
+        When set, returns one page of at most this many rows as @{ Items; NextToken }, in table walk order.    .PARAMETER ContinuationToken
+        NextToken from the previous page. Only meaningful together with PageSize.
+
     .EXAMPLE
         Get-CIPPMailboxesReport -TenantFilter 'contoso.onmicrosoft.com'
         Gets all mailboxes for the tenant from the report database
@@ -16,10 +20,33 @@ function Get-CIPPMailboxesReport {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$TenantFilter
+        [string]$TenantFilter,
+        [int]$PageSize,
+        [string]$ContinuationToken
     )
 
     try {
+        if ($PageSize -gt 0) {
+            $Page = Get-CIPPDbItemPage -TenantFilter $TenantFilter -Type 'Mailboxes' -PageSize $PageSize -ContinuationToken $ContinuationToken
+            if ($TenantFilter -ne 'AllTenants' -and -not $ContinuationToken -and @($Page.Items).Count -eq 0 -and -not $Page.NextToken) {
+                throw 'No mailbox data found in reporting database. Sync the report data first.'
+            }
+            $Results = [System.Collections.Generic.List[PSCustomObject]]::new()
+            foreach ($Item in $Page.Items) {
+                $Mailbox = $Item.Data | ConvertFrom-Json
+                # Per-item timestamp: a page may span tenants.
+                $Mailbox | Add-Member -NotePropertyName 'CacheTimestamp' -NotePropertyValue $Item.Timestamp -Force
+                if ($TenantFilter -eq 'AllTenants') {
+                    $Mailbox | Add-Member -NotePropertyName 'Tenant' -NotePropertyValue $Item.PartitionKey -Force
+                }
+                $Results.Add($Mailbox)
+            }
+            return [PSCustomObject]@{
+                Items     = $Results
+                NextToken = $Page.NextToken
+            }
+        }
+
         # Handle AllTenants
         if ($TenantFilter -eq 'AllTenants') {
             # Get all tenants that have mailbox data

--- a/backend/Modules/CIPPCore/Public/Get-CIPPPagedTableRows.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPPagedTableRows.ps1
@@ -1,0 +1,115 @@
+function Get-CIPPPagedTableRows {
+    <#
+    .FUNCTIONALITY
+    Internal
+    .SYNOPSIS
+    Reads one page of rows from an Azure Table by scanning an ordinal range of partitions.
+    .DESCRIPTION
+    Continuation-token pager over an ordinal (PartitionKey, RowKey) range: one range query
+    per chunk, so page cost tracks rows returned, not partition count. Rows from partitions
+    outside $PartitionKeys are dropped but still advance the cursor. A null NextToken means
+    the walk is complete.
+
+    Invariants: $PartitionKeys must be ordinal ascending; resume uses RowKey gt '<last>~'
+    ('~' sorts after every key character and the '-partN' rows, but an id that prefix-extends
+    another id could be skipped at a boundary - GUID ids cannot); -First counts physical
+    rows, so only an empty chunk proves the range drained, and the module completes any
+    split entity cut at the boundary (RecoverMissingPartRows) so pages hold whole entities.
+    .PARAMETER Table
+    Table splat from Get-CIPPTable.
+    .PARAMETER PartitionKeys
+    Partition keys to serve, ordinal ascending; the caller owns membership filtering.
+    .PARAMETER RowKeyGe
+    Optional inclusive RowKey lower bound (e.g. 'Guests-').
+    .PARAMETER RowKeyLt
+    Optional exclusive RowKey upper bound (e.g. 'Guests.').
+    .PARAMETER ExtraFilterClauses
+    Optional OData clauses ANDed onto every query; values must already be escaped.
+    .PARAMETER PageSize
+    Target kept rows per page (also the physical-row chunk size per query).
+    .PARAMETER MaxQueries
+    Safety bound on round trips per call; normally one or two are needed.
+    .PARAMETER ContinuationToken
+    NextToken from the previous call. Opaque to callers.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Table,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$PartitionKeys,
+        [string]$RowKeyGe,
+        [string]$RowKeyLt,
+        [string[]]$ExtraFilterClauses = @(),
+        [ValidateRange(1, 10000)]
+        [int]$PageSize = 5000,
+        [ValidateRange(1, 100)]
+        [int]$MaxQueries = 10,
+        [string]$ContinuationToken
+    )
+
+    $Rows = [System.Collections.Generic.List[object]]::new()
+    if ($PartitionKeys.Count -eq 0) {
+        return [PSCustomObject]@{ Rows = $Rows; NextToken = $null }
+    }
+
+    $Known = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($Pk in $PartitionKeys) { $null = $Known.Add($Pk) }
+
+    $CursorPk = $null
+    $CursorRk = $null
+    if ($ContinuationToken) {
+        $TokenParts = $ContinuationToken.Split('|', 2)
+        $CursorPk = [System.Uri]::UnescapeDataString($TokenParts[0])
+        if ($TokenParts.Count -eq 2 -and $TokenParts[1]) {
+            $CursorRk = [System.Uri]::UnescapeDataString($TokenParts[1])
+        }
+    }
+
+    $Queries = 0
+    $Exhausted = $false
+    while (-not $Exhausted -and $Queries -lt $MaxQueries -and $Rows.Count -lt $PageSize) {
+        $Clauses = [System.Collections.Generic.List[string]]::new()
+        $Clauses.Add("PartitionKey ge '{0}'" -f (ConvertTo-CIPPODataFilterValue -Value $PartitionKeys[0] -Type String))
+        $Clauses.Add("PartitionKey le '{0}'" -f (ConvertTo-CIPPODataFilterValue -Value $PartitionKeys[-1] -Type String))
+        if ($RowKeyGe) {
+            $Clauses.Add("RowKey ge '{0}'" -f (ConvertTo-CIPPODataFilterValue -Value $RowKeyGe -Type String))
+        }
+        if ($RowKeyLt) {
+            $Clauses.Add("RowKey lt '{0}'" -f (ConvertTo-CIPPODataFilterValue -Value $RowKeyLt -Type String))
+        }
+        if ($CursorPk) {
+            $SafePk = ConvertTo-CIPPODataFilterValue -Value $CursorPk -Type String
+            if ($CursorRk) {
+                $SafeRk = ConvertTo-CIPPODataFilterValue -Value $CursorRk -Type String
+                $Clauses.Add("((PartitionKey gt '$SafePk') or (PartitionKey eq '$SafePk' and RowKey gt '$SafeRk~'))")
+            } else {
+                # A token naming a partition but no row resumes from that partition's start.
+                $Clauses.Add("PartitionKey ge '$SafePk'")
+            }
+        }
+        foreach ($Clause in $ExtraFilterClauses) { $Clauses.Add($Clause) }
+
+        $Chunk = @(Get-CIPPAzDataTableEntity @Table -Filter ($Clauses -join ' and ') -First $PageSize)
+        $Queries++
+        if ($Chunk.Count -eq 0) {
+            $Exhausted = $true
+            break
+        }
+        foreach ($Row in $Chunk) {
+            if ($Known.Contains([string]$Row.PartitionKey)) { $Rows.Add($Row) }
+        }
+        $CursorPk = [string]$Chunk[-1].PartitionKey
+        $CursorRk = [string]$Chunk[-1].RowKey
+    }
+
+    $NextToken = if (-not $Exhausted) {
+        '{0}|{1}' -f [System.Uri]::EscapeDataString($CursorPk), $(if ($CursorRk) { [System.Uri]::EscapeDataString($CursorRk) } else { '' })
+    } else { $null }
+
+    return [PSCustomObject]@{
+        Rows      = $Rows
+        NextToken = $NextToken
+    }
+}

--- a/backend/Modules/CIPPCore/Public/GraphHelper/Write-LogMessage.ps1
+++ b/backend/Modules/CIPPCore/Public/GraphHelper/Write-LogMessage.ps1
@@ -47,6 +47,12 @@ function Write-LogMessage {
     $TzId = if ($env:CIPP_TIMEZONE) { $env:CIPP_TIMEZONE } else { 'UTC' }
     $LocalNow = [TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcNow, $TzId)
     $PartitionKey = $LocalNow.ToString('yyyyMMdd')
+    # Inverted-ticks RowKey: the table service returns rows in ascending RowKey order, so
+    # (MaxValue - now) makes a partition read newest-first without scanning it whole. The
+    # suffix keeps concurrent writers from colliding; Invoke-ListLogs derives the day
+    # partition back out of the tick prefix. Rows written before this scheme have GUID
+    # RowKeys and simply sort in arbitrary order within their (historical) partitions.
+    $RowKey = '{0:D19}-{1}' -f ([DateTime]::MaxValue.Ticks - [DateTime]::UtcNow.Ticks), [guid]::NewGuid().ToString('N').Substring(0, 12)
     $TableRow = @{
         'Tenant'       = [string]$tenant
         'API'          = [string]$API
@@ -55,7 +61,7 @@ function Write-LogMessage {
         'Severity'     = [string]$sev
         'sentAsAlert'  = $false
         'PartitionKey' = [string]$PartitionKey
-        'RowKey'       = [string]([guid]::NewGuid()).ToString()
+        'RowKey'       = [string]$RowKey
         'FunctionNode' = [string]$env:WEBSITE_SITE_NAME
         'LogData'      = [string]$LogData
     }

--- a/backend/Modules/CIPPCore/Public/GraphRequests/Get-GraphRequestList.ps1
+++ b/backend/Modules/CIPPCore/Public/GraphRequests/Get-GraphRequestList.ps1
@@ -81,10 +81,12 @@ function Get-GraphRequestList {
         [boolean]$AsApp = $false,
         [string]$Caller = 'Get-GraphRequestList',
         [switch]$UseBatchExpand,
-        [switch]$RawJsonArray
+        [switch]$RawJsonArray,
+        [int]$MaxPageBytes
     )
 
     $SingleTenantThreshold = 8000
+    $PagedAllTenants = $false
     Write-Information "Tenant: $TenantFilter"
     $TableName = ('cache{0}' -f ($Endpoint -replace '[^A-Za-z0-9]'))[0..62] -join ''
     $Endpoint = $Endpoint -replace '^/', ''
@@ -210,7 +212,28 @@ function Get-GraphRequestList {
                     $Filter = "PartitionKey eq '{0}' and (RowKey eq '{1}' or OriginalEntityId eq '{1}') and Timestamp ge datetime'{2}'" -f $PartitionKey, $TenantFilter, $Timestamp
                 }
                 $Tenants = Get-Tenants -IncludeErrors
-                $Rows = Get-CIPPAzDataTableEntity @Table -Filter $Filter | Where-Object { $_.OriginalEntityId -in $Tenants.defaultDomainName -or $_.RowKey -in $Tenants.defaultDomainName }
+                # Paged AllTenants serve: key scan here, bounded blob fetches in the serve branch.
+                $PagedAllTenants = $TenantFilter -eq 'AllTenants' -and $ManualPagination.IsPresent -and $RawJsonArray.IsPresent
+                if ($PagedAllTenants) {
+                    # Keys only, and none of the split-entity markers: projecting a subset of them
+                    # (e.g. OriginalEntityId alone) makes reassembly fail and drops split tenants.
+                    $KeyRows = Get-CIPPAzDataTableEntity @Table -Filter $Filter -Property PartitionKey, RowKey
+                    # Physical rows per tenant ('-part<n>' rows fold into their head); sizes the spans below.
+                    $PagedTenantRowCounts = [System.Collections.Generic.Dictionary[string, int]]::new([StringComparer]::Ordinal)
+                    foreach ($KeyRow in @($KeyRows)) {
+                        $TenantKey = [string]$KeyRow.RowKey -replace '-part\d+$', ''
+                        if ($TenantKey) {
+                            $PagedTenantRowCounts[$TenantKey] = 1 + $(if ($PagedTenantRowCounts.ContainsKey($TenantKey)) { $PagedTenantRowCounts[$TenantKey] } else { 0 })
+                        }
+                    }
+                    # Ordinal, to match the resume comparison below (a culture sort re-served tenants).
+                    $PagedTenantPlan = [string[]]@($PagedTenantRowCounts.Keys | Where-Object { $_ -in $Tenants.defaultDomainName })
+                    [System.Array]::Sort($PagedTenantPlan, [System.Collections.IComparer][StringComparer]::Ordinal)
+                    # $Rows gates queue-vs-serve below; an empty plan queues like an empty fetch.
+                    $Rows = $PagedTenantPlan
+                } else {
+                    $Rows = Get-CIPPAzDataTableEntity @Table -Filter $Filter | Where-Object { $_.OriginalEntityId -in $Tenants.defaultDomainName -or $_.RowKey -in $Tenants.defaultDomainName }
+                }
                 $Type = 'Cache'
                 Write-Information "Table: $TableName | PK: $PartitionKey | Cached: $(($Rows | Measure-Object).Count) rows (Type: $($Type))"
                 $QueueReference = '{0}-{1}' -f $TenantFilter, $PartitionKey
@@ -436,6 +459,71 @@ function Get-GraphRequestList {
         }
     } else {
         if ($RawJsonArray.IsPresent) {
+            if ($PagedAllTenants) {
+                # One page of whole tenant blobs, ended by the byte budget alone (never a tenant
+                # count); tenants are fetched in RowKey-range spans so split blobs reassemble.
+                $MaxPageChars = if ($MaxPageBytes -gt 0) { [Math]::Min([Math]::Max($MaxPageBytes, 262144), 8388608) } else { 4000000 }
+                # Rows are <= ~1MB each, so a row cap bounds a span's worst-case fetch.
+                $SpanRowCap = 40
+                $StartAfter = if ($nextLink) { $nextLink } else { $null }
+
+                $Remaining = [System.Collections.Generic.List[string]]::new()
+                foreach ($TenantKey in $PagedTenantPlan) {
+                    if (-not $StartAfter -or [string]::CompareOrdinal($TenantKey, $StartAfter) -gt 0) { $Remaining.Add($TenantKey) }
+                }
+
+                $JsonParts = [System.Collections.Generic.List[string]]::new()
+                $Chars = 0
+                $Queries = 0
+                $LastEmitted = $null
+                $BudgetReached = $false
+                $Index = 0
+                while ($Index -lt $Remaining.Count -and -not $BudgetReached) {
+                    # Build the next span: consecutive plan tenants until the row cap fills.
+                    $SpanStart = $Index
+                    $SpanRows = 0
+                    $SpanSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+                    while ($Index -lt $Remaining.Count) {
+                        $Candidate = $Remaining[$Index]
+                        $CandidateRows = $PagedTenantRowCounts[$Candidate]
+                        if ($SpanSet.Count -gt 0 -and ($SpanRows + $CandidateRows) -gt $SpanRowCap) { break }
+                        $null = $SpanSet.Add($Candidate)
+                        $SpanRows += $CandidateRows
+                        $Index++
+                    }
+                    $SpanFirst = ConvertTo-CIPPODataFilterValue -Value $Remaining[$SpanStart] -Type String
+                    $SpanLast = ConvertTo-CIPPODataFilterValue -Value $Remaining[$Index - 1] -Type String
+                    # le '<last>~' keeps the last tenant's '-partN' rows in range; non-member rows
+                    # the range also catches are dropped below.
+                    $SpanFilter = "PartitionKey eq '{0}' and RowKey ge '{1}' and RowKey le '{2}~' and Timestamp ge datetime'{3}'" -f $PartitionKey, $SpanFirst, $SpanLast, $Timestamp
+                    # Budget is enforced per whole tenant; the rest of a span past it is discarded
+                    # and re-fetched by the next page.
+                    foreach ($Row in @(Get-CIPPAzDataTableEntity @Table -Filter $SpanFilter)) {
+                        if (-not $SpanSet.Contains([string]$Row.RowKey)) { continue }
+                        if ($BudgetReached) { break }
+                        $LastEmitted = [string]$Row.RowKey
+                        if ($Row.Data) {
+                            $d = $Row.Data.Trim()
+                            if ($d.Length -gt 2 -and $d[0] -eq '[' -and $d[-1] -eq ']') {
+                                $JsonParts.Add($d.Substring(1, $d.Length - 2))
+                                $Chars += $d.Length
+                            } elseif ($d.Length -gt 0 -and $d -ne '[]') {
+                                $JsonParts.Add($d)
+                                $Chars += $d.Length
+                            }
+                        }
+                        if ($Chars -ge $MaxPageChars) { $BudgetReached = $true }
+                    }
+                    $Queries++
+                }
+                # A drained plan is complete even if the last tenant landed on the budget.
+                $MoreRemain = $BudgetReached -and $null -ne $LastEmitted -and [string]::CompareOrdinal($LastEmitted, $Remaining[$Remaining.Count - 1]) -lt 0
+                Write-Information "Paged AllTenants cache serve: $Queries spans, $Chars chars, last: $LastEmitted, more: $MoreRemain"
+                return [PSCustomObject]@{
+                    CippPagedJson = '[' + ($JsonParts -join ',') + ']'
+                    CippNextLink  = if ($MoreRemain) { $LastEmitted } else { $null }
+                }
+            }
             # Fast path: concatenate raw JSON strings without deserialization. This is much faster and uses less memory when no post-processing is needed, especially for large datasets.
             $JsonParts = [System.Collections.Generic.List[string]]::new()
             foreach ($Row in $Rows) {

--- a/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheGroups.ps1
+++ b/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheGroups.ps1
@@ -77,6 +77,12 @@ function Set-CIPPDBCacheGroups {
                 $NoteProperties = [ordered]@{}
                 if ($Group.id -and $Group.groupTypes -notcontains 'DynamicMembership') {
                     $NoteProperties['members'] = $MembersByGroupId[$Group.id]
+                    # Precompute the UPN CSV so the paged list read can stream the stored blob
+                    # verbatim instead of parsing every member array (heavy on 50k-member groups).
+                    $NoteProperties['membersCsv'] = ($MembersByGroupId[$Group.id].userPrincipalName -join ',')
+                }
+                if ($Group.owners) {
+                    $NoteProperties['ownersCsv'] = ($Group.owners.userPrincipalName -join ',')
                 }
                 $NoteProperties['primDomain'] = ($Group.mail -split '@' | Select-Object -Last 1)
                 $NoteProperties['teamsEnabled'] = ($Group.resourceProvisioningOptions -contains 'Team')

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListGraphRequest.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListGraphRequest.ps1
@@ -113,6 +113,12 @@ function Invoke-ListGraphRequest {
         $GraphRequestParams.nextLink = $Request.Query.nextLink
     }
 
+    # Paged AllTenants cache reads only: target page size in bytes of raw JSON, clamped
+    # between 262144 and 8388608 (default 4000000). Pages always hold at least one whole tenant.
+    if ($Request.Query.maxPageBytes -as [int]) {
+        $GraphRequestParams.MaxPageBytes = [int]$Request.Query.maxPageBytes
+    }
+
     # Return just the number of matching records instead of the records themselves. The
     # cheapest way to size a collection before deciding whether to fetch it.
     if ($Request.Query.CountOnly) {
@@ -163,6 +169,27 @@ function Invoke-ListGraphRequest {
 
         if ($script:LastGraphResponseHeaders) {
             $Metadata.GraphHeaders = $script:LastGraphResponseHeaders
+        }
+
+        # Paged AllTenants cache serve: one page of tenant blobs plus Metadata.nextLink.
+        if ($UseRawJson -and $Results -isnot [string] -and $Results.PSObject.Properties.Name -contains 'CippPagedJson') {
+            if ($Request.Headers.'x-ms-coldstart' -eq 1) {
+                $Metadata.ColdStart = $true
+            }
+            if ($Results.CippNextLink) {
+                $Metadata.nextLink = $Results.CippNextLink
+            } else {
+                # Do not echo the incoming token back on the final page.
+                $Metadata.Remove('nextLink')
+            }
+            $MetadataJson = ConvertTo-Json -InputObject $Metadata -Depth 5 -Compress
+            $GraphRequestData = '{"Results":' + $Results.CippPagedJson + ',"Metadata":' + $MetadataJson + '}'
+
+            return ([HttpResponseContext]@{
+                    StatusCode  = [HttpStatusCode]::OK
+                    ContentType = 'application/json'
+                    Body        = $GraphRequestData
+                })
         }
 
         # RawJsonArray returns a JSON string directly — skip object-level processing

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListLogs.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListLogs.ps1
@@ -5,64 +5,91 @@ function Invoke-ListLogs {
     .ROLE
         CIPP.Core.Read
     .DESCRIPTION
-        Lists CIPP platform audit logs with filtering by severity, date range, tenant, and user. Supports listing available log categories.
+        Lists CIPP platform audit logs with filtering by severity, date range, tenant, and user. Supports listing available log categories, fetching a single entry, and server-side pagination via manualPagination/nextLink.
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
     $Table = Get-CIPPTable
     $TzId = if ($env:CIPP_TIMEZONE) { $env:CIPP_TIMEZONE } else { 'UTC' }
+    $LocalNow = [TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcNow, $TzId)
 
-    $TemplatesTable = Get-CIPPTable -tablename 'templates'
-    $Templates = Get-CIPPAzDataTableEntity @TemplatesTable
+    function Get-LogStandardInfo {
+        param($Row, $Templates)
+        if (-not $Row.StandardTemplateId) { return @{} }
+        $Standard = ($Templates | Where-Object { $_.RowKey -eq $Row.StandardTemplateId }).JSON | ConvertFrom-Json
 
-    $ReturnedLog = if ($Request.Query.ListLogs) {
-        Get-AzDataTableEntity @Table -Property PartitionKey | Sort-Object -Unique PartitionKey | Select-Object PartitionKey | ForEach-Object {
+        $StandardInfo = @{
+            Template = $Standard.templateName
+            Standard = $Row.Standard
+        }
+
+        if ($Row.IntuneTemplateId) {
+            $IntuneTemplate = ($Templates | Where-Object { $_.RowKey -eq $Row.IntuneTemplateId }).JSON | ConvertFrom-Json
+            $StandardInfo.IntunePolicy = $IntuneTemplate.displayName
+        }
+        if ($Row.ConditionalAccessTemplateId) {
+            $ConditionalAccessTemplate = ($Templates | Where-Object { $_.RowKey -eq $Row.ConditionalAccessTemplateId }).JSON | ConvertFrom-Json
+            $StandardInfo.ConditionalAccessPolicy = $ConditionalAccessTemplate.displayName
+        }
+        return $StandardInfo
+    }
+
+    if ($Request.Query.ListLogs) {
+        $ReturnedLog = Get-CIPPAzDataTableEntity @Table -Property PartitionKey | Sort-Object -Unique PartitionKey | Select-Object PartitionKey | ForEach-Object {
             @{
                 value = $_.PartitionKey
                 label = $_.PartitionKey
             }
         }
-    } elseif ($Request.Query.logentryid) {
-        # Return single log entry by RowKey
-        $LocalNow = [TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcNow, $TzId)
-        $DateFilter = ConvertTo-CIPPODataFilterValue -Value ($Request.Query.DateFilter ?? $LocalNow.ToString('yyyyMMdd')) -Type Date
-        $SafeLogEntryId = ConvertTo-CIPPODataFilterValue -Value $Request.Query.logentryid -Type Guid
-        $Filter = "RowKey eq '{0}' and PartitionKey eq '{1}'" -f $SafeLogEntryId, $DateFilter
+        return [HttpResponseContext]@{
+            StatusCode = [HttpStatusCode]::OK
+            Body       = @($ReturnedLog)
+        }
+    }
+
+    if ($Request.Query.logentryid) {
+        # Return single log entry by RowKey. RowKeys are either legacy GUIDs or the
+        # inverted-ticks format Write-LogMessage writes; both use only hex digits and hyphens.
+        $LogEntryId = [string]$Request.Query.logentryid
+        if ($LogEntryId -notmatch '^[0-9a-fA-F-]{1,64}$') {
+            throw "Invalid log entry id format: '$LogEntryId'"
+        }
+        $DateFilter = if ($Request.Query.DateFilter) {
+            ConvertTo-CIPPODataFilterValue -Value $Request.Query.DateFilter -Type Date
+        } elseif ($LogEntryId -match '^(?<Inverted>\d{19})-') {
+            # New-format RowKeys embed the write time, so links without a dateFilter (e.g. from
+            # the API logs drawer) resolve regardless of which day the entry was written.
+            try {
+                $Ticks = [DateTime]::MaxValue.Ticks - [long]$Matches.Inverted
+                [TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::new($Ticks, [DateTimeKind]::Utc), $TzId).ToString('yyyyMMdd')
+            } catch {
+                $LocalNow.ToString('yyyyMMdd')
+            }
+        } else {
+            $LocalNow.ToString('yyyyMMdd')
+        }
+        $Filter = "RowKey eq '{0}' and PartitionKey eq '{1}'" -f $LogEntryId, $DateFilter
         $AllowedTenants = Test-CIPPAccess -Request $Request -TenantList
-        Write-Host "Getting single log entry for RowKey: $($Request.Query.logentryid)"
+        Write-Host "Getting single log entry for RowKey: $LogEntryId"
 
-        $Row = Get-AzDataTableEntity @Table -Filter $Filter
+        $Row = Get-CIPPAzDataTableEntity @Table -Filter $Filter
 
-        if ($Row) {
+        $ReturnedLog = if ($Row) {
             if ($AllowedTenants -notcontains 'AllTenants') {
                 $TenantList = Get-Tenants -IncludeErrors | Where-Object { $_.customerId -in $AllowedTenants }
             }
 
             if ($AllowedTenants -contains 'AllTenants' -or ($AllowedTenants -notcontains 'AllTenants' -and ($TenantList.defaultDomainName -contains $Row.Tenant -or $Row.Tenant -eq 'CIPP' -or $TenantList.customerId -contains $Row.TenantId -or $TenantList.initialDomainName -contains $Row.Tenant)) ) {
-                if ($Row.StandardTemplateId) {
-                    $Standard = ($Templates | Where-Object { $_.RowKey -eq $Row.StandardTemplateId }).JSON | ConvertFrom-Json
-
-                    $StandardInfo = @{
-                        Template = $Standard.templateName
-                        Standard = $Row.Standard
-                    }
-
-                    if ($Row.IntuneTemplateId) {
-                        $IntuneTemplate = ($Templates | Where-Object { $_.RowKey -eq $Row.IntuneTemplateId }).JSON | ConvertFrom-Json
-                        $StandardInfo.IntunePolicy = $IntuneTemplate.displayName
-                    }
-                    if ($Row.ConditionalAccessTemplateId) {
-                        $ConditionalAccessTemplate = ($Templates | Where-Object { $_.RowKey -eq $Row.ConditionalAccessTemplateId }).JSON | ConvertFrom-Json
-                        $StandardInfo.ConditionalAccessPolicy = $ConditionalAccessTemplate.displayName
-                    }
-
-                } else {
-                    $StandardInfo = @{}
-                }
-
+                $StandardInfo = if ($Row.StandardTemplateId) {
+                    $TemplatesTable = Get-CIPPTable -tablename 'templates'
+                    $Templates = Get-CIPPAzDataTableEntity @TemplatesTable
+                    Get-LogStandardInfo -Row $Row -Templates $Templates
+                } else { @{} }
                 $LogData = if ($Row.LogData -and (Test-Json -Json $Row.LogData -ErrorAction SilentlyContinue)) {
                     $Row.LogData | ConvertFrom-Json
                 } else { $Row.LogData }
+                # Same record shape as the list paths below, except the log entry page reads
+                # the template info as 'Standard' rather than 'StandardInfo'.
                 [PSCustomObject]@{
                     DateTime   = $Row.Timestamp
                     Tenant     = $Row.Tenant
@@ -84,129 +111,235 @@ function Invoke-ListLogs {
                 }
             }
         }
+        return [HttpResponseContext]@{
+            StatusCode = [HttpStatusCode]::OK
+            Body       = @($ReturnedLog)
+        }
+    }
+
+    # When true, the Severity/User/Tenant/API/StartDate/EndDate query filters are applied; otherwise the current day is returned unfiltered.
+    if ($Request.Query.Filter -eq $true) {
+        $LogLevel = if ($Request.Query.Severity) { ($Request.Query.Severity).split(',') } else { 'Info', 'Warn', 'Warning', 'Error', 'Critical', 'Alert' }
+        $Username = $Request.Query.User ?? '*'
+        $TenantFilter = $Request.Query.Tenant
+        $ApiFilter = $Request.Query.API
+        $StandardFilter = $Request.Query.StandardTemplateId
+        $ScheduledTaskFilter = $Request.Query.ScheduledTaskId
+        $BaselineRunFilter = $Request.Query.BaselineRunId
+        $StartDateRaw = $Request.Query.StartDate ?? $Request.Query.DateFilter
+        $EndDateRaw = $Request.Query.EndDate ?? $Request.Query.DateFilter
     } else {
-        if ($request.Query.Filter -eq $true) {
-            $LogLevel = if ($Request.Query.Severity) { ($Request.query.Severity).split(',') } else { 'Info', 'Warn', 'Warning', 'Error', 'Critical', 'Alert' }
-            $PartitionKey = $Request.Query.DateFilter
-            $username = $Request.Query.User ?? '*'
-            $TenantFilter = $Request.Query.Tenant
-            $ApiFilter = $Request.Query.API
-            $StandardFilter = $Request.Query.StandardTemplateId
-            $ScheduledTaskFilter = $Request.Query.ScheduledTaskId
-            $BaselineRunFilter = $Request.Query.BaselineRunId
+        $LogLevel = 'Info', 'Warn', 'Warning', 'Error', 'Critical', 'Alert'
+        $Username = '*'
+        $TenantFilter = $null
+        $ApiFilter = $null
+        $StandardFilter = $null
+        $ScheduledTaskFilter = $null
+        $BaselineRunFilter = $null
+        $StartDateRaw = $null
+        $EndDateRaw = $null
+    }
 
-            $StartDate = if ($Request.Query.StartDate ?? $Request.Query.DateFilter) { ConvertTo-CIPPODataFilterValue -Value ($Request.Query.StartDate ?? $Request.Query.DateFilter) -Type Date } else { $null }
-            $EndDate = if ($Request.Query.EndDate ?? $Request.Query.DateFilter) { ConvertTo-CIPPODataFilterValue -Value ($Request.Query.EndDate ?? $Request.Query.DateFilter) -Type Date } else { $null }
+    $StartDate = if ($StartDateRaw) { ConvertTo-CIPPODataFilterValue -Value $StartDateRaw -Type Date } else { $null }
+    $EndDate = if ($EndDateRaw) { ConvertTo-CIPPODataFilterValue -Value $EndDateRaw -Type Date } else { $null }
 
-            # Days=N widens a filtered query to the last N calendar days (in the instance timezone).
-            # The scoped drawers (standard template, scheduled task, baseline run) use this: a run
-            # that finished last night otherwise shows an empty log early the next day, because the
-            # default window is "today" only.
-            $Days = $Request.Query.Days -as [int]
-            if (-not $StartDate -and -not $EndDate -and $Days -gt 0) {
-                $LocalToday = [TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcNow, $TzId)
-                $StartDate = $LocalToday.AddDays(-([Math]::Min($Days, 90) - 1)).ToString('yyyyMMdd')
-                $EndDate = $LocalToday.ToString('yyyyMMdd')
+    # Days=N widens a filtered query to the last N calendar days (in the instance timezone),
+    # so the scoped drawers still show a run that finished last night. Ignored when dates are given.
+    $Days = if ($Request.Query.Filter -eq $true) { $Request.Query.Days -as [int] } else { 0 }
+    if (-not $StartDate -and -not $EndDate -and $Days -gt 0) {
+        $StartDate = $LocalNow.Date.AddDays(-([Math]::Min($Days, 90) - 1)).ToString('yyyyMMdd')
+        $EndDate = $LocalNow.ToString('yyyyMMdd')
+    }
+
+    # Severity stays client-side: Azurite/Azure Table OData has been unreliable
+    # on long OR chains. Per-partition row counts are small enough that this is fine.
+    $ServerSideFilter = [System.Collections.Generic.List[string]]::new()
+    if ($StandardFilter) {
+        $SafeStd = ConvertTo-CIPPODataFilterValue -Value $StandardFilter -Type Guid
+        $ServerSideFilter.Add("StandardTemplateId eq '$SafeStd'")
+    }
+    if ($ScheduledTaskFilter) {
+        $SafeSched = ConvertTo-CIPPODataFilterValue -Value $ScheduledTaskFilter -Type Guid
+        $ServerSideFilter.Add("ScheduledTaskId eq '$SafeSched'")
+    }
+    if ($BaselineRunFilter) {
+        $SafeRun = ConvertTo-CIPPODataFilterValue -Value $BaselineRunFilter -Type Guid
+        $ServerSideFilter.Add("BaselineRunId eq '$SafeRun'")
+    }
+
+    $AllowedTenants = Test-CIPPAccess -Request $Request -TenantList
+    if ($AllowedTenants -notcontains 'AllTenants') {
+        $TenantList = Get-Tenants -IncludeErrors | Where-Object { $_.customerId -in $AllowedTenants }
+    }
+
+    # Templates are only needed to resolve StandardInfo names, and only the scheduled-task
+    # view renders those - skip the extra table read everywhere else.
+    $Templates = if ($ScheduledTaskFilter) {
+        $TemplatesTable = Get-CIPPTable -tablename 'templates'
+        Get-CIPPAzDataTableEntity @TemplatesTable
+    } else { $null }
+
+    # The row-level filters that cannot (or should not) go into the table query.
+    $RowFilter = {
+        param($Row)
+        $Row.Severity -in $LogLevel -and
+        ($Username -eq '*' -or $Row.Username -like $Username) -and
+        ([string]::IsNullOrEmpty($TenantFilter) -or $TenantFilter -eq 'AllTenants' -or $Row.Tenant -like "*$TenantFilter*" -or $Row.TenantID -eq $TenantFilter) -and
+        ([string]::IsNullOrEmpty($ApiFilter) -or $Row.API -match "$ApiFilter") -and
+        ($AllowedTenants -contains 'AllTenants' -or $TenantList.defaultDomainName -contains $Row.Tenant -or $Row.Tenant -eq 'CIPP' -or $TenantList.customerId -contains $Row.TenantId)
+    }
+
+    # Return one page per request plus a continuation token in Metadata.nextLink, which the
+    # frontend passes back as nextLink to fetch the next page. Pages walk the requested date
+    # range newest-day-first and, within a day, in RowKey order (newest-first for entries
+    # written with the inverted-ticks RowKey scheme).
+    if ($Request.Query.manualPagination -and [System.Convert]::ToBoolean($Request.Query.manualPagination)) {
+        $PageSize = 400
+        # Rows to return per page, clamped between 50 and 1000. Defaults to 400.
+        if ($Request.Query.PageSize -as [int]) {
+            $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 50), 1000)
+        }
+        # Bound the table round trips a single request can make, so a filter that matches
+        # nothing across many partitions returns a short (possibly empty) page with a
+        # nextLink instead of scanning until the gateway times out.
+        $MaxQueries = 10
+
+        $ParseDay = {
+            param($Value)
+            # ConvertTo-CIPPODataFilterValue has already validated the shape; normalize
+            # yyyy-MM-dd / ISO datetime forms down to a date.
+            [datetime]::ParseExact(($Value -replace '-', '').Substring(0, 8), 'yyyyMMdd', [cultureinfo]::InvariantCulture)
+        }
+        $EndDay = if ($EndDate) { & $ParseDay $EndDate } elseif ($StartDate) { & $ParseDay $StartDate } else { $LocalNow.Date }
+        $StartDay = if ($StartDate) { & $ParseDay $StartDate } else { $EndDay }
+        if (($EndDay - $StartDay).TotalDays -gt 366) { $StartDay = $EndDay.AddDays(-366) }
+
+        $CursorDay = $EndDay
+        $LastRowKey = $null
+        # Continuation token from the previous page's Metadata.nextLink; opaque to callers.
+        if ($Request.Query.nextLink) {
+            $TokenParts = ([string]$Request.Query.nextLink).Split('|', 2)
+            $CursorDay = [datetime]::ParseExact($TokenParts[0], 'yyyyMMdd', [cultureinfo]::InvariantCulture)
+            if ($CursorDay -gt $EndDay) { $CursorDay = $EndDay }
+            if ($TokenParts.Count -eq 2 -and $TokenParts[1]) {
+                $LastRowKey = $TokenParts[1]
             }
+        }
 
-            if ($StartDate -and $EndDate) {
-                $Filter = "PartitionKey ge '$StartDate' and PartitionKey le '$EndDate'"
-            } elseif ($StartDate) {
-                $Filter = "PartitionKey eq '{0}'" -f $StartDate
+        $Rows = [System.Collections.Generic.List[object]]::new()
+        $Queries = 0
+        $Exhausted = $CursorDay -lt $StartDay
+        while (-not $Exhausted -and $Queries -lt $MaxQueries -and $Rows.Count -lt $PageSize) {
+            $Filter = "PartitionKey eq '{0}'" -f $CursorDay.ToString('yyyyMMdd')
+            if ($LastRowKey) {
+                $SafeRowKey = ConvertTo-CIPPODataFilterValue -Value $LastRowKey -Type String
+                # '~' sorts after every character valid in these RowKeys, so this resumes
+                # strictly after the last returned entity including any of its '-partN'
+                # split-entity continuation rows.
+                $Filter = "$Filter and RowKey gt '$SafeRowKey~'"
+            }
+            foreach ($Clause in $ServerSideFilter) { $Filter = "$Filter and $Clause" }
+
+            $Chunk = @(Get-CIPPAzDataTableEntity @Table -Filter $Filter -First $PageSize)
+            $Queries++
+            if ($Chunk.Count -gt 0) {
+                $LastRowKey = $Chunk[-1].RowKey
+                foreach ($Row in $Chunk) {
+                    if (& $RowFilter $Row) {
+                        $StandardInfo = if ($ScheduledTaskFilter) { Get-LogStandardInfo -Row $Row -Templates $Templates } else { @{} }
+                        $LogData = if ($Row.LogData -and (Test-Json -Json $Row.LogData -ErrorAction SilentlyContinue)) {
+                            $Row.LogData | ConvertFrom-Json
+                        } else { $Row.LogData }
+                        # Keep this record shape identical to the legacy list path below - the
+                        # frontend treats paged and unpaged rows interchangeably.
+                        $Rows.Add([PSCustomObject]@{
+                                DateTime     = $Row.Timestamp
+                                Tenant       = $Row.Tenant
+                                API          = $Row.API
+                                Message      = $Row.Message
+                                User         = $Row.Username
+                                Severity     = $Row.Severity
+                                LogData      = $LogData
+                                TenantID     = if ($null -ne $Row.TenantID) {
+                                    $Row.TenantID
+                                } else {
+                                    'None'
+                                }
+                                AppId        = $Row.AppId
+                                IP           = $Row.IP
+                                RowKey       = $Row.RowKey
+                                StandardInfo = $StandardInfo
+                                DateFilter   = $Row.PartitionKey
+                            })
+                    }
+                }
             } else {
-                $Filter = "PartitionKey eq '{0}'" -f [TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcNow, $TzId).ToString('yyyyMMdd')
+                # -First counts physical rows before split-entity reassembly, so a short
+                # chunk does not prove the partition is drained; only an empty one does.
+                $CursorDay = $CursorDay.AddDays(-1)
+                $LastRowKey = $null
+                if ($CursorDay -lt $StartDay) { $Exhausted = $true }
             }
-        } else {
-            $LogLevel = 'Info', 'Warn', 'Warning', 'Error', 'Critical', 'Alert'
-            $PartitionKey = [TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcNow, $TzId).ToString('yyyyMMdd')
-            $username = '*'
-            $TenantFilter = $null
-            $ApiFilter = $null
-            $StandardFilter = $null
-            $ScheduledTaskFilter = $null
-            $BaselineRunFilter = $null
-            $Filter = "PartitionKey eq '{0}'" -f $PartitionKey
         }
 
-        # Severity stays client-side: Azurite/Azure Table OData has been unreliable
-        # on long OR chains. Per-partition row counts are small enough that this is fine.
-        if ($StandardFilter) {
-            $SafeStd = ConvertTo-CIPPODataFilterValue -Value $StandardFilter -Type Guid
-            $Filter = "$Filter and StandardTemplateId eq '$SafeStd'"
+        $Metadata = @{}
+        if (-not $Exhausted) {
+            $Metadata.nextLink = '{0}|{1}' -f $CursorDay.ToString('yyyyMMdd'), $LastRowKey
         }
-        if ($ScheduledTaskFilter) {
-            $SafeSched = ConvertTo-CIPPODataFilterValue -Value $ScheduledTaskFilter -Type Guid
-            $Filter = "$Filter and ScheduledTaskId eq '$SafeSched'"
+        return [HttpResponseContext]@{
+            StatusCode = [HttpStatusCode]::OK
+            Body       = [PSCustomObject]@{
+                # Walk order is already newest-first for inverted-ticks RowKeys, and more
+                # truthful than re-sorting on the table Timestamp, which jitters at ms
+                # granularity for near-simultaneous writes. Rows from pre-scheme GUID-keyed
+                # partitions arrive unordered; the logs table sorts by DateTime client-side.
+                Results  = @($Rows)
+                Metadata = $Metadata
+            }
         }
-        if ($BaselineRunFilter) {
-            $SafeRun = ConvertTo-CIPPODataFilterValue -Value $BaselineRunFilter -Type Guid
-            $Filter = "$Filter and BaselineRunId eq '$SafeRun'"
-        }
+    }
 
-        $AllowedTenants = Test-CIPPAccess -Request $Request -TenantList
-        Write-Host "Getting logs for filter: $Filter, LogLevel: $LogLevel, Username: $username"
+    # Legacy unpaginated path: fetch the whole requested range in one go and return a bare
+    # array. Kept for callers that do not speak the Results/Metadata pagination contract.
+    if ($StartDate -and $EndDate) {
+        $Filter = "PartitionKey ge '$StartDate' and PartitionKey le '$EndDate'"
+    } elseif ($StartDate) {
+        $Filter = "PartitionKey eq '{0}'" -f $StartDate
+    } else {
+        $Filter = "PartitionKey eq '{0}'" -f $LocalNow.ToString('yyyyMMdd')
+    }
+    foreach ($Clause in $ServerSideFilter) { $Filter = "$Filter and $Clause" }
+    Write-Host "Getting logs for filter: $Filter, LogLevel: $LogLevel, Username: $Username"
 
-        if ($AllowedTenants -notcontains 'AllTenants') {
-            $TenantList = Get-Tenants -IncludeErrors | Where-Object { $_.customerId -in $AllowedTenants }
-        }
-
-        $ReturnedLog = Get-AzDataTableEntity @Table -Filter $Filter | Where-Object {
-            $_.Severity -in $LogLevel -and
-            ($username -eq '*' -or $_.Username -like $username) -and
-            ([string]::IsNullOrEmpty($TenantFilter) -or $TenantFilter -eq 'AllTenants' -or $_.Tenant -like "*$TenantFilter*" -or $_.TenantID -eq $TenantFilter) -and
-            ([string]::IsNullOrEmpty($ApiFilter) -or $_.API -match "$ApiFilter") -and
-            ($AllowedTenants -contains 'AllTenants' -or $TenantList.defaultDomainName -contains $_.Tenant -or $_.Tenant -eq 'CIPP' -or $TenantList.customerId -contains $_.TenantId)
-        } | ForEach-Object {
-            $Row = $_
-            if ($ScheduledTaskFilter -and $Row.StandardTemplateId) {
-                $Standard = ($Templates | Where-Object { $_.RowKey -eq $Row.StandardTemplateId }).JSON | ConvertFrom-Json
-
-                $StandardInfo = @{
-                    Template = $Standard.templateName
-                    Standard = $Row.Standard
-                }
-
-                if ($Row.IntuneTemplateId) {
-                    $IntuneTemplate = ($Templates | Where-Object { $_.RowKey -eq $Row.IntuneTemplateId }).JSON | ConvertFrom-Json
-                    $StandardInfo.IntunePolicy = $IntuneTemplate.displayName
-                }
-                if ($Row.ConditionalAccessTemplateId) {
-                    $ConditionalAccessTemplate = ($Templates | Where-Object { $_.RowKey -eq $Row.ConditionalAccessTemplateId }).JSON | ConvertFrom-Json
-                    $StandardInfo.ConditionalAccessPolicy = $ConditionalAccessTemplate.displayName
-                }
+    $ReturnedLog = Get-CIPPAzDataTableEntity @Table -Filter $Filter | Where-Object { & $RowFilter $_ } | ForEach-Object {
+        $Row = $_
+        $StandardInfo = if ($ScheduledTaskFilter) { Get-LogStandardInfo -Row $Row -Templates $Templates } else { @{} }
+        $LogData = if ($Row.LogData -and (Test-Json -Json $Row.LogData -ErrorAction SilentlyContinue)) {
+            $Row.LogData | ConvertFrom-Json
+        } else { $Row.LogData }
+        [PSCustomObject]@{
+            DateTime     = $Row.Timestamp
+            Tenant       = $Row.Tenant
+            API          = $Row.API
+            Message      = $Row.Message
+            User         = $Row.Username
+            Severity     = $Row.Severity
+            LogData      = $LogData
+            TenantID     = if ($null -ne $Row.TenantID) {
+                $Row.TenantID
             } else {
-                $StandardInfo = @{}
+                'None'
             }
-
-            $LogData = if ($Row.LogData -and (Test-Json -Json $Row.LogData -ErrorAction SilentlyContinue)) {
-                $Row.LogData | ConvertFrom-Json
-            } else { $Row.LogData }
-            [PSCustomObject]@{
-                DateTime     = $Row.Timestamp
-                Tenant       = $Row.Tenant
-                API          = $Row.API
-                Message      = $Row.Message
-                User         = $Row.Username
-                Severity     = $Row.Severity
-                LogData      = $LogData
-                TenantID     = if ($null -ne $Row.TenantID) {
-                    $Row.TenantID
-                } else {
-                    'None'
-                }
-                AppId        = $Row.AppId
-                IP           = $Row.IP
-                RowKey       = $Row.RowKey
-                StandardInfo = $StandardInfo
-                DateFilter   = $Row.PartitionKey
-            }
+            AppId        = $Row.AppId
+            IP           = $Row.IP
+            RowKey       = $Row.RowKey
+            StandardInfo = $StandardInfo
+            DateFilter   = $Row.PartitionKey
         }
-        $ReturnedLog
     }
 
     return [HttpResponseContext]@{
         StatusCode = [HttpStatusCode]::OK
         Body       = @($ReturnedLog | Sort-Object -Property DateTime -Descending)
     }
-
 }

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ListExcludedLicenses.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Settings/Invoke-ListExcludedLicenses.ps1
@@ -30,7 +30,7 @@ function Invoke-ListExcludedLicenses {
                 $_ | Add-Member -NotePropertyName 'ExcludedEverywhere' -NotePropertyValue $true -Force
             }
             if ($null -eq $_.ShowInLicenseDropdown) {
-                $_ | Add-Member -NotePropertyName 'ShowInLicenseDropdown' -NotePropertyValue $false -Force
+                $_ | Add-Member -NotePropertyName 'ShowInLicenseDropdown' -NotePropertyValue $true -Force
             }
             $ExclusionType = if ($_.ExcludedEverywhere -eq $true) { 'Excluded Everywhere' } else { 'Excluded from Alerts Only' }
             $_ | Add-Member -NotePropertyName 'ExclusionType' -NotePropertyValue $ExclusionType -Force

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1
@@ -5,7 +5,7 @@ function Invoke-ListMailboxes {
     .ROLE
         Exchange.Mailbox.Read
     .DESCRIPTION
-        Lists Exchange Online mailboxes for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants.
+        Lists Exchange Online mailboxes for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants. When manualPagination is also set, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
@@ -13,10 +13,30 @@ function Invoke-ListMailboxes {
     $TenantFilter = $Request.Query.tenantFilter
     # Serve from the reporting database cache instead of live Graph. Much faster, especially for AllTenants.
     $UseReportDB = $Request.Query.UseReportDB -eq $true
+    # Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.
+    $ManualPagination = $Request.Query.manualPagination -and [System.Convert]::ToBoolean($Request.Query.manualPagination)
     try {
         # If UseReportDB is specified, retrieve from report database
         if ($UseReportDB) {
             try {
+                if ($ManualPagination) {
+                    # Rows per page, clamped between 250 and 10000. Defaults to 5000.
+                    $PageSize = 5000
+                    if ($Request.Query.PageSize -as [int]) {
+                        $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 250), 10000)
+                    }
+                    # Continuation token from the previous page's Metadata.nextLink; opaque to callers.
+                    $Page = Get-CIPPMailboxesReport -TenantFilter $TenantFilter -PageSize $PageSize -ContinuationToken $Request.Query.nextLink -ErrorAction Stop
+                    $Metadata = @{}
+                    if ($Page.NextToken) { $Metadata.nextLink = $Page.NextToken }
+                    return ([HttpResponseContext]@{
+                            StatusCode = [HttpStatusCode]::OK
+                            Body       = [PSCustomObject]@{
+                                Results  = @($Page.Items)
+                                Metadata = $Metadata
+                            }
+                        })
+                }
                 $GraphRequest = Get-CIPPMailboxesReport -TenantFilter $TenantFilter -ErrorAction Stop
                 $StatusCode = [HttpStatusCode]::OK
             } catch {

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
@@ -5,7 +5,7 @@ function Invoke-ListGroups {
     .ROLE
         Identity.Group.Read
     .DESCRIPTION
-        Lists Entra ID groups for a tenant, including group members and owners. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants.
+        Lists Entra ID groups for a tenant, including group members and owners. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants. When manualPagination is also set on a cached read, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
@@ -24,6 +24,8 @@ function Invoke-ListGroups {
     $ExpandOwners = $Request.Query.expandOwners -eq $true
     # Serve from the reporting database cache instead of live Graph. Much faster, especially for AllTenants.
     $UseReportDB = $Request.Query.UseReportDB -eq $true
+    # Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.
+    $ManualPagination = $Request.Query.manualPagination -and [System.Convert]::ToBoolean($Request.Query.manualPagination)
 
     # members/owners read groups/<groupID>/..., so without a groupID the URL collapses to
     # groups//members and the failure surfaces as an opaque parameter binding error.
@@ -37,6 +39,25 @@ function Invoke-ListGroups {
     # Cache path: list view only — skip when fetching a specific group's details
     if ((-not $GroupID) -and (-not $Members) -and (-not $Owners) -and ($TenantFilter -eq 'AllTenants' -or $UseReportDB)) {
         try {
+            if ($ManualPagination) {
+                # Rows per page, clamped between 100 and 5000. Defaults to 1000: group rows
+                # carry full member arrays and run far heavier than other report types.
+                $PageSize = 1000
+                if ($Request.Query.PageSize -as [int]) {
+                    $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 100), 5000)
+                }
+                # Continuation token from the previous page's Metadata.nextLink; opaque to callers.
+                $Page = Get-CIPPGroupsReport -TenantFilter $TenantFilter -PageSize $PageSize -ContinuationToken $Request.Query.nextLink -ErrorAction Stop
+                $Metadata = @{}
+                if ($Page.NextToken) { $Metadata.nextLink = $Page.NextToken }
+                return ([HttpResponseContext]@{
+                        StatusCode = [HttpStatusCode]::OK
+                        Body       = [PSCustomObject]@{
+                            Results  = @($Page.Items)
+                            Metadata = $Metadata
+                        }
+                    })
+            }
             $GraphRequest = Get-CIPPGroupsReport -TenantFilter $TenantFilter -ErrorAction Stop
             $StatusCode = [HttpStatusCode]::OK
         } catch {

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
@@ -47,15 +47,15 @@ function Invoke-ListGroups {
                     $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 100), 5000)
                 }
                 # Continuation token from the previous page's Metadata.nextLink; opaque to callers.
-                $Page = Get-CIPPGroupsReport -TenantFilter $TenantFilter -PageSize $PageSize -ContinuationToken $Request.Query.nextLink -ErrorAction Stop
+                # Stream the cached blobs as raw JSON so member arrays are never re-parsed here.
+                $Page = Get-CIPPGroupsReport -TenantFilter $TenantFilter -PageSize $PageSize -ContinuationToken $Request.Query.nextLink -AsRawJson -ErrorAction Stop
                 $Metadata = @{}
                 if ($Page.NextToken) { $Metadata.nextLink = $Page.NextToken }
+                $MetadataJson = ConvertTo-Json -InputObject $Metadata -Depth 5 -Compress
                 return ([HttpResponseContext]@{
-                        StatusCode = [HttpStatusCode]::OK
-                        Body       = [PSCustomObject]@{
-                            Results  = @($Page.Items)
-                            Metadata = $Metadata
-                        }
+                        StatusCode  = [HttpStatusCode]::OK
+                        ContentType = 'application/json'
+                        Body        = '{"Results":' + $Page.CippPagedJson + ',"Metadata":' + $MetadataJson + '}'
                     })
             }
             $GraphRequest = Get-CIPPGroupsReport -TenantFilter $TenantFilter -ErrorAction Stop

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
@@ -40,9 +40,9 @@ function Invoke-ListGroups {
     if ((-not $GroupID) -and (-not $Members) -and (-not $Owners) -and ($TenantFilter -eq 'AllTenants' -or $UseReportDB)) {
         try {
             if ($ManualPagination) {
-                # Rows per page, clamped between 100 and 5000. Defaults to 1000: group rows
+                # Rows per page, clamped between 100 and 5000. Defaults to 750: group rows
                 # carry full member arrays and run far heavier than other report types.
-                $PageSize = 1000
+                $PageSize = 750
                 if ($Request.Query.PageSize -as [int]) {
                     $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 100), 5000)
                 }

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListGuestUsers.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListGuestUsers.ps1
@@ -7,7 +7,7 @@ function Invoke-ListGuestUsers {
     .SYNOPSIS
         List guest users with lifecycle status
     .DESCRIPTION
-        Lists all guest accounts in a tenant with a computed lifecycle status (Active, Pending Acceptance, Stale, Never Signed In or Disabled) based on the invitation state and sign-in activity. Supports UseReportDB=true to serve cached data from the reporting database; AllTenants always uses the cache.
+        Lists all guest accounts in a tenant with a computed lifecycle status (Active, Pending Acceptance, Stale, Never Signed In or Disabled) based on the invitation state and sign-in activity. Supports UseReportDB=true to serve cached data from the reporting database; AllTenants always uses the cache. When manualPagination is set on a cached read, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
@@ -21,13 +21,28 @@ function Invoke-ListGuestUsers {
     $StaleDays = $Request.Query.staleDays ? [int]$Request.Query.staleDays : 90
     # Serve from the reporting database cache instead of live Graph. AllTenants always uses the cache.
     $UseReportDB = $Request.Query.UseReportDB -eq $true
+    # Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.
+    $ManualPagination = $Request.Query.manualPagination -and [System.Convert]::ToBoolean($Request.Query.manualPagination)
+    $NextToken = $null
 
     try {
         if ($TenantFilter -eq 'AllTenants' -or $UseReportDB) {
             # Cached rows carry a per-row signInLogsCapable stamp written by the cache job,
             # so sign-in availability is judged per row below.
             $SignInLogsCapable = $null
-            $GuestUsers = Get-CIPPGuestUsersReport -TenantFilter $TenantFilter
+            if ($ManualPagination) {
+                # Rows per page, clamped between 250 and 10000. Defaults to 5000.
+                $PageSize = 5000
+                if ($Request.Query.PageSize -as [int]) {
+                    $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 250), 10000)
+                }
+                # Continuation token from the previous page's Metadata.nextLink; opaque to callers.
+                $Page = Get-CIPPGuestUsersReport -TenantFilter $TenantFilter -PageSize $PageSize -ContinuationToken $Request.Query.nextLink
+                $GuestUsers = $Page.Items
+                $NextToken = $Page.NextToken
+            } else {
+                $GuestUsers = Get-CIPPGuestUsersReport -TenantFilter $TenantFilter
+            }
         } else {
             # signInActivity can only be requested on tenants with an Entra ID P1 license - Graph
             # rejects the whole query on unlicensed tenants, so fall back to listing without
@@ -111,6 +126,19 @@ function Invoke-ListGuestUsers {
         Write-LogMessage -headers $Headers -API $APIName -tenant $TenantFilter -message "Failed to list guest users: $($ErrorMessage.NormalizedError)" -Sev 'Error' -LogData $ErrorMessage
         $StatusCode = [System.Net.HttpStatusCode]::InternalServerError
         $GraphRequest = @{ Error = $ErrorMessage.NormalizedError }
+    }
+
+    # Paged cached reads return { Results, Metadata }; everything else keeps the legacy bare array.
+    if ($ManualPagination -and ($TenantFilter -eq 'AllTenants' -or $UseReportDB) -and $StatusCode -eq [System.Net.HttpStatusCode]::OK) {
+        $Metadata = @{}
+        if ($NextToken) { $Metadata.nextLink = $NextToken }
+        return ([HttpResponseContext]@{
+                StatusCode = $StatusCode
+                Body       = [PSCustomObject]@{
+                    Results  = @($GraphRequest)
+                    Metadata = $Metadata
+                }
+            })
     }
 
     return ([HttpResponseContext]@{

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Reports/Invoke-ListMFAUsers.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Reports/Invoke-ListMFAUsers.ps1
@@ -5,7 +5,7 @@ function Invoke-ListMFAUsers {
     .ROLE
         Identity.User.Read
     .DESCRIPTION
-        Lists users and their MFA registration status for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants.
+        Lists users and their MFA registration status for a tenant. Supports UseReportDB=true query parameter to retrieve cached data from the reporting database for significantly better performance, especially when querying AllTenants. When manualPagination is also set, one page is returned per request as { Results, Metadata } with a continuation token in Metadata.nextLink.
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
@@ -13,10 +13,30 @@ function Invoke-ListMFAUsers {
     $TenantFilter = $Request.Query.tenantFilter
     # Serve from the reporting database cache instead of live Graph. Much faster, especially for AllTenants.
     $UseReportDB = $Request.Query.UseReportDB -eq $true
+    # Return one page per request as { Results, Metadata } with a continuation token in Metadata.nextLink; cached reads only.
+    $ManualPagination = $Request.Query.manualPagination -and [System.Convert]::ToBoolean($Request.Query.manualPagination)
     try {
         # If UseReportDB is specified, retrieve from report database
         if ($UseReportDB) {
             try {
+                if ($ManualPagination) {
+                    # Rows per page, clamped between 250 and 10000. Defaults to 5000.
+                    $PageSize = 5000
+                    if ($Request.Query.PageSize -as [int]) {
+                        $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 250), 10000)
+                    }
+                    # Continuation token from the previous page's Metadata.nextLink; opaque to callers.
+                    $Page = Get-CIPPMFAStateReport -TenantFilter $TenantFilter -PageSize $PageSize -ContinuationToken $Request.Query.nextLink -ErrorAction Stop
+                    $Metadata = @{}
+                    if ($Page.NextToken) { $Metadata.nextLink = $Page.NextToken }
+                    return ([HttpResponseContext]@{
+                            StatusCode = [HttpStatusCode]::OK
+                            Body       = [PSCustomObject]@{
+                                Results  = @($Page.Items)
+                                Metadata = $Metadata
+                            }
+                        })
+                }
                 $GraphRequest = Get-CIPPMFAStateReport -TenantFilter $TenantFilter -ErrorAction Stop
                 $StatusCode = [HttpStatusCode]::OK
             } catch {

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Conditional/Invoke-ListConditionalAccessPolicies.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Conditional/Invoke-ListConditionalAccessPolicies.ps1
@@ -5,7 +5,7 @@ function Invoke-ListConditionalAccessPolicies {
     .ROLE
         Tenant.ConditionalAccess.Read
     .DESCRIPTION
-        Lists Conditional Access policies for a tenant with resolved display names for users, groups, applications, and locations.
+        Lists Conditional Access policies for a tenant with resolved display names for users, groups, applications, and locations. When manualPagination is set on an AllTenants read, one page is returned per request with a continuation token in Metadata.nextLink.
     #>
     [CmdletBinding()]
     param($Request, $TriggerMetadata)
@@ -200,8 +200,22 @@ function Invoke-ListConditionalAccessPolicies {
             # AllTenants functionality
             $Table = Get-CIPPTable -TableName cacheCAPolicies
             $PartitionKey = 'CAPolicy'
-            $Filter = "PartitionKey eq '$PartitionKey'"
-            $Rows = Get-CIPPAzDataTableEntity @Table -filter $Filter | Where-Object -Property Timestamp -GT (Get-Date).AddMinutes(-60)
+            # Return one page per request with a continuation token in Metadata.nextLink; AllTenants reads only.
+            $ManualPagination = $Request.Query.manualPagination -and [System.Convert]::ToBoolean($Request.Query.manualPagination)
+            if ($ManualPagination) {
+                # Rows per page, clamped between 250 and 10000. Defaults to 5000.
+                $PageSize = 5000
+                if ($Request.Query.PageSize -as [int]) {
+                    $PageSize = [Math]::Min([Math]::Max([int]$Request.Query.PageSize, 250), 10000)
+                }
+                $FreshClause = "Timestamp ge datetime'{0}'" -f (Get-Date).AddMinutes(-60).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffK')
+                # Continuation token from the previous page's Metadata.nextLink; opaque to callers.
+                $Page = Get-CIPPPagedTableRows -Table $Table -PartitionKeys @($PartitionKey) -PageSize $PageSize -ContinuationToken $Request.Query.nextLink -ExtraFilterClauses @($FreshClause)
+                $Rows = @($Page.Rows)
+            } else {
+                $Filter = "PartitionKey eq '$PartitionKey'"
+                $Rows = Get-CIPPAzDataTableEntity @Table -filter $Filter | Where-Object -Property Timestamp -GT (Get-Date).AddMinutes(-60)
+            }
             $QueueReference = '{0}-{1}' -f $TenantFilter, $PartitionKey
             $RunningQueue = Get-CIPPQueueData -Reference $QueueReference | Where-Object { $_.Status -notmatch 'Completed' -and $_.Status -notmatch 'Failed' }
             # If a queue is running, we will not start a new one
@@ -210,7 +224,7 @@ function Invoke-ListConditionalAccessPolicies {
                     QueueMessage = 'Still loading data for all tenants. Please check back in a few more minutes'
                     QueueId      = $RunningQueue.RowKey
                 }
-            } elseif (!$Rows -and !$RunningQueue) {
+            } elseif (!$Rows -and !$RunningQueue -and !$Request.Query.nextLink) {
                 # If no rows are found and no queue is running, we will start a new one
                 $TenantList = Get-Tenants -IncludeErrors
                 $Queue = New-CippQueueEntry -Name 'Conditional Access Policies - All Tenants' -Link '/tenant/conditional/list-policies?customerId=AllTenants' -Reference $QueueReference -TotalTasks ($TenantList | Measure-Object).Count
@@ -234,6 +248,9 @@ function Invoke-ListConditionalAccessPolicies {
             } else {
                 $Metadata = [PSCustomObject]@{
                     QueueId = $RunningQueue.RowKey ?? $null
+                }
+                if ($ManualPagination -and $Page.NextToken) {
+                    $Metadata | Add-Member -NotePropertyName 'nextLink' -NotePropertyValue $Page.NextToken
                 }
                 $Policies = $Rows | Select-CippAllowedTenantData -TenantProperty 'Tenant'
                 # Output all policies from all tenants the caller is allowed to see

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Conditional/Invoke-ListConditionalAccessPolicies.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Conditional/Invoke-ListConditionalAccessPolicies.ps1
@@ -252,11 +252,23 @@ function Invoke-ListConditionalAccessPolicies {
                 if ($ManualPagination -and $Page.NextToken) {
                     $Metadata | Add-Member -NotePropertyName 'nextLink' -NotePropertyValue $Page.NextToken
                 }
-                $Policies = $Rows | Select-CippAllowedTenantData -TenantProperty 'Tenant'
-                # Output all policies from all tenants the caller is allowed to see
-                foreach ($policy in $Policies) {
-                    ($policy.Policy | ConvertFrom-Json)
+                # Each cached Policy blob is already the final shape; stitch the allowed rows
+                # into Results verbatim instead of parsing and letting Craft re-serialize.
+                $AllowedRows = @($Rows | Select-CippAllowedTenantData -TenantProperty 'Tenant')
+                $JsonParts = [System.Collections.Generic.List[string]]::new($AllowedRows.Count)
+                foreach ($Row in $AllowedRows) {
+                    $Blob = [string]$Row.Policy
+                    if ([string]::IsNullOrWhiteSpace($Blob)) { continue }
+                    $Blob = $Blob.Trim()
+                    if ($Blob[0] -eq '{' -or $Blob[0] -eq '[') { $JsonParts.Add($Blob) }
                 }
+                $ResultsJson = '[' + ($JsonParts -join ',') + ']'
+                $MetadataJson = ConvertTo-Json -InputObject $Metadata -Depth 5 -Compress
+                return ([HttpResponseContext]@{
+                        StatusCode  = [HttpStatusCode]::OK
+                        ContentType = 'application/json'
+                        Body        = '{"Results":' + $ResultsJson + ',"Metadata":' + $MetadataJson + '}'
+                    })
             }
         }
         $StatusCode = [HttpStatusCode]::OK

--- a/backend/Tests/ActivityTriggers/Push-ListConditionalAccessPoliciesAllTenants.Tests.ps1
+++ b/backend/Tests/ActivityTriggers/Push-ListConditionalAccessPoliciesAllTenants.Tests.ps1
@@ -1,0 +1,67 @@
+# Cache writes for cacheCAPolicies must be idempotent: rows used to be keyed by a fresh
+# GUID per policy per run with no cleanup, so overlapping fan-outs (a request near the
+# 60-minute staleness boundary queues a second run while the first is filling) doubled
+# every policy in the table and the list endpoint served the duplicates.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Push-ListConditionalAccessPoliciesAllTenants.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Push-ListConditionalAccessPoliciesAllTenants.ps1 under Modules/' }
+
+    # Stubs so Mock has commands to replace.
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function Get-CIPPTable { param($TableName) }
+    function Add-CIPPAzDataTableEntity { param($Context, $Entity, [switch]$Force) }
+    function New-GraphBulkRequest { param($Requests, $tenantid, $asapp) }
+
+    . $FunctionPath
+
+    function New-BulkResult {
+        param([object[]]$Policies)
+        @(
+            [pscustomobject]@{ id = 'policies'; body = [pscustomobject]@{ value = $Policies } }
+            foreach ($Id in 'namedLocations', 'applications', 'roleDefinitions', 'groups', 'users', 'servicePrincipals') {
+                [pscustomobject]@{ id = $Id; body = [pscustomobject]@{ value = @() } }
+            }
+        )
+    }
+}
+
+Describe 'Push-ListConditionalAccessPoliciesAllTenants cache idempotence' {
+    BeforeEach {
+        $script:Written = [System.Collections.Generic.List[object]]::new()
+        Mock -CommandName Get-Tenants -MockWith { [pscustomobject]@{ defaultDomainName = 'contoso.com' } }
+        Mock -CommandName Get-CIPPTable -MockWith { @{ Context = 'fake' } }
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith { $script:Written.Add(@{ Entity = $Entity; Force = [bool]$Force }) }
+    }
+
+    It 'writes deterministic tenant+policy RowKeys, identical across runs, with -Force' {
+        Mock -CommandName New-GraphBulkRequest -MockWith {
+            New-BulkResult -Policies @(
+                [pscustomobject]@{ id = 'p1'; displayName = 'Block legacy auth'; state = 'enabled'; conditions = $null; grantControls = $null }
+                [pscustomobject]@{ id = 'p2'; displayName = 'Require MFA'; state = 'enabled'; conditions = $null; grantControls = $null }
+            )
+        }
+
+        Push-ListConditionalAccessPoliciesAllTenants -Item ([pscustomobject]@{ customerId = 'tenant-guid' })
+        Push-ListConditionalAccessPoliciesAllTenants -Item ([pscustomobject]@{ customerId = 'tenant-guid' })
+
+        $script:Written | Should -HaveCount 4
+        # Same keys both runs: the second run upserts instead of appending duplicates.
+        ($script:Written.Entity.RowKey | Sort-Object -Unique) | Should -Be @('contoso.com-p1', 'contoso.com-p2')
+        $script:Written.Force | Should -Not -Contain $false
+        ($script:Written.Entity.Policy[0] | ConvertFrom-Json).id | Should -Be 'p1'
+    }
+
+    It 'writes one deterministic error row per tenant when the tenant is unreachable' {
+        Mock -CommandName New-GraphBulkRequest -MockWith { throw 'tenant unreachable' }
+
+        Push-ListConditionalAccessPoliciesAllTenants -Item ([pscustomobject]@{ customerId = 'tenant-guid' })
+        Push-ListConditionalAccessPoliciesAllTenants -Item ([pscustomobject]@{ customerId = 'tenant-guid' })
+
+        $script:Written | Should -HaveCount 2
+        ($script:Written.Entity.RowKey | Sort-Object -Unique) | Should -Be @('contoso.com-Error')
+        ($script:Written.Entity.Policy[0] | ConvertFrom-Json).state | Should -Be 'Error'
+    }
+}

--- a/backend/Tests/DBCache/Set-CIPPDBCache.Memory.Tests.ps1
+++ b/backend/Tests/DBCache/Set-CIPPDBCache.Memory.Tests.ps1
@@ -137,18 +137,22 @@ Describe 'DBCache collectors reworked for bounded memory' {
 
         It 'emits the computed properties in the documented order' {
             Mock -CommandName New-GraphGetRequest -MockWith {
-                @([pscustomobject]@{ id = 'g1'; displayName = 'One'; mail = 'one@contoso.com'; groupTypes = @('Unified'); mailEnabled = $true; securityEnabled = $false; resourceProvisioningOptions = @('Team') })
+                @([pscustomobject]@{ id = 'g1'; displayName = 'One'; mail = 'one@contoso.com'; groupTypes = @('Unified'); mailEnabled = $true; securityEnabled = $false; resourceProvisioningOptions = @('Team'); owners = @([pscustomobject]@{ id = 'o1'; userPrincipalName = 'owner1@contoso.com' }) })
             }
             Mock -CommandName New-GraphBulkRequest -MockWith {
-                @([pscustomobject]@{ id = 'g1'; body = [pscustomobject]@{ value = @() } })
+                @([pscustomobject]@{ id = 'g1'; body = [pscustomobject]@{ value = @([pscustomobject]@{ id = 'u1'; userPrincipalName = 'user1@contoso.com' }) } })
             }
 
             Set-CIPPDBCacheGroups -TenantFilter 'contoso.com'
 
             Should -Invoke New-GraphGetRequest -Times 1 -Exactly -ParameterFilter { $Stream.IsPresent }
             $Row = $script:DbWrites[0].Rows[0]
-            $Added = @($Row.PSObject.Properties.Name) | Select-Object -Last 6
-            $Added | Should -Be @('members', 'primDomain', 'teamsEnabled', 'dynamicGroupBool', 'groupType', 'calculatedGroupType')
+            # membersCsv/ownersCsv are precomputed so the paged list read can stream the blob
+            # verbatim; both sit next to their source arrays in the emitted order.
+            $Added = @($Row.PSObject.Properties.Name) | Select-Object -Last 8
+            $Added | Should -Be @('members', 'membersCsv', 'ownersCsv', 'primDomain', 'teamsEnabled', 'dynamicGroupBool', 'groupType', 'calculatedGroupType')
+            $Row.membersCsv | Should -Be 'user1@contoso.com'
+            $Row.ownersCsv | Should -Be 'owner1@contoso.com'
             $Row.groupType | Should -Be 'Microsoft 365'
             $Row.calculatedGroupType | Should -Be 'm365'
             $Row.primDomain | Should -Be 'contoso.com'

--- a/backend/Tests/Endpoint/Invoke-ListConditionalAccessPolicies.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListConditionalAccessPolicies.Tests.ps1
@@ -1,0 +1,126 @@
+# Pester tests for the AllTenants branch of Invoke-ListConditionalAccessPolicies
+# Validates the manualPagination contract over the cacheCAPolicies table, the queue
+# fallback on a cold cache (and its suppression mid-walk), and the legacy unpaged path.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    # Stub every CIPP helper the exercised paths call so Pester's Mock has a command to replace.
+    function Get-CIPPTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter, $Property, $First) }
+    function Get-CIPPPagedTableRows { param($Table, $PartitionKeys, $RowKeyGe, $RowKeyLt, $ExtraFilterClauses, $PageSize, $MaxQueries, $ContinuationToken) }
+    function Get-CIPPQueueData { param($Reference) }
+    function New-CippQueueEntry { param($Name, $Link, $Reference, $TotalTasks) }
+    function Start-CIPPOrchestrator { param($InputObject) }
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function New-GraphBulkRequest { param($Requests, $tenantid, $asapp) }
+    function Get-NormalizedError { param($Message) $Message }
+    # Real passthrough, not a Mock: the endpoint pipes rows into it, and pipeline binding
+    # inside Pester mock bodies is unreliable.
+    function Select-CippAllowedTenantData { param([Parameter(ValueFromPipeline)]$Row, $TenantProperty) process { $Row } }
+
+    $EndpointPath = Join-Path $RepoRoot 'Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Conditional/Invoke-ListConditionalAccessPolicies.ps1'
+    $EndpointScript = [ScriptBlock]::Create("using namespace System.Net`n" + (Get-Content -LiteralPath $EndpointPath -Raw))
+    . $EndpointScript
+
+    function New-CaRequest {
+        param([hashtable]$Query = @{})
+        $Merged = @{ tenantFilter = 'AllTenants' }
+        foreach ($Key in $Query.Keys) { $Merged[$Key] = $Query[$Key] }
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ListConditionalAccessPolicies' }
+            Headers = @{ Authorization = 'token' }
+            Query   = [pscustomobject]$Merged
+        }
+    }
+
+    function New-CacheRow {
+        param([string]$Tenant, [string]$Id)
+        [PSCustomObject]@{
+            PartitionKey = 'CAPolicy'
+            RowKey       = [guid]::NewGuid().ToString()
+            Tenant       = $Tenant
+            Timestamp    = (Get-Date)
+            Policy       = (@{ id = $Id; displayName = "Policy $Id"; Tenant = $Tenant } | ConvertTo-Json -Compress)
+        }
+    }
+}
+
+Describe 'Invoke-ListConditionalAccessPolicies AllTenants' {
+    BeforeEach {
+        Mock -CommandName Get-CIPPTable -MockWith { @{ Context = 'fake' } }
+        Mock -CommandName Get-CIPPQueueData -MockWith { $null }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { @() }
+        Mock -CommandName Get-CIPPPagedTableRows -MockWith { [PSCustomObject]@{ Rows = @(); NextToken = $null } }
+        Mock -CommandName New-CippQueueEntry -MockWith { @{ RowKey = 'queue-1' } }
+        Mock -CommandName Start-CIPPOrchestrator -MockWith { 'instance-1' }
+        Mock -CommandName Get-Tenants -MockWith { @([PSCustomObject]@{ defaultDomainName = 'a.com' }) }
+    }
+
+    It 'serves a paged { Results, Metadata } page with nextLink and clamps PageSize' {
+        Mock -CommandName Get-CIPPPagedTableRows -MockWith {
+            [PSCustomObject]@{
+                Rows      = @((New-CacheRow 'a.com' 'p1'), (New-CacheRow 'b.com' 'p2'))
+                NextToken = 'CAPolicy|some-guid'
+            }
+        }
+
+        $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true'; PageSize = '10' }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 200
+        $response.Body.Results | Should -HaveCount 2
+        $response.Body.Results.id | Should -Contain 'p1'
+        $response.Body.Metadata.nextLink | Should -Be 'CAPolicy|some-guid'
+        Should -Invoke Get-CIPPPagedTableRows -Times 1 -ParameterFilter {
+            ($PartitionKeys -join ',') -eq 'CAPolicy' -and $PageSize -eq 250 -and
+            ($ExtraFilterClauses -join '') -like 'Timestamp ge datetime*'
+        }
+        Should -Invoke Start-CIPPOrchestrator -Times 0
+    }
+
+    It 'omits nextLink on the final page' {
+        Mock -CommandName Get-CIPPPagedTableRows -MockWith {
+            [PSCustomObject]@{ Rows = @((New-CacheRow 'a.com' 'p1')); NextToken = $null }
+        }
+
+        $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true' }) -TriggerMetadata $null
+
+        $response.Body.Results | Should -HaveCount 1
+        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+        Should -Invoke Get-CIPPPagedTableRows -Times 1 -ParameterFilter { $PageSize -eq 5000 }
+    }
+
+    It 'queues the fan-out on a cold cache first page' {
+        $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true' }) -TriggerMetadata $null
+
+        $response.Body.Metadata.QueueMessage | Should -Match 'Loading data'
+        @($response.Body.Results) | Should -HaveCount 0
+        Should -Invoke Start-CIPPOrchestrator -Times 1
+    }
+
+    It 'does not re-queue when an empty page arrives mid-walk' {
+        $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true'; nextLink = 'CAPolicy|stale' }) -TriggerMetadata $null
+
+        @($response.Body.Results) | Should -HaveCount 0
+        Should -Invoke Start-CIPPOrchestrator -Times 0
+        Should -Invoke New-CippQueueEntry -Times 0
+    }
+
+    It 'keeps the legacy unpaged full fetch without manualPagination' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @((New-CacheRow 'a.com' 'p1'), (New-CacheRow 'b.com' 'p2'), (New-CacheRow 'c.com' 'p3'))
+        }
+
+        $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest) -TriggerMetadata $null
+
+        $response.Body.Results | Should -HaveCount 3
+        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+        Should -Invoke Get-CIPPPagedTableRows -Times 0
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1
+    }
+}

--- a/backend/Tests/Endpoint/Invoke-ListConditionalAccessPolicies.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListConditionalAccessPolicies.Tests.ps1
@@ -8,6 +8,14 @@ BeforeAll {
     class HttpResponseContext {
         [int]$StatusCode
         [object]$Body
+        [object]$ContentType
+    }
+
+    # Rows-exist path returns a raw-JSON string Body; queue/cold paths return an object.
+    function ConvertFrom-ResponseBody {
+        param($Response)
+        if ($Response.Body -is [string]) { return ($Response.Body | ConvertFrom-Json) }
+        return $Response.Body
     }
 
     # Stub every CIPP helper the exercised paths call so Pester's Mock has a command to replace.
@@ -73,14 +81,31 @@ Describe 'Invoke-ListConditionalAccessPolicies AllTenants' {
         $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true'; PageSize = '10' }) -TriggerMetadata $null
 
         $response.StatusCode | Should -Be 200
-        $response.Body.Results | Should -HaveCount 2
-        $response.Body.Results.id | Should -Contain 'p1'
-        $response.Body.Metadata.nextLink | Should -Be 'CAPolicy|some-guid'
+        $response.ContentType | Should -Be 'application/json'
+        $response.Body | Should -BeOfType [string]
+        $body = ConvertFrom-ResponseBody $response
+        $body.Results | Should -HaveCount 2
+        $body.Results.id | Should -Contain 'p1'
+        $body.Metadata.nextLink | Should -Be 'CAPolicy|some-guid'
         Should -Invoke Get-CIPPPagedTableRows -Times 1 -ParameterFilter {
             ($PartitionKeys -join ',') -eq 'CAPolicy' -and $PageSize -eq 250 -and
             ($ExtraFilterClauses -join '') -like 'Timestamp ge datetime*'
         }
         Should -Invoke Start-CIPPOrchestrator -Times 0
+    }
+
+    It 'stitches the cached Policy blob verbatim without a parse round-trip' {
+        $rowA = New-CacheRow 'a.com' 'p1'
+        Mock -CommandName Get-CIPPPagedTableRows -MockWith {
+            [PSCustomObject]@{ Rows = @($rowA); NextToken = $null }
+        }.GetNewClosure()
+
+        $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true' }) -TriggerMetadata $null
+
+        # Exact stored blob bytes must appear verbatim; a parse + re-serialize would restyle them.
+        $response.Body | Should -BeLike ('*' + $rowA.Policy + '*')
+        $body = ConvertFrom-ResponseBody $response
+        $body.Results.id | Should -Be 'p1'
     }
 
     It 'omits nextLink on the final page' {
@@ -90,8 +115,9 @@ Describe 'Invoke-ListConditionalAccessPolicies AllTenants' {
 
         $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true' }) -TriggerMetadata $null
 
-        $response.Body.Results | Should -HaveCount 1
-        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+        $body = ConvertFrom-ResponseBody $response
+        $body.Results | Should -HaveCount 1
+        $body.Metadata.nextLink | Should -BeNullOrEmpty
         Should -Invoke Get-CIPPPagedTableRows -Times 1 -ParameterFilter { $PageSize -eq 5000 }
     }
 
@@ -106,7 +132,8 @@ Describe 'Invoke-ListConditionalAccessPolicies AllTenants' {
     It 'does not re-queue when an empty page arrives mid-walk' {
         $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest -Query @{ manualPagination = 'true'; nextLink = 'CAPolicy|stale' }) -TriggerMetadata $null
 
-        @($response.Body.Results) | Should -HaveCount 0
+        $body = ConvertFrom-ResponseBody $response
+        @($body.Results) | Should -HaveCount 0
         Should -Invoke Start-CIPPOrchestrator -Times 0
         Should -Invoke New-CippQueueEntry -Times 0
     }
@@ -118,8 +145,9 @@ Describe 'Invoke-ListConditionalAccessPolicies AllTenants' {
 
         $response = Invoke-ListConditionalAccessPolicies -Request (New-CaRequest) -TriggerMetadata $null
 
-        $response.Body.Results | Should -HaveCount 3
-        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+        $body = ConvertFrom-ResponseBody $response
+        $body.Results | Should -HaveCount 3
+        $body.Metadata.nextLink | Should -BeNullOrEmpty
         Should -Invoke Get-CIPPPagedTableRows -Times 0
         Should -Invoke Get-CIPPAzDataTableEntity -Times 1
     }

--- a/backend/Tests/Endpoint/Invoke-ListGroups.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListGroups.Tests.ps1
@@ -1,0 +1,113 @@
+# Pester tests for the reporting-database branch of Invoke-ListGroups
+# Validates the legacy bare-array shape and the manualPagination contract
+# ({ Results, Metadata } pages chained via Metadata.nextLink).
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    # Stub every CIPP helper the exercised paths call so Pester's Mock has a command to replace.
+    function Get-CIPPGroupsReport { param($TenantFilter, $PageSize, $ContinuationToken) }
+    function New-GraphGetRequest { param($uri, $tenantid) }
+    function New-GraphBulkRequest { param($Requests, $tenantid) }
+    function Get-GraphBulkResultByID { param($Results, $ID) }
+    function Convert-AzureAdObjectIdToSid { param($ObjectID) }
+    function Get-NormalizedError { param($Message) $Message }
+
+    $EndpointPath = Join-Path $RepoRoot 'Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1'
+    $EndpointScript = [ScriptBlock]::Create("using namespace System.Net`n" + (Get-Content -LiteralPath $EndpointPath -Raw))
+    . $EndpointScript
+
+    function New-GroupsRequest {
+        param([hashtable]$Query = @{})
+        $Merged = @{ tenantFilter = 'AllTenants' }
+        foreach ($Key in $Query.Keys) { $Merged[$Key] = $Query[$Key] }
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ListGroups' }
+            Headers = @{ Authorization = 'token' }
+            Query   = [pscustomobject]$Merged
+        }
+    }
+
+    function New-GroupRow {
+        param([string]$Id)
+        [pscustomobject]@{
+            id          = $Id
+            displayName = "Group $Id"
+            members     = @([pscustomobject]@{ id = 'u1'; userPrincipalName = 'u1@contoso.com' })
+            membersCsv  = 'u1@contoso.com'
+            Tenant      = 'contoso.onmicrosoft.com'
+        }
+    }
+}
+
+Describe 'Invoke-ListGroups report database branch' {
+    BeforeEach {
+        Mock -CommandName New-GraphGetRequest -MockWith { throw 'live Graph should not be called' }
+        Mock -CommandName New-GraphBulkRequest -MockWith { throw 'live Graph should not be called' }
+    }
+
+    It 'returns the legacy bare array without manualPagination' {
+        Mock -CommandName Get-CIPPGroupsReport -MockWith { @((New-GroupRow 'g1'), (New-GroupRow 'g2')) }
+
+        $response = Invoke-ListGroups -Request (New-GroupsRequest) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 200
+        $response.Body | Should -HaveCount 2
+        $response.Body[0].members | Should -HaveCount 1
+        Should -Invoke Get-CIPPGroupsReport -Times 1 -ParameterFilter {
+            $TenantFilter -eq 'AllTenants' -and -not $PageSize
+        }
+    }
+
+    It 'returns { Results, Metadata } pages with members intact when manualPagination is set' {
+        Mock -CommandName Get-CIPPGroupsReport -MockWith {
+            [PSCustomObject]@{
+                Items     = @((New-GroupRow 'g1'))
+                NextToken = 'contoso.onmicrosoft.com|Groups-abc'
+            }
+        }
+
+        $response = Invoke-ListGroups -Request (New-GroupsRequest -Query @{
+                manualPagination = 'true'; PageSize = '7'; nextLink = 'prev|token'
+            }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 200
+        $response.Body.Results | Should -HaveCount 1
+        $response.Body.Results[0].members[0].userPrincipalName | Should -Be 'u1@contoso.com'
+        $response.Body.Metadata.nextLink | Should -Be 'contoso.onmicrosoft.com|Groups-abc'
+        # PageSize 7 is below the 100 floor and must be clamped; the incoming token is
+        # forwarded verbatim.
+        Should -Invoke Get-CIPPGroupsReport -Times 1 -ParameterFilter {
+            $TenantFilter -eq 'AllTenants' -and $PageSize -eq 100 -and $ContinuationToken -eq 'prev|token'
+        }
+    }
+
+    It 'omits nextLink on the final page but keeps the paged shape and default size' {
+        Mock -CommandName Get-CIPPGroupsReport -MockWith {
+            [PSCustomObject]@{ Items = @((New-GroupRow 'g1')); NextToken = $null }
+        }
+
+        $response = Invoke-ListGroups -Request (New-GroupsRequest -Query @{
+                UseReportDB = 'true'; manualPagination = 'true'
+            }) -TriggerMetadata $null
+
+        $response.Body.Results | Should -HaveCount 1
+        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+        $response.Body.PSObject.Properties.Name | Should -Contain 'Metadata'
+        Should -Invoke Get-CIPPGroupsReport -Times 1 -ParameterFilter { $PageSize -eq 1000 }
+    }
+
+    It 'returns InternalServerError when the paged report read fails' {
+        Mock -CommandName Get-CIPPGroupsReport -MockWith { throw 'No groups data found in reporting database for AllTenants. Sync the report data first.' }
+
+        $response = Invoke-ListGroups -Request (New-GroupsRequest -Query @{ manualPagination = 'true' }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 500
+        "$($response.Body)" | Should -Match 'Sync the report data first'
+    }
+}

--- a/backend/Tests/Endpoint/Invoke-ListGroups.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListGroups.Tests.ps1
@@ -8,10 +8,18 @@ BeforeAll {
     class HttpResponseContext {
         [int]$StatusCode
         [object]$Body
+        [object]$ContentType
+    }
+
+    # Paged path returns a raw-JSON string Body; the legacy path returns an object.
+    function ConvertFrom-ResponseBody {
+        param($Response)
+        if ($Response.Body -is [string]) { return ($Response.Body | ConvertFrom-Json) }
+        return $Response.Body
     }
 
     # Stub every CIPP helper the exercised paths call so Pester's Mock has a command to replace.
-    function Get-CIPPGroupsReport { param($TenantFilter, $PageSize, $ContinuationToken) }
+    function Get-CIPPGroupsReport { param($TenantFilter, $PageSize, $ContinuationToken, [switch]$AsRawJson) }
     function New-GraphGetRequest { param($uri, $tenantid) }
     function New-GraphBulkRequest { param($Requests, $tenantid) }
     function Get-GraphBulkResultByID { param($Results, $ID) }
@@ -43,6 +51,17 @@ BeforeAll {
             Tenant      = 'contoso.onmicrosoft.com'
         }
     }
+
+    # Mirror what Get-CIPPGroupsReport -AsRawJson returns: the group blobs pre-stitched
+    # into a JSON array string, with a continuation token.
+    function New-GroupsPageJson {
+        param([object[]]$Rows, [string]$NextToken)
+        $parts = foreach ($row in $Rows) { $row | ConvertTo-Json -Depth 10 -Compress }
+        [PSCustomObject]@{
+            CippPagedJson = '[' + ($parts -join ',') + ']'
+            NextToken     = $NextToken
+        }
+    }
 }
 
 Describe 'Invoke-ListGroups report database branch' {
@@ -66,10 +85,7 @@ Describe 'Invoke-ListGroups report database branch' {
 
     It 'returns { Results, Metadata } pages with members intact when manualPagination is set' {
         Mock -CommandName Get-CIPPGroupsReport -MockWith {
-            [PSCustomObject]@{
-                Items     = @((New-GroupRow 'g1'))
-                NextToken = 'contoso.onmicrosoft.com|Groups-abc'
-            }
+            New-GroupsPageJson -Rows @((New-GroupRow 'g1')) -NextToken 'contoso.onmicrosoft.com|Groups-abc'
         }
 
         $response = Invoke-ListGroups -Request (New-GroupsRequest -Query @{
@@ -77,29 +93,33 @@ Describe 'Invoke-ListGroups report database branch' {
             }) -TriggerMetadata $null
 
         $response.StatusCode | Should -Be 200
-        $response.Body.Results | Should -HaveCount 1
-        $response.Body.Results[0].members[0].userPrincipalName | Should -Be 'u1@contoso.com'
-        $response.Body.Metadata.nextLink | Should -Be 'contoso.onmicrosoft.com|Groups-abc'
+        $response.ContentType | Should -Be 'application/json'
+        $response.Body | Should -BeOfType [string]
+        $body = ConvertFrom-ResponseBody $response
+        $body.Results | Should -HaveCount 1
+        $body.Results[0].members[0].userPrincipalName | Should -Be 'u1@contoso.com'
+        $body.Metadata.nextLink | Should -Be 'contoso.onmicrosoft.com|Groups-abc'
         # PageSize 7 is below the 100 floor and must be clamped; the incoming token is
-        # forwarded verbatim.
+        # forwarded verbatim, and the read runs in raw-JSON mode.
         Should -Invoke Get-CIPPGroupsReport -Times 1 -ParameterFilter {
-            $TenantFilter -eq 'AllTenants' -and $PageSize -eq 100 -and $ContinuationToken -eq 'prev|token'
+            $TenantFilter -eq 'AllTenants' -and $PageSize -eq 100 -and $ContinuationToken -eq 'prev|token' -and $AsRawJson
         }
     }
 
     It 'omits nextLink on the final page but keeps the paged shape and default size' {
         Mock -CommandName Get-CIPPGroupsReport -MockWith {
-            [PSCustomObject]@{ Items = @((New-GroupRow 'g1')); NextToken = $null }
+            New-GroupsPageJson -Rows @((New-GroupRow 'g1')) -NextToken $null
         }
 
         $response = Invoke-ListGroups -Request (New-GroupsRequest -Query @{
                 UseReportDB = 'true'; manualPagination = 'true'
             }) -TriggerMetadata $null
 
-        $response.Body.Results | Should -HaveCount 1
-        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
-        $response.Body.PSObject.Properties.Name | Should -Contain 'Metadata'
-        Should -Invoke Get-CIPPGroupsReport -Times 1 -ParameterFilter { $PageSize -eq 1000 }
+        $body = ConvertFrom-ResponseBody $response
+        $body.Results | Should -HaveCount 1
+        $body.Metadata.nextLink | Should -BeNullOrEmpty
+        $body.PSObject.Properties.Name | Should -Contain 'Metadata'
+        Should -Invoke Get-CIPPGroupsReport -Times 1 -ParameterFilter { $PageSize -eq 750 }
     }
 
     It 'returns InternalServerError when the paged report read fails' {

--- a/backend/Tests/Endpoint/Invoke-ListGuestUsers.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListGuestUsers.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
     function Get-CippException { param($Exception) @{ NormalizedError = $Exception } }
     function Test-CIPPStandardLicense { param($StandardName, $TenantFilter, $RequiredCapabilities, $Preset, [switch]$SkipLog) }
     function New-GraphGetRequest { param($uri, $tenantid, [switch]$ComplexFilter) }
-    function Get-CIPPGuestUsersReport { param($TenantFilter) }
+    function Get-CIPPGuestUsersReport { param($TenantFilter, $PageSize, $ContinuationToken) }
     function Write-LogMessage { param($headers, $API, $tenant, $message, $Sev, $LogData) }
 
     . $FunctionPath
@@ -276,5 +276,81 @@ Describe 'Invoke-ListGuestUsers' {
         $response.Body[0].Tenant | Should -Be 'contoso.onmicrosoft.com'
         Should -Invoke Get-CIPPGuestUsersReport -Times 1 -ParameterFilter { $TenantFilter -eq 'AllTenants' }
         Should -Invoke New-GraphGetRequest -Times 0
+    }
+
+    Context 'manualPagination' {
+        BeforeEach {
+            Mock -CommandName New-GraphGetRequest -MockWith { throw 'live Graph should not be called' }
+        }
+
+        It 'returns a { Results, Metadata } page with nextLink and clamps PageSize' {
+            Mock -CommandName Get-CIPPGuestUsersReport -MockWith {
+                [PSCustomObject]@{
+                    Items     = @(
+                        [pscustomobject]@{
+                            id = 'g-1'; displayName = 'Guest'; mail = 'g@partner.com'
+                            userPrincipalName = 'g_partner.com#EXT#@contoso.onmicrosoft.com'
+                            createdDateTime = (Get-Date).AddDays(-10).ToString('o'); accountEnabled = $true
+                            externalUserState = 'PendingAcceptance'; externalUserStateChangeDateTime = $null
+                            signInLogsCapable = $true
+                            CacheTimestamp = '2026-08-18T10:00:00Z'; Tenant = 'contoso.onmicrosoft.com'
+                        }
+                    )
+                    NextToken = 'contoso.onmicrosoft.com|Guests-abc'
+                }
+            }
+
+            $response = Invoke-ListGuestUsers -Request (New-GuestRequest -Query @{
+                    tenantFilter = 'AllTenants'; manualPagination = 'true'; PageSize = '10'; nextLink = 'prev|token'
+                }) -TriggerMetadata $null
+
+            $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+            $response.Body.Results | Should -HaveCount 1
+            $response.Body.Results[0].status | Should -Be 'Pending Acceptance'
+            $response.Body.Results[0].Tenant | Should -Be 'contoso.onmicrosoft.com'
+            $response.Body.Metadata.nextLink | Should -Be 'contoso.onmicrosoft.com|Guests-abc'
+            # PageSize 10 is below the floor and must be clamped to 250; the incoming
+            # continuation token is forwarded verbatim.
+            Should -Invoke Get-CIPPGuestUsersReport -Times 1 -ParameterFilter {
+                $TenantFilter -eq 'AllTenants' -and $PageSize -eq 250 -and $ContinuationToken -eq 'prev|token'
+            }
+        }
+
+        It 'omits nextLink on the final page but keeps the paged shape' {
+            Mock -CommandName Get-CIPPGuestUsersReport -MockWith {
+                [PSCustomObject]@{ Items = @(); NextToken = $null }
+            }
+
+            $response = Invoke-ListGuestUsers -Request (New-GuestRequest -Query @{
+                    UseReportDB = 'true'; manualPagination = 'true'
+                }) -TriggerMetadata $null
+
+            $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+            @($response.Body.Results) | Should -HaveCount 0
+            $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+            $response.Body.PSObject.Properties.Name | Should -Contain 'Metadata'
+        }
+
+        It 'keeps the legacy bare array for live reads even when manualPagination is set' {
+            Mock -CommandName Get-CIPPGuestUsersReport -MockWith { throw 'report cache should not be called' }
+            Mock -CommandName New-GraphGetRequest -MockWith {
+                @(
+                    [pscustomobject]@{
+                        id = 'g-1'; displayName = 'Guest'; mail = 'g@partner.com'
+                        userPrincipalName = 'g_partner.com#EXT#@contoso.onmicrosoft.com'
+                        createdDateTime = (Get-Date).AddDays(-10).ToString('o'); accountEnabled = $true
+                        externalUserState = 'PendingAcceptance'; externalUserStateChangeDateTime = $null
+                    }
+                )
+            }
+
+            $response = Invoke-ListGuestUsers -Request (New-GuestRequest -Query @{ manualPagination = 'true' }) -TriggerMetadata $null
+
+            $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+            # No Results wrapper: the body is the plain row array.
+            $response.Body | Should -HaveCount 1
+            $response.Body[0].status | Should -Be 'Pending Acceptance'
+            Should -Invoke Get-CIPPGuestUsersReport -Times 0
+        }
     }
 }

--- a/backend/Tests/Endpoint/Invoke-ListLogs.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListLogs.Tests.ps1
@@ -1,0 +1,276 @@
+# Pester tests for Invoke-ListLogs
+# Validates the manualPagination contract (page shape, keyset continuation, split-row guard,
+# cross-day walk, query budget), the client-side severity/user filters, the legacy
+# unpaginated shape, and single-entry lookup including tick-derived partitions.
+
+BeforeAll {
+    # Resolve by name under Modules/ so the test survives the function moving between modules.
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Invoke-ListLogs.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Invoke-ListLogs.ps1 under Modules/' }
+    $ConverterPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'ConvertTo-CIPPODataFilterValue.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $ConverterPath) { throw 'Could not locate ConvertTo-CIPPODataFilterValue.ps1 under Modules/' }
+
+    # Azure Functions binding types do not exist outside the Functions host - fake them.
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    $Accelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+    if (-not $Accelerators::Get.ContainsKey('HttpStatusCode')) {
+        $Accelerators::Add('HttpStatusCode', [System.Net.HttpStatusCode])
+    }
+
+    # Stub every CIPP helper the function calls so Pester's Mock has a command to replace.
+    function Get-CIPPTable { param($tablename) @{ Context = ($tablename ?? 'CippLogs') } }
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter, $Property, $First, $Skip, $Sort, [switch]$Count, $MaxRetries) }
+    function Test-CIPPAccess { param($Request, [switch]$TenantList) }
+    function Get-Tenants { param([switch]$IncludeErrors) }
+
+    . $ConverterPath
+    . $FunctionPath
+
+    # Deterministic partitioning: pin the timezone the endpoint reads.
+    $script:OldTz = $env:CIPP_TIMEZONE
+    $env:CIPP_TIMEZONE = 'UTC'
+
+    function New-FakeRowKey([datetime]$InstantUtc, [string]$Suffix = 'aaaaaaaaaaaa') {
+        '{0:D19}-{1}' -f ([DateTime]::MaxValue.Ticks - $InstantUtc.Ticks), $Suffix
+    }
+
+    # Rows land in the partition of their instant's UTC date, mirroring Write-LogMessage.
+    # $RowKey deliberately untyped: [string]$null coerces to '' and would defeat the ?? fallback.
+    function New-FakeLogRow([datetime]$InstantUtc, [int]$Seq, [string]$Severity = 'Info', [string]$Username = 'user@contoso.com', $RowKey = $null) {
+        [pscustomobject]@{
+            PartitionKey = $InstantUtc.ToString('yyyyMMdd')
+            RowKey       = $RowKey ?? (New-FakeRowKey $InstantUtc)
+            Timestamp    = [System.DateTimeOffset]::new($InstantUtc)
+            Tenant       = 'contoso.onmicrosoft.com'
+            API          = 'FakeApi'
+            Message      = "seq $Seq"
+            Username     = $Username
+            Severity     = $Severity
+            LogData      = ''
+        }
+    }
+
+    # Static store the table mock reads; ordinal (PartitionKey, RowKey) order like the service.
+    function Select-FakeRows {
+        param($Filter, $First)
+        $Rows = @($script:FakeLogRows)
+        if ($Filter -match "PartitionKey eq '([^']+)'") { $PK = $Matches[1]; $Rows = @($Rows | Where-Object { $_.PartitionKey -eq $PK }) }
+        if ($Filter -match "PartitionKey ge '([^']+)'") { $PK = $Matches[1]; $Rows = @($Rows | Where-Object { [string]::CompareOrdinal($_.PartitionKey, $PK) -ge 0 }) }
+        if ($Filter -match "PartitionKey le '([^']+)'") { $PK = $Matches[1]; $Rows = @($Rows | Where-Object { [string]::CompareOrdinal($_.PartitionKey, $PK) -le 0 }) }
+        if ($Filter -match "RowKey gt '([^']+)'") { $RK = $Matches[1]; $Rows = @($Rows | Where-Object { [string]::CompareOrdinal($_.RowKey, $RK) -gt 0 }) }
+        if ($Filter -match "RowKey eq '([^']+)'") { $RK = $Matches[1]; $Rows = @($Rows | Where-Object { $_.RowKey -eq $RK }) }
+        $Sorted = [System.Collections.Generic.List[object]]::new()
+        $Sorted.AddRange($Rows)
+        $Sorted.Sort([System.Comparison[object]] { param($a, $b) [string]::CompareOrdinal("$($a.PartitionKey)|$($a.RowKey)", "$($b.PartitionKey)|$($b.RowKey)") })
+        if ($First) { @($Sorted | Select-Object -First $First) } else { @($Sorted) }
+    }
+
+    function New-LogsRequest {
+        param([hashtable]$Query = @{})
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ListLogs' }
+            Headers = @{ Authorization = 'token' }
+            Query   = [pscustomobject]$Query
+        }
+    }
+}
+
+AfterAll {
+    $env:CIPP_TIMEZONE = $script:OldTz
+}
+
+Describe 'Invoke-ListLogs pagination' {
+    BeforeEach {
+        Mock -CommandName Test-CIPPAccess -MockWith { @('AllTenants') }
+        Mock -CommandName Get-Tenants -MockWith { @() }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { Select-FakeRows -Filter $Filter -First $First }
+    }
+
+    It 'returns a full page with a continuation token, newest entries first' {
+        $Base = [datetime]::new(2025, 6, 10, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $script:FakeLogRows = foreach ($i in 1..120) { New-FakeLogRow $Base.AddSeconds($i) $i }
+
+        $response = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250610'; EndDate = '20250610'
+                manualPagination = 'true'; PageSize = '50'
+            }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be ([System.Net.HttpStatusCode]::OK)
+        $response.Body.Results | Should -HaveCount 50
+        $response.Body.Results[0].Message | Should -Be 'seq 120'
+        $response.Body.Results[49].Message | Should -Be 'seq 71'
+        # Pin the record shape: the paged and legacy paths build this literal separately and
+        # the frontend treats their rows interchangeably.
+        $response.Body.Results[0].PSObject.Properties.Name | Should -Be @(
+            'DateTime', 'Tenant', 'API', 'Message', 'User', 'Severity', 'LogData',
+            'TenantID', 'AppId', 'IP', 'RowKey', 'StandardInfo', 'DateFilter')
+        $response.Body.Metadata.nextLink | Should -Be ('20250610|{0}' -f $response.Body.Results[49].RowKey)
+        # One chunk fills the page: exactly one CippLogs read.
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly
+    }
+
+    It 'continues after the token without duplicates and skips -partN split rows' {
+        $Base = [datetime]::new(2025, 6, 10, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $Rows = [System.Collections.Generic.List[object]]::new()
+        foreach ($i in 1..120) { $Rows.Add((New-FakeLogRow $Base.AddSeconds($i) $i)) }
+        $script:FakeLogRows = $Rows
+
+        $PageOne = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250610'; EndDate = '20250610'
+                manualPagination = 'true'; PageSize = '50'
+            }) -TriggerMetadata $null
+        $BoundaryKey = $PageOne.Body.Results[49].RowKey
+        # A split-entity continuation row for the boundary entity sorts right after it and
+        # must not surface as an entity of its own on the next page.
+        $PartRow = New-FakeLogRow $Base.AddSeconds(71) 71 -RowKey "$BoundaryKey-part2"
+        $Rows.Add($PartRow)
+        $script:FakeLogRows = $Rows
+
+        $PageTwo = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250610'; EndDate = '20250610'
+                manualPagination = 'true'; PageSize = '50'
+                nextLink = $PageOne.Body.Metadata.nextLink
+            }) -TriggerMetadata $null
+
+        $PageTwo.Body.Results | Should -HaveCount 50
+        $PageTwo.Body.Results[0].Message | Should -Be 'seq 70'
+        $PageTwo.Body.Results.RowKey | Should -Not -Contain "$BoundaryKey-part2"
+        $Overlap = @($PageTwo.Body.Results.RowKey | Where-Object { $PageOne.Body.Results.RowKey -contains $_ })
+        $Overlap | Should -HaveCount 0
+    }
+
+    It 'walks the date range newest day first, skipping empty days, and omits nextLink when exhausted' {
+        $DayNew = [datetime]::new(2025, 6, 10, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $DayOld = [datetime]::new(2025, 6, 7, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $script:FakeLogRows = @(
+            foreach ($i in 1..10) { New-FakeLogRow $DayNew.AddSeconds($i) $i }
+            foreach ($i in 301..305) { New-FakeLogRow $DayOld.AddSeconds($i) $i }
+        )
+
+        $response = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250607'; EndDate = '20250610'
+                manualPagination = 'true'; PageSize = '50'
+            }) -TriggerMetadata $null
+
+        $response.Body.Results | Should -HaveCount 15
+        $response.Body.Results[0].Message | Should -Be 'seq 10'
+        $response.Body.Results[9].Message | Should -Be 'seq 1'
+        $response.Body.Results[10].Message | Should -Be 'seq 305'
+        $response.Body.Results[14].Message | Should -Be 'seq 301'
+        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+    }
+
+    It 'bounds table reads per request and resumes via nextLink over an empty range' {
+        $script:FakeLogRows = @()
+
+        $PageOne = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250527'; EndDate = '20250610'
+                manualPagination = 'true'; PageSize = '50'
+            }) -TriggerMetadata $null
+
+        $PageOne.Body.Results | Should -HaveCount 0
+        # 15-day range, 10-query budget: page one stops mid-walk with a resumable token.
+        $PageOne.Body.Metadata.nextLink | Should -Not -BeNullOrEmpty
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 10 -Exactly
+
+        $PageTwo = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250527'; EndDate = '20250610'
+                manualPagination = 'true'; PageSize = '50'
+                nextLink = $PageOne.Body.Metadata.nextLink
+            }) -TriggerMetadata $null
+
+        $PageTwo.Body.Results | Should -HaveCount 0
+        $PageTwo.Body.Metadata.nextLink | Should -BeNullOrEmpty
+    }
+
+    It 'applies severity and username filters client-side within pages' {
+        $Base = [datetime]::new(2025, 6, 10, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $script:FakeLogRows = @(
+            New-FakeLogRow $Base.AddSeconds(1) 1 'Info' 'alice@contoso.com'
+            New-FakeLogRow $Base.AddSeconds(2) 2 'Error' 'alice@contoso.com'
+            New-FakeLogRow $Base.AddSeconds(3) 3 'Error' 'bob@contoso.com'
+            New-FakeLogRow $Base.AddSeconds(4) 4 'Debug' 'alice@contoso.com'
+        )
+
+        $response = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250610'; EndDate = '20250610'
+                Severity = 'Error'; User = 'alice*'
+                manualPagination = 'true'; PageSize = '50'
+            }) -TriggerMetadata $null
+
+        $response.Body.Results | Should -HaveCount 1
+        $response.Body.Results[0].Message | Should -Be 'seq 2'
+    }
+
+    It 'keeps the legacy unpaginated bare-array shape when manualPagination is absent' {
+        $Base = [datetime]::new(2025, 6, 10, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $script:FakeLogRows = foreach ($i in 1..5) { New-FakeLogRow $Base.AddSeconds($i) $i }
+
+        $response = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                Filter = 'true'; StartDate = '20250610'; EndDate = '20250610'
+            }) -TriggerMetadata $null
+
+        # Bare array of entries - no Results/Metadata wrapper - with the same record shape
+        # as the paged path.
+        $response.Body | Should -HaveCount 5
+        $response.Body[0].PSObject.Properties.Name | Should -Be @(
+            'DateTime', 'Tenant', 'API', 'Message', 'User', 'Severity', 'LogData',
+            'TenantID', 'AppId', 'IP', 'RowKey', 'StandardInfo', 'DateFilter')
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Filter -match "PartitionKey ge '20250610' and PartitionKey le '20250610'"
+        }
+    }
+}
+
+Describe 'Invoke-ListLogs single entry' {
+    BeforeEach {
+        Mock -CommandName Test-CIPPAccess -MockWith { @('AllTenants') }
+        Mock -CommandName Get-Tenants -MockWith { @() }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { Select-FakeRows -Filter $Filter -First $First }
+    }
+
+    It 'derives the day partition from an inverted-ticks RowKey when no DateFilter is given' {
+        $Instant = [datetime]::new(2025, 6, 8, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $Row = New-FakeLogRow $Instant 42
+        $script:FakeLogRows = @($Row)
+
+        $response = Invoke-ListLogs -Request (New-LogsRequest -Query @{ logentryid = $Row.RowKey }) -TriggerMetadata $null
+
+        $response.Body | Should -HaveCount 1
+        $response.Body[0].RowKey | Should -Be $Row.RowKey
+        $response.Body[0].DateFilter | Should -Be '20250608'
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Filter -match "PartitionKey eq '20250608'"
+        }
+    }
+
+    It 'honours an explicit DateFilter and still resolves legacy GUID RowKeys' {
+        $Instant = [datetime]::new(2025, 6, 8, 12, 0, 0, [System.DateTimeKind]::Utc)
+        $Row = New-FakeLogRow $Instant 7 -RowKey 'd6b31653-b3a4-4a54-9761-d5a2b746a349'
+        $script:FakeLogRows = @($Row)
+
+        $response = Invoke-ListLogs -Request (New-LogsRequest -Query @{
+                logentryid = $Row.RowKey; DateFilter = '20250608'
+            }) -TriggerMetadata $null
+
+        $response.Body | Should -HaveCount 1
+        $response.Body[0].RowKey | Should -Be $Row.RowKey
+        # The single-entry shape exposes Standard, not StandardInfo.
+        $response.Body[0].PSObject.Properties.Name | Should -Contain 'Standard'
+        $response.Body[0].PSObject.Properties.Name | Should -Not -Contain 'StandardInfo'
+    }
+
+    It 'rejects log entry ids that are not plain hex-and-hyphen strings' {
+        $script:FakeLogRows = @()
+        {
+            Invoke-ListLogs -Request (New-LogsRequest -Query @{ logentryid = "x' or PartitionKey gt '" }) -TriggerMetadata $null
+        } | Should -Throw '*Invalid log entry id*'
+    }
+}

--- a/backend/Tests/Endpoint/Invoke-ListLogs.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListLogs.Tests.ps1
@@ -227,6 +227,27 @@ Describe 'Invoke-ListLogs pagination' {
             $Filter -match "PartitionKey ge '20250610' and PartitionKey le '20250610'"
         }
     }
+
+    It 'widens a filtered query without dates to the last N days via Days, on both paths' {
+        # The scoped log drawers pass Days=N so a run that finished last night is still
+        # visible early the next day. Timezone is pinned to UTC by the harness.
+        $script:FakeLogRows = @()
+        $Today = [DateTime]::UtcNow.Date
+        $From = $Today.AddDays(-6).ToString('yyyyMMdd')
+        $To = $Today.ToString('yyyyMMdd')
+
+        $null = Invoke-ListLogs -Request (New-LogsRequest -Query @{ Filter = 'true'; Days = '7' }) -TriggerMetadata $null
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Filter -match "PartitionKey ge '$From' and PartitionKey le '$To'"
+        }
+
+        # Paged: the day walk covers the same seven partitions (all empty here) and completes.
+        $response = Invoke-ListLogs -Request (New-LogsRequest -Query @{ Filter = 'true'; Days = '7'; manualPagination = 'true' }) -TriggerMetadata $null
+        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 7 -Exactly -ParameterFilter { $Filter -match "PartitionKey eq '" }
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter { $Filter -match "PartitionKey eq '$From'" }
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter { $Filter -match "PartitionKey eq '$To'" }
+    }
 }
 
 Describe 'Invoke-ListLogs single entry' {

--- a/backend/Tests/Endpoint/Invoke-ListMailboxes.Tests.ps1
+++ b/backend/Tests/Endpoint/Invoke-ListMailboxes.Tests.ps1
@@ -1,0 +1,113 @@
+# Pester tests for Invoke-ListMailboxes
+# Validates the reporting-database branch: the legacy bare-array shape, and the
+# manualPagination contract ({ Results, Metadata } pages chained via Metadata.nextLink).
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    class HttpResponseContext {
+        [int]$StatusCode
+        [object]$Body
+    }
+
+    # Stub every CIPP helper the function calls so Pester's Mock has a command to replace.
+    function Get-CIPPMailboxesReport { param($TenantFilter, $PageSize, $ContinuationToken) }
+    function New-ExoRequest { param($tenantid, $cmdlet, $cmdParams, $Select) }
+    function Get-CIPPAutoExpandingArchiveState { param($MailboxAutoExpandingArchiveEnabled, $OrgAutoExpandingArchiveEnabled) }
+    function Get-NormalizedError { param($Message) $Message }
+
+    $EndpointPath = Join-Path $RepoRoot 'Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Email-Exchange/Administration/Invoke-ListMailboxes.ps1'
+    $EndpointScript = [ScriptBlock]::Create("using namespace System.Net`n" + (Get-Content -LiteralPath $EndpointPath -Raw))
+    . $EndpointScript
+
+    function New-MailboxRequest {
+        param([hashtable]$Query = @{})
+        $Merged = @{ tenantFilter = 'contoso.onmicrosoft.com' }
+        foreach ($Key in $Query.Keys) { $Merged[$Key] = $Query[$Key] }
+        [pscustomobject]@{
+            Params  = @{ CIPPEndpoint = 'ListMailboxes' }
+            Headers = @{ Authorization = 'token' }
+            Query   = [pscustomobject]$Merged
+        }
+    }
+}
+
+Describe 'Invoke-ListMailboxes report database branch' {
+    BeforeEach {
+        Mock -CommandName New-ExoRequest -MockWith { throw 'live EXO should not be called' }
+    }
+
+    It 'returns the legacy bare array without manualPagination' {
+        Mock -CommandName Get-CIPPMailboxesReport -MockWith {
+            @(
+                [pscustomobject]@{ displayName = 'Box One'; UPN = 'one@contoso.com'; CacheTimestamp = '2026-08-18T10:00:00Z' }
+                [pscustomobject]@{ displayName = 'Box Two'; UPN = 'two@contoso.com'; CacheTimestamp = '2026-08-18T10:00:00Z' }
+            )
+        }
+
+        $response = Invoke-ListMailboxes -Request (New-MailboxRequest -Query @{ UseReportDB = 'true' }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 200
+        $response.Body | Should -HaveCount 2
+        $response.Body[0].displayName | Should -Be 'Box One'
+        Should -Invoke Get-CIPPMailboxesReport -Times 1 -ParameterFilter {
+            $TenantFilter -eq 'contoso.onmicrosoft.com' -and -not $PageSize
+        }
+    }
+
+    It 'returns { Results, Metadata } pages when manualPagination is set' {
+        Mock -CommandName Get-CIPPMailboxesReport -MockWith {
+            [PSCustomObject]@{
+                Items     = @(
+                    [pscustomobject]@{ displayName = 'Box One'; UPN = 'one@contoso.com'; Tenant = 'contoso.onmicrosoft.com' }
+                )
+                NextToken = 'contoso.onmicrosoft.com|Mailboxes-abc'
+            }
+        }
+
+        $response = Invoke-ListMailboxes -Request (New-MailboxRequest -Query @{
+                tenantFilter = 'AllTenants'; UseReportDB = 'true'; manualPagination = 'true'; PageSize = '9999'; nextLink = 'prev|token'
+            }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 200
+        $response.Body.Results | Should -HaveCount 1
+        $response.Body.Results[0].displayName | Should -Be 'Box One'
+        $response.Body.Metadata.nextLink | Should -Be 'contoso.onmicrosoft.com|Mailboxes-abc'
+        # PageSize 9999 is inside the 250-10000 clamp and passes through; the incoming
+        # continuation token is forwarded verbatim.
+        Should -Invoke Get-CIPPMailboxesReport -Times 1 -ParameterFilter {
+            $TenantFilter -eq 'AllTenants' -and $PageSize -eq 9999 -and $ContinuationToken -eq 'prev|token'
+        }
+    }
+
+    It 'omits nextLink on the final page but keeps the paged shape' {
+        Mock -CommandName Get-CIPPMailboxesReport -MockWith {
+            [PSCustomObject]@{
+                Items     = @([pscustomobject]@{ displayName = 'Box One' })
+                NextToken = $null
+            }
+        }
+
+        $response = Invoke-ListMailboxes -Request (New-MailboxRequest -Query @{
+                UseReportDB = 'true'; manualPagination = 'true'
+            }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 200
+        $response.Body.Results | Should -HaveCount 1
+        $response.Body.Metadata.nextLink | Should -BeNullOrEmpty
+        $response.Body.PSObject.Properties.Name | Should -Contain 'Metadata'
+        # No PageSize in the request: the default lands between the clamp bounds.
+        Should -Invoke Get-CIPPMailboxesReport -Times 1 -ParameterFilter { $PageSize -eq 5000 }
+    }
+
+    It 'returns InternalServerError when the paged report read fails' {
+        Mock -CommandName Get-CIPPMailboxesReport -MockWith { throw 'No mailbox data found in reporting database. Sync the report data first.' }
+
+        $response = Invoke-ListMailboxes -Request (New-MailboxRequest -Query @{
+                UseReportDB = 'true'; manualPagination = 'true'
+            }) -TriggerMetadata $null
+
+        $response.StatusCode | Should -Be 500
+        "$($response.Body)" | Should -Match 'Sync the report data first'
+    }
+}

--- a/backend/Tests/Private/Get-CIPPDbItemPage.Tests.ps1
+++ b/backend/Tests/Private/Get-CIPPDbItemPage.Tests.ps1
@@ -1,0 +1,84 @@
+# Pester tests for Get-CIPPDbItemPage
+# Validates the reporting-database partition plan (count-row enumeration intersected with
+# managed tenants, alphabetical), the single-tenant plan, the RowKey range handed to the
+# walker, and count-marker removal.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    # Stub every helper the function calls so Pester's Mock has a command to replace.
+    function Get-CippTable { param($tablename) }
+    function Get-CIPPDbItem { param($TenantFilter, $Type, [switch]$CountsOnly) }
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function Get-CIPPPagedTableRows {
+        param($Table, $PartitionKeys, $RowKeyGe, $RowKeyLt, $ExtraFilterClauses, $PageSize, $MaxQueries, $ContinuationToken)
+    }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPDbItemPage.ps1')
+}
+
+Describe 'Get-CIPPDbItemPage' {
+    BeforeEach {
+        Mock -CommandName Get-CippTable -MockWith { @{ Context = 'fake' } }
+        Mock -CommandName Get-CIPPDbItem -MockWith { @() }
+        Mock -CommandName Get-CIPPPagedTableRows -MockWith {
+            [PSCustomObject]@{
+                Rows      = [System.Collections.Generic.List[object]]@(
+                    [PSCustomObject]@{ PartitionKey = 'alpha.onmicrosoft.com'; RowKey = 'Guests-1'; Data = '{}' }
+                    [PSCustomObject]@{ PartitionKey = 'alpha.onmicrosoft.com'; RowKey = 'Guests-Count'; DataCount = 1 }
+                )
+                NextToken = 'alpha.onmicrosoft.com|Guests-Count'
+            }
+        }
+    }
+
+    It 'builds the AllTenants plan from count rows, managed tenants only, alphabetical' {
+        Mock -CommandName Get-CIPPDbItem -MockWith {
+            @(
+                [PSCustomObject]@{ PartitionKey = 'zeta.onmicrosoft.com'; RowKey = 'Guests-Count'; DataCount = 5 }
+                [PSCustomObject]@{ PartitionKey = 'alpha.onmicrosoft.com'; RowKey = 'Guests-Count'; DataCount = 2 }
+                # Has cached data but is no longer managed - must be excluded from the walk.
+                [PSCustomObject]@{ PartitionKey = 'gone.onmicrosoft.com'; RowKey = 'Guests-Count'; DataCount = 9 }
+            )
+        }
+        Mock -CommandName Get-Tenants -MockWith {
+            @(
+                [PSCustomObject]@{ defaultDomainName = 'alpha.onmicrosoft.com' }
+                [PSCustomObject]@{ defaultDomainName = 'zeta.onmicrosoft.com' }
+            )
+        }
+
+        $Result = Get-CIPPDbItemPage -TenantFilter 'AllTenants' -Type 'Guests' -PageSize 500 -ContinuationToken 'tok'
+
+        Should -Invoke Get-CIPPDbItem -Times 1 -ParameterFilter { $TenantFilter -eq 'allTenants' -and $Type -eq 'Guests' -and $CountsOnly }
+        Should -Invoke Get-CIPPPagedTableRows -Times 1 -ParameterFilter {
+            ($PartitionKeys -join ',') -eq 'alpha.onmicrosoft.com,zeta.onmicrosoft.com' -and
+            $RowKeyGe -eq 'Guests-' -and $RowKeyLt -eq 'Guests.' -and
+            $PageSize -eq 500 -and $ContinuationToken -eq 'tok'
+        }
+        # The count marker row is stripped; the data row and token pass through.
+        $Result.Items | Should -HaveCount 1
+        $Result.Items[0].RowKey | Should -Be 'Guests-1'
+        $Result.NextToken | Should -Be 'alpha.onmicrosoft.com|Guests-Count'
+    }
+
+    It 'walks a single tenant partition after normalizing the tenant filter' {
+        Mock -CommandName Get-Tenants -MockWith {
+            [PSCustomObject]@{ defaultDomainName = 'alpha.onmicrosoft.com' }
+        }
+
+        $null = Get-CIPPDbItemPage -TenantFilter 'alpha.onmicrosoft.com' -Type 'Mailboxes'
+
+        Should -Invoke Get-Tenants -Times 1 -ParameterFilter { $TenantFilter -eq 'alpha.onmicrosoft.com' }
+        Should -Invoke Get-CIPPDbItem -Times 0
+        Should -Invoke Get-CIPPPagedTableRows -Times 1 -ParameterFilter {
+            ($PartitionKeys -join ',') -eq 'alpha.onmicrosoft.com' -and $RowKeyGe -eq 'Mailboxes-' -and $RowKeyLt -eq 'Mailboxes.'
+        }
+    }
+
+    It 'throws when the single tenant cannot be resolved' {
+        Mock -CommandName Get-Tenants -MockWith { $null }
+
+        { Get-CIPPDbItemPage -TenantFilter 'missing.example.com' -Type 'Guests' } | Should -Throw "*not found*"
+    }
+}

--- a/backend/Tests/Private/Get-CIPPGroupsReport.Tests.ps1
+++ b/backend/Tests/Private/Get-CIPPGroupsReport.Tests.ps1
@@ -1,0 +1,99 @@
+# Pester tests for Get-CIPPGroupsReport -AsRawJson
+# Validates that a page is stitched from the stored blobs verbatim (no member array is
+# ever deserialized), with per-row CacheTimestamp and (AllTenants only) Tenant spliced in.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    # Stub the helpers the exercised path touches so Pester's Mock has a command to replace.
+    function Get-CIPPDbItemPage { param($TenantFilter, $Type, $PageSize, $ContinuationToken) }
+    function Get-CIPPDbItem { param($TenantFilter, $Type) }
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function Write-LogMessage { param($API, $tenant, $message, $sev) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPGroupsReport.ps1')
+
+    function New-GroupBlob {
+        param([string]$Id, [string[]]$Upns)
+        $members = @(foreach ($u in $Upns) { [PSCustomObject]@{ id = $u; userPrincipalName = $u } })
+        [PSCustomObject]@{
+            id          = $Id
+            displayName = "Group $Id"
+            members     = $members
+            membersCsv  = ($Upns -join ',')
+        } | ConvertTo-Json -Depth 10 -Compress
+    }
+
+    function New-PageItem {
+        param([string]$Tenant, [string]$Blob, $Timestamp)
+        [PSCustomObject]@{ PartitionKey = $Tenant; Timestamp = $Timestamp; Data = $Blob }
+    }
+}
+
+Describe 'Get-CIPPGroupsReport -AsRawJson' {
+    It 'stitches blobs verbatim and splices Tenant + CacheTimestamp for AllTenants' {
+        $ts = [datetimeoffset]'2024-05-01T10:00:00Z'
+        $blobA = New-GroupBlob -Id 'g1' -Upns @('a@contoso.com', 'b@contoso.com')
+        $blobB = New-GroupBlob -Id 'g2' -Upns @('c@fabrikam.com')
+        $page = [PSCustomObject]@{
+            Items     = @(
+                (New-PageItem -Tenant 'contoso.onmicrosoft.com' -Blob $blobA -Timestamp $ts),
+                (New-PageItem -Tenant 'fabrikam.onmicrosoft.com' -Blob $blobB -Timestamp $ts)
+            )
+            NextToken = 'fabrikam.onmicrosoft.com|Groups-xyz'
+        }
+        Mock -CommandName Get-CIPPDbItemPage -MockWith { $page }.GetNewClosure()
+
+        $result = Get-CIPPGroupsReport -TenantFilter 'AllTenants' -PageSize 100 -AsRawJson
+
+        $result.NextToken | Should -Be 'fabrikam.onmicrosoft.com|Groups-xyz'
+        # The stored blob (minus its closing brace) must appear byte-for-byte — proof the
+        # member array was streamed, not parsed and rebuilt. Literal Contains, not -BeLike:
+        # the members array's [ ] are wildcard metacharacters.
+        $result.CippPagedJson.Contains($blobA.Substring(0, $blobA.Length - 1)) | Should -BeTrue
+
+        $parsed = $result.CippPagedJson | ConvertFrom-Json
+        $parsed | Should -HaveCount 2
+        $parsed[0].members | Should -HaveCount 2
+        $parsed[0].members[0].userPrincipalName | Should -Be 'a@contoso.com'
+        $parsed[0].membersCsv | Should -Be 'a@contoso.com,b@contoso.com'
+        $parsed[0].Tenant | Should -Be 'contoso.onmicrosoft.com'
+        $parsed[1].Tenant | Should -Be 'fabrikam.onmicrosoft.com'
+        $parsed[0].CacheTimestamp | Should -Not -BeNullOrEmpty
+    }
+
+    It 'does not splice a Tenant field for a single-tenant read' {
+        $blob = New-GroupBlob -Id 'g1' -Upns @('a@contoso.com')
+        $page = [PSCustomObject]@{
+            Items     = @((New-PageItem -Tenant 'contoso.onmicrosoft.com' -Blob $blob -Timestamp ([datetimeoffset]::UtcNow)))
+            NextToken = $null
+        }
+        Mock -CommandName Get-CIPPDbItemPage -MockWith { $page }.GetNewClosure()
+
+        $result = Get-CIPPGroupsReport -TenantFilter 'contoso.onmicrosoft.com' -PageSize 100 -AsRawJson
+        $parsed = $result.CippPagedJson | ConvertFrom-Json
+
+        $parsed.PSObject.Properties.Name | Should -Not -Contain 'Tenant'
+        $parsed.CacheTimestamp | Should -Not -BeNullOrEmpty
+        $result.NextToken | Should -BeNullOrEmpty
+    }
+
+    It 'skips empty or malformed blobs' {
+        $good = New-GroupBlob -Id 'g1' -Upns @('a@contoso.com')
+        $page = [PSCustomObject]@{
+            Items     = @(
+                (New-PageItem -Tenant 'contoso.onmicrosoft.com' -Blob '' -Timestamp ([datetimeoffset]::UtcNow)),
+                (New-PageItem -Tenant 'contoso.onmicrosoft.com' -Blob '   ' -Timestamp ([datetimeoffset]::UtcNow)),
+                (New-PageItem -Tenant 'contoso.onmicrosoft.com' -Blob $good -Timestamp ([datetimeoffset]::UtcNow))
+            )
+            NextToken = $null
+        }
+        Mock -CommandName Get-CIPPDbItemPage -MockWith { $page }.GetNewClosure()
+
+        $result = Get-CIPPGroupsReport -TenantFilter 'AllTenants' -PageSize 100 -AsRawJson
+        $parsed = @($result.CippPagedJson | ConvertFrom-Json)
+
+        $parsed | Should -HaveCount 1
+        $parsed[0].id | Should -Be 'g1'
+    }
+}

--- a/backend/Tests/Private/Get-CIPPPagedTableRows.Tests.ps1
+++ b/backend/Tests/Private/Get-CIPPPagedTableRows.Tests.ps1
@@ -1,0 +1,200 @@
+# Pester tests for Get-CIPPPagedTableRows
+# Validates the cross-partition range-scan pager: row-count paging independent of how many
+# partitions the data spans, continuation token round-trips (including escaping), plan
+# membership filtering, and the query-count economy that motivated the range design.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    # Stub so Pester's Mock has a command to replace.
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter, $Property, $First) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/ConvertTo-CIPPODataFilterValue.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPPagedTableRows.ps1')
+
+    # In-memory table emulation for the filter shapes the pager emits (PK/RK ranges, the
+    # OR resume clause, ordinal ordering, -First). Test keys never contain quotes.
+    function Select-FakeRows {
+        param([object[]]$Rows, [string]$Filter, $First)
+        $PkGe = if ($Filter -match "PartitionKey ge '([^']*)'") { $Matches[1] } else { $null }
+        $PkLe = if ($Filter -match "PartitionKey le '([^']*)'") { $Matches[1] } else { $null }
+        $RkGe = if ($Filter -match "RowKey ge '([^']*)'") { $Matches[1] } else { $null }
+        $RkLt = if ($Filter -match "RowKey lt '([^']*)'") { $Matches[1] } else { $null }
+        $Resume = if ($Filter -match "\(\(PartitionKey gt '([^']*)'\) or \(PartitionKey eq '[^']*' and RowKey gt '([^']*)'\)\)") {
+            @{ Pk = $Matches[1]; Rk = $Matches[2] }
+        } else { $null }
+        $Out = @($Rows | Where-Object {
+                $Row = $_
+                $Keep = (-not $PkGe -or [string]::CompareOrdinal($Row.PartitionKey, $PkGe) -ge 0) -and
+                        (-not $PkLe -or [string]::CompareOrdinal($Row.PartitionKey, $PkLe) -le 0) -and
+                        (-not $RkGe -or [string]::CompareOrdinal($Row.RowKey, $RkGe) -ge 0) -and
+                        (-not $RkLt -or [string]::CompareOrdinal($Row.RowKey, $RkLt) -lt 0)
+                if ($Keep -and $Resume) {
+                    $Keep = ([string]::CompareOrdinal($Row.PartitionKey, $Resume.Pk) -gt 0) -or
+                            ($Row.PartitionKey -ceq $Resume.Pk -and [string]::CompareOrdinal($Row.RowKey, $Resume.Rk) -gt 0)
+                }
+                $Keep
+            } | Sort-Object -Property @{ Expression = { $_.PartitionKey }; Ascending = $true }, @{ Expression = { $_.RowKey }; Ascending = $true })
+        if ($First) { $Out = @($Out | Select-Object -First ([int]$First)) }
+        $Out
+    }
+
+    function New-FakeRow {
+        param([string]$Pk, [string]$Rk)
+        [PSCustomObject]@{ PartitionKey = $Pk; RowKey = $Rk; Data = "$Pk/$Rk" }
+    }
+}
+
+Describe 'Get-CIPPPagedTableRows' {
+    BeforeEach {
+        $script:FakeRows = @()
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            Select-FakeRows -Rows $script:FakeRows -Filter $Filter -First $First
+        }
+    }
+
+    It 'walks partitions in ordinal order and completes with a null token when everything fits' {
+        $script:FakeRows = @(
+            New-FakeRow 'tenantB' 'Guests-2'
+            New-FakeRow 'tenantA' 'Guests-1'
+            New-FakeRow 'tenantB' 'Guests-1'
+        )
+
+        $Page = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('tenantA', 'tenantB') -PageSize 100
+
+        $Page.Rows | Should -HaveCount 3
+        $Page.Rows[0].Data | Should -Be 'tenantA/Guests-1'
+        $Page.Rows[1].Data | Should -Be 'tenantB/Guests-1'
+        $Page.Rows[2].Data | Should -Be 'tenantB/Guests-2'
+        $Page.NextToken | Should -BeNullOrEmpty
+    }
+
+    It 'pages many small partitions in one page with a bounded query count' {
+        # The complaint this design answers: row-count paging must not degrade with the
+        # partition count. 60 one-row tenants fit one 100-row page in a couple of queries.
+        $script:FakeRows = foreach ($i in 1..60) {
+            New-FakeRow ('tenant{0:D3}' -f $i) 'Users-1'
+        }
+        $Plan = @(1..60 | ForEach-Object { 'tenant{0:D3}' -f $_ })
+
+        $Page = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys $Plan -PageSize 100
+
+        $Page.Rows | Should -HaveCount 60
+        $Page.NextToken | Should -BeNullOrEmpty
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 2 -Exactly
+    }
+
+    It 'returns full coverage without duplicates when paging with continuation tokens' {
+        $script:FakeRows = foreach ($Tenant in 'tenantA', 'tenantB') {
+            foreach ($i in 1..5) { New-FakeRow $Tenant ('Users-{0:D2}' -f $i) }
+        }
+
+        $Collected = [System.Collections.Generic.List[string]]::new()
+        $Token = $null
+        $Pages = 0
+        do {
+            $Page = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('tenantA', 'tenantB') -PageSize 3 -ContinuationToken $Token
+            foreach ($Row in $Page.Rows) { $Collected.Add($Row.Data) }
+            $Token = $Page.NextToken
+            $Pages++
+        } while ($Token -and $Pages -lt 20)
+
+        $Pages | Should -BeLessThan 20
+        $Collected | Should -HaveCount 10
+        ($Collected | Sort-Object -Unique) | Should -HaveCount 10
+        $Collected[0] | Should -Be 'tenantA/Users-01'
+        $Collected[-1] | Should -Be 'tenantB/Users-05'
+    }
+
+    It 'applies the RowKey range bounds' {
+        $script:FakeRows = @(
+            New-FakeRow 'tenantA' 'Groups-1'
+            New-FakeRow 'tenantA' 'Guests-1'
+            New-FakeRow 'tenantA' 'Guests-Count'
+            New-FakeRow 'tenantA' 'Mailboxes-1'
+        )
+
+        $Page = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('tenantA') -RowKeyGe 'Guests-' -RowKeyLt 'Guests.' -PageSize 100
+
+        # Only the Guests-* range: no Groups, no Mailboxes. The count marker is inside the
+        # range by design; callers remove it.
+        $Page.Rows.RowKey | Should -Be @('Guests-1', 'Guests-Count')
+    }
+
+    It 'drops rows from partitions outside the plan but keeps advancing the cursor' {
+        # gone.example sits ordinally between the plan tenants and floods the range with
+        # rows; they must be filtered out without stalling or re-reading.
+        $script:FakeRows = @(New-FakeRow 'aaa.example' 'Users-1') +
+        @(foreach ($i in 1..6) { New-FakeRow 'gone.example' ('Users-{0}' -f $i) }) +
+        @(New-FakeRow 'zzz.example' 'Users-1')
+
+        $Collected = [System.Collections.Generic.List[string]]::new()
+        $Token = $null
+        $Pages = 0
+        do {
+            $Page = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('aaa.example', 'zzz.example') -PageSize 3 -ContinuationToken $Token
+            foreach ($Row in $Page.Rows) { $Collected.Add($Row.Data) }
+            $Token = $Page.NextToken
+            $Pages++
+        } while ($Token -and $Pages -lt 10)
+
+        $Collected | Should -Be @('aaa.example/Users-1', 'zzz.example/Users-1')
+    }
+
+    It 'ends a short page with a token when MaxQueries runs out before PageSize' {
+        # Every chunk is full of non-plan rows, so kept rows stay short of PageSize and
+        # the safety bound has to end the page with resumable progress.
+        $script:FakeRows = @(foreach ($i in 1..9) { New-FakeRow 'gone.example' ('Users-{0}' -f $i) }) +
+        @(New-FakeRow 'zzz.example' 'Users-1')
+
+        $Page1 = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('aaa.example', 'zzz.example') -PageSize 3 -MaxQueries 2
+        $Page1.Rows | Should -HaveCount 0
+        $Page1.NextToken | Should -Not -BeNullOrEmpty
+
+        # Chaining the short pages still reaches everything exactly once.
+        $Collected = [System.Collections.Generic.List[string]]::new()
+        $Token = $Page1.NextToken
+        $Pages = 1
+        do {
+            $Page = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('aaa.example', 'zzz.example') -PageSize 3 -MaxQueries 2 -ContinuationToken $Token
+            foreach ($Row in $Page.Rows) { $Collected.Add($Row.Data) }
+            $Token = $Page.NextToken
+            $Pages++
+        } while ($Token -and $Pages -lt 10)
+
+        $Pages | Should -BeLessThan 10
+        $Collected | Should -Be @('zzz.example/Users-1')
+    }
+
+    It 'round-trips tokens whose keys contain the separator and non-ASCII characters' {
+        $script:FakeRows = @(
+            New-FakeRow 'tenant|pipe' 'Users-aä'
+            New-FakeRow 'tenant|pipe' 'Users-b'
+        )
+
+        $Page1 = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('tenant|pipe') -PageSize 1
+        $Page1.Rows | Should -HaveCount 1
+        $Page1.Rows[0].RowKey | Should -Be 'Users-aä'
+        $Page1.NextToken | Should -Not -BeNullOrEmpty
+
+        $Page2 = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('tenant|pipe') -PageSize 1 -ContinuationToken $Page1.NextToken
+        $Page2.Rows | Should -HaveCount 1
+        $Page2.Rows[0].RowKey | Should -Be 'Users-b'
+    }
+
+    It 'ANDs extra filter clauses onto every query' {
+        $script:FakeRows = @(New-FakeRow 'tenantA' 'Users-1')
+
+        $null = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @('tenantA') -PageSize 10 -ExtraFilterClauses @("Severity eq 'Error'")
+
+        Should -Invoke Get-CIPPAzDataTableEntity -ParameterFilter { $Filter -like "*and Severity eq 'Error'" }
+    }
+
+    It 'returns an empty completed page for an empty partition plan' {
+        $Page = Get-CIPPPagedTableRows -Table @{ Context = 'fake' } -PartitionKeys @() -PageSize 10
+
+        $Page.Rows | Should -HaveCount 0
+        $Page.NextToken | Should -BeNullOrEmpty
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 0
+    }
+}

--- a/backend/Tests/Private/Get-GraphRequestList.Paging.Tests.ps1
+++ b/backend/Tests/Private/Get-GraphRequestList.Paging.Tests.ps1
@@ -1,0 +1,219 @@
+# Pester tests for the paged AllTenants cache serve in Get-GraphRequestList
+# Validates that ManualPagination + RawJsonArray serves pages bounded by the byte budget
+# alone (never a tenant count), fetched as span range queries, with a continuation token;
+# that the key scan never fetches Data payloads; that the queue fallback still triggers on
+# a cold cache; and that the unpaged fast path is intact.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+
+    # Stub every CIPP helper the exercised paths call so Pester's Mock has a command to replace.
+    function Get-CIPPTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter, $Property, $First) }
+    function Get-Tenants { param($TenantFilter, [switch]$IncludeErrors) }
+    function Get-CIPPQueueData { param($Reference) }
+    function Get-StringHash { param($String) }
+    function New-CippQueueEntry { param($Name, $Link, $Reference, $TotalTasks) }
+    function Start-CIPPOrchestrator { param($InputObject) }
+    function New-GraphGetRequest { param($uri, $tenantid) }
+
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/ConvertTo-CIPPODataFilterValue.ps1')
+    . (Join-Path $RepoRoot 'Modules/CIPPCore/Public/GraphRequests/Get-GraphRequestList.ps1')
+
+    # Emulates a span fetch: blobs inside the [From, To] RowKey range in ordinal order.
+    function Select-FakeBlobRows {
+        param([string]$Filter)
+        if ($Filter -notmatch "RowKey ge '([^']*)' and RowKey le '([^']*)~'") { return @() }
+        $From = $Matches[1]
+        $To = $Matches[2]
+        $Keys = [string[]]@($script:TenantBlobs.Keys)
+        [System.Array]::Sort($Keys, [System.Collections.IComparer][StringComparer]::Ordinal)
+        @($Keys | Where-Object {
+                [string]::CompareOrdinal($_, $From) -ge 0 -and [string]::CompareOrdinal($_, $To) -le 0
+            } | ForEach-Object {
+                [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = $_; Data = $script:TenantBlobs[$_] }
+            })
+    }
+}
+
+Describe 'Get-GraphRequestList paged AllTenants cache serve' {
+    BeforeEach {
+        Mock -CommandName Get-StringHash -MockWith { 'PKHASH' }
+        Mock -CommandName Get-CIPPTable -MockWith { @{ Context = 'fake' } }
+        Mock -CommandName Get-CIPPQueueData -MockWith { $null }
+        Mock -CommandName Get-Tenants -MockWith {
+            @(
+                [PSCustomObject]@{ defaultDomainName = 'a.com' }
+                [PSCustomObject]@{ defaultDomainName = 'b.com' }
+                [PSCustomObject]@{ defaultDomainName = 'c.com' }
+            )
+        }
+
+        # Key scans (Property set) return raw physical rows incl. '-part<n>' rows and an
+        # unmanaged tenant (b0gus.com) inside the span range; data fetches return blobs.
+        $script:TenantBlobs = @{
+            'a.com'     = '[{"id":"a1"},{"id":"a2"}]'
+            'b.com'     = '[{"id":"b1"}]'
+            'b0gus.com' = '[{"id":"bogus"}]'
+            'c.com'     = '[{"id":"c1"}]'
+        }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            if ($Property) {
+                @(
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'a.com' }
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'b.com' }
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'b.com-part1' }
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'b.com-part2' }
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'b0gus.com' }
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'c.com' }
+                )
+            } else {
+                Select-FakeBlobRows -Filter $Filter
+            }
+        }
+    }
+
+    It 'serves all managed tenants in one span when they fit, with valid JSON and no token' {
+        $Result = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray
+
+        $Result.PSObject.Properties.Name | Should -Contain 'CippPagedJson'
+        $Result.CippNextLink | Should -BeNullOrEmpty
+        $Parsed = $Result.CippPagedJson | ConvertFrom-Json
+        # a.com's two rows plus one each from b.com and c.com. b0gus.com sits inside the
+        # span's RowKey range but is unmanaged, so it must be dropped; the part rows
+        # deduplicate into b.com's count.
+        $Parsed | Should -HaveCount 4
+        $Parsed.id | Should -Be @('a1', 'a2', 'b1', 'c1')
+        # The key scan must project keys only - never Data payloads, and never a subset of
+        # the split-entity markers (a partial marker projection makes the module fail
+        # reassembly and drop split tenants from the plan entirely).
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -ParameterFilter {
+            $null -ne $Property -and $Property -notcontains 'OriginalEntityId' -and $Property -notcontains 'Data'
+        }
+        # One span covers all three tenants: exactly one range fetch.
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 1 -ParameterFilter { $Filter -like "*RowKey ge*" }
+    }
+
+    It 'resumes after the tenant named by the incoming nextLink token' {
+        $Result = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray -nextLink 'a.com'
+
+        $Parsed = $Result.CippPagedJson | ConvertFrom-Json
+        $Parsed.id | Should -Be @('b1', 'c1')
+        $Result.CippNextLink | Should -BeNullOrEmpty
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 0 -ParameterFilter { $Filter -like "*RowKey ge 'a.com'*" }
+    }
+
+    It 'ends the page on the character budget mid-span and resumes from the token' {
+        # b.com's blob alone exceeds the 4M character budget. All three tenants share one
+        # span, so the budget must end the page inside the span: c.com's fetched blob is
+        # discarded and served by the next page.
+        $script:TenantBlobs['b.com'] = '[{"id":"b1","pad":"' + ('x' * 4200000) + '"}]'
+
+        $Result = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray
+
+        $Result.CippNextLink | Should -Be 'b.com'
+        $Ids = ($Result.CippPagedJson | ConvertFrom-Json).id
+        $Ids | Should -Contain 'a1'
+        $Ids | Should -Not -Contain 'c1'
+
+        $Next = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray -nextLink $Result.CippNextLink
+        ($Next.CippPagedJson | ConvertFrom-Json).id | Should -Be @('c1')
+        $Next.CippNextLink | Should -BeNullOrEmpty
+    }
+
+    It 'honours a MaxPageBytes override, clamped to the floor' {
+        # a.com's ~300KB exceeds the 256KB floor that the 1-byte request clamps up to, so
+        # the page ends after the first tenant even though all three share a span.
+        $script:TenantBlobs['a.com'] = '[{"id":"a1","pad":"' + ('x' * 300000) + '"}]'
+
+        $Result = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray -MaxPageBytes 1
+
+        $Result.CippNextLink | Should -Be 'a.com'
+        $Next = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray -MaxPageBytes 1 -nextLink $Result.CippNextLink
+        ($Next.CippPagedJson | ConvertFrom-Json).id | Should -Be @('b1', 'c1')
+        $Next.CippNextLink | Should -BeNullOrEmpty
+    }
+
+    It 'never re-serves earlier tenants on resume when tenant casing is mixed' {
+        # Ordinal order puts 'CyberDrainDev.com' (uppercase C) before 'cipp.com'; a
+        # culture-aware plan sort ordered them the other way round, so resuming after
+        # CyberDrainDev re-served cipp's rows and the chain returned duplicates.
+        Mock -CommandName Get-Tenants -MockWith {
+            @(
+                [PSCustomObject]@{ defaultDomainName = 'CyberDrainDev.com' }
+                [PSCustomObject]@{ defaultDomainName = 'cipp.com' }
+            )
+        }
+        $script:TenantBlobs = @{
+            'CyberDrainDev.com' = '[{"id":"cdd1"}]'
+            'cipp.com'          = '[{"id":"cipp1"}]'
+        }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            if ($Property) {
+                @(
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'cipp.com' }
+                    [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'CyberDrainDev.com' }
+                )
+            } else {
+                Select-FakeBlobRows -Filter $Filter
+            }
+        }
+
+        $Full = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray
+        ($Full.CippPagedJson | ConvertFrom-Json).id | Should -Be @('cdd1', 'cipp1')
+
+        $Resumed = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray -nextLink 'CyberDrainDev.com'
+        ($Resumed.CippPagedJson | ConvertFrom-Json).id | Should -Be @('cipp1')
+    }
+
+    It 'serves many small tenants in one page regardless of tenant count' {
+        # The complaint span fetching answers: 60 tiny tenants must not need 60 requests
+        # or 60 queries - they share spans and land in a single page.
+        $script:ManyTenants = @(1..60 | ForEach-Object { 'tenant{0:D3}.example' -f $_ })
+        Mock -CommandName Get-Tenants -MockWith {
+            @($script:ManyTenants | ForEach-Object { [PSCustomObject]@{ defaultDomainName = $_ } })
+        }
+        $script:TenantBlobs = @{}
+        foreach ($Tenant in $script:ManyTenants) { $script:TenantBlobs[$Tenant] = ('[{{"id":"{0}"}}]' -f $Tenant) }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            if ($Property) {
+                @($script:ManyTenants | ForEach-Object { [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = $_ } })
+            } else {
+                Select-FakeBlobRows -Filter $Filter
+            }
+        }
+
+        $Result = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray
+
+        $Result.CippNextLink | Should -BeNullOrEmpty
+        ($Result.CippPagedJson | ConvertFrom-Json) | Should -HaveCount 60
+        # 60 one-row tenants at 40 rows per span: two range fetches, one page.
+        Should -Invoke Get-CIPPAzDataTableEntity -Times 2 -ParameterFilter { $Filter -like "*RowKey ge*" }
+    }
+
+    It 'falls through to the queue flow when the cache is cold' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { @() }
+        Mock -CommandName New-CippQueueEntry -MockWith { @{ RowKey = 'queue-1' } }
+        Mock -CommandName Start-CIPPOrchestrator -MockWith { 'instance-1' }
+
+        $Result = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -ManualPagination -RawJsonArray
+
+        $Result.Queued | Should -BeTrue
+        $Result.QueueId | Should -Be 'queue-1'
+        Should -Invoke Start-CIPPOrchestrator -Times 1
+    }
+
+    It 'keeps the unpaged raw concat path when ManualPagination is not set' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @(
+                [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'a.com'; OriginalEntityId = $null; Data = '[{"id":"a1"}]' }
+                [PSCustomObject]@{ PartitionKey = 'PKHASH'; RowKey = 'c.com'; OriginalEntityId = $null; Data = '[{"id":"c1"}]' }
+            )
+        }
+
+        $Result = Get-GraphRequestList -TenantFilter 'AllTenants' -Endpoint 'users' -RawJsonArray
+
+        $Result | Should -BeOfType [string]
+        ($Result | ConvertFrom-Json).id | Should -Be @('a1', 'c1')
+    }
+}

--- a/backend/Tests/Reports/Get-CIPPLicenseOverview.Tests.ps1
+++ b/backend/Tests/Reports/Get-CIPPLicenseOverview.Tests.ps1
@@ -1,0 +1,120 @@
+# Pester tests for Get-CIPPLicenseOverview
+# Focus: the exclusion/dropdown gate that decides which SKUs each caller sees.
+#   - Reporting/alert callers (no -IncludeExcluded) drop every excluded SKU.
+#   - Picker callers (-IncludeExcluded) keep excluded SKUs so they stay assignable,
+#     unless the SKU has been explicitly hidden from the dropdown (ShowInLicenseDropdown = $false).
+# Regression guard for free/self-service SKUs (e.g. Power Automate Free) vanishing from the
+# add-license picker because they ship as default reporting exclusions.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/Get-CIPPLicenseOverview.ps1'
+
+    # ConversionTable.csv is read directly off disk (not via a mockable command), so point the
+    # function at the real backend config. Pretty-name resolution falls back to skuPartNumber for
+    # SKUs missing from the CSV, which is all this test relies on.
+    $env:CIPPRootPath = $RepoRoot
+
+    # Minimal stubs so Mock has commands to replace (only Get-CIPPLicenseOverview is dot-sourced,
+    # not the whole module).
+    function New-GraphGetRequest { param($uri, $scope, $TenantID, $AsApp) }
+    function New-GraphBulkRequest { param($Requests, $TenantID, $asapp) }
+    function Get-CIPPTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($Table) }
+    function Initialize-CIPPExcludedLicenses { }
+
+    . $FunctionPath
+
+    $script:FlowFreeGuid = 'f30db892-07e9-47e9-837c-80727f46fd3d'   # Microsoft Power Automate Free (default exclusion)
+    $script:E5Guid = '06ebc4ee-1bb5-47dd-8120-11324bc54e06'         # SPE_E5 (not excluded)
+
+    # Builds the New-GraphBulkRequest response shape from a set of subscribedSkus.
+    function New-BulkResult {
+        param($Skus)
+        @(
+            [pscustomobject]@{ id = 'subscribedSkus'; body = [pscustomobject]@{ value = @($Skus) } }
+            [pscustomobject]@{ id = 'directorySubscriptions'; body = [pscustomobject]@{ value = @() } }
+            [pscustomobject]@{ id = 'licensedUsers'; body = [pscustomobject]@{ value = @() } }
+            [pscustomobject]@{ id = 'licensedGroups'; body = [pscustomobject]@{ value = @() } }
+        )
+    }
+
+    function New-Sku {
+        param($SkuId, $PartNumber)
+        [pscustomobject]@{
+            skuId           = $SkuId
+            skuPartNumber   = $PartNumber
+            consumedUnits   = 1
+            prepaidUnits    = [pscustomobject]@{ enabled = 10000 }
+            subscriptionIds = @()
+            servicePlans    = @()
+        }
+    }
+}
+
+Describe 'Get-CIPPLicenseOverview exclusion/dropdown gate' {
+    BeforeEach {
+        $script:Tenant = 'contoso.onmicrosoft.com'
+        Mock -CommandName New-GraphGetRequest -MockWith { @() }
+        Mock -CommandName Get-CIPPTable -MockWith { @{ TableName = 'ExcludedLicenses' } }
+        Mock -CommandName Initialize-CIPPExcludedLicenses -MockWith { }
+        Mock -CommandName New-GraphBulkRequest -MockWith {
+            New-BulkResult -Skus @(
+                (New-Sku -SkuId $script:FlowFreeGuid -PartNumber 'FLOW_FREE'),
+                (New-Sku -SkuId $script:E5Guid -PartNumber 'SPE_E5')
+            )
+        }
+    }
+
+    It 'keeps a default-excluded free SKU in the picker (IncludeExcluded) so it stays assignable' {
+        # Default-config exclusion: GUID present, no ExcludedEverywhere / ShowInLicenseDropdown set.
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @([pscustomobject]@{ GUID = $script:FlowFreeGuid; Product_Display_Name = 'Microsoft Power Automate Free' })
+        }
+
+        $Result = Get-CIPPLicenseOverview -TenantFilter $script:Tenant -IncludeExcluded
+
+        @($Result).skuId | Should -Contain $script:FlowFreeGuid
+        @($Result).skuId | Should -Contain $script:E5Guid
+    }
+
+    It 'drops the excluded SKU from reporting callers (no IncludeExcluded)' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @([pscustomobject]@{ GUID = $script:FlowFreeGuid; Product_Display_Name = 'Microsoft Power Automate Free' })
+        }
+
+        $Result = Get-CIPPLicenseOverview -TenantFilter $script:Tenant
+
+        @($Result).skuId | Should -Not -Contain $script:FlowFreeGuid
+        @($Result).skuId | Should -Contain $script:E5Guid
+    }
+
+    It 'hides an excluded SKU from the picker only when ShowInLicenseDropdown is explicitly false' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @([pscustomobject]@{
+                    GUID                  = $script:FlowFreeGuid
+                    Product_Display_Name  = 'Microsoft Power Automate Free'
+                    ShowInLicenseDropdown = $false
+                })
+        }
+
+        $Result = Get-CIPPLicenseOverview -TenantFilter $script:Tenant -IncludeExcluded
+
+        @($Result).skuId | Should -Not -Contain $script:FlowFreeGuid
+        @($Result).skuId | Should -Contain $script:E5Guid
+    }
+
+    It 'treats ExcludedEverywhere = false as alert-only, leaving the SKU visible to reporting' {
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith {
+            @([pscustomobject]@{
+                    GUID                 = $script:FlowFreeGuid
+                    Product_Display_Name = 'Microsoft Power Automate Free'
+                    ExcludedEverywhere   = $false
+                })
+        }
+
+        $Result = Get-CIPPLicenseOverview -TenantFilter $script:Tenant
+
+        @($Result).skuId | Should -Contain $script:FlowFreeGuid
+    }
+}

--- a/frontend/src/api/ApiCall.jsx
+++ b/frontend/src/api/ApiCall.jsx
@@ -317,10 +317,11 @@ export function ApiGetCallWithPagination({
       return response.data;
     },
     getNextPageParam: (lastPage) => {
+      // AllTenants pages only when the page opted into manualPagination.
       if (
         data?.noPagination ||
         data?.manualPagination === false ||
-        data?.tenantFilter === "AllTenants"
+        (data?.tenantFilter === "AllTenants" && data?.manualPagination !== true)
       ) {
         return undefined;
       }

--- a/frontend/src/components/CippComponents/CippReportDBControls.jsx
+++ b/frontend/src/components/CippComponents/CippReportDBControls.jsx
@@ -23,6 +23,8 @@ import { CippQueueTracker } from "../CippTable/CippQueueTracker";
  * @param {string[]} [config.cacheColumns=["CacheTimestamp"]] - Extra columns to show when in cached mode.
  * @param {string} [config.tenantColumn="Tenant"] - Column name for tenant (shown in AllTenants mode).
  * @param {Object} [config.apiData]       - Additional static API data to merge (e.g. extra params).
+ * @param {boolean} [config.serverPagination=false] - Server-side paging for cached reads; the
+ *   endpoint must support manualPagination and the page must pass apiDataKey={reportDB.apiDataKey}.
  *
  * @returns {Object}
  *   - useReportDB {boolean}          - Current cache mode
@@ -31,6 +33,7 @@ import { CippQueueTracker } from "../CippTable/CippQueueTracker";
  *   - resolvedApiUrl {string}        - API URL with ?UseReportDB=true appended when needed
  *   - resolvedApiData {Object|undefined} - Merged apiData (for pages that use apiData instead of URL params)
  *   - resolvedQueryKey {string}      - Query key including tenant and cache mode
+ *   - apiDataKey {string|undefined}  - Pass as apiDataKey when serverPagination is set ('Results' in cached mode)
  *   - cacheColumns {string[]}        - Columns to prepend/append when cached (includes Tenant for AllTenants)
  *   - controls {JSX.Element}         - Ready-to-render JSX for the cache toggle, sync button, and queue tracker
  *   - syncDialog {JSX.Element}       - The CippApiDialog element to render alongside CippTablePage
@@ -49,6 +52,7 @@ export function useCippReportDB(config) {
     cacheColumns = ['CacheTimestamp'],
     tenantColumn = 'Tenant',
     apiData: extraApiData,
+    serverPagination = false,
   } = config
 
   const currentTenant = useSettings().currentTenant;
@@ -85,12 +89,18 @@ export function useCippReportDB(config) {
   }, [apiUrl, useReportDB])
 
   // Keep mode flag in the URL only; CippTablePage merges apiData into query params.
+  // serverPagination adds manualPagination on cached reads.
   const resolvedApiData = useMemo(() => {
-    if (!extraApiData) return undefined
+    const paging = serverPagination && useReportDB ? { manualPagination: true } : {}
+    if (!extraApiData && !serverPagination) return undefined
     return {
+      ...paging,
       ...extraApiData,
     }
-  }, [extraApiData])
+  }, [extraApiData, serverPagination, useReportDB])
+
+  // Paged responses nest rows under Results; the legacy bare array needs no dataKey.
+  const apiDataKey = serverPagination && useReportDB ? 'Results' : undefined
 
   // Query key that includes tenant + mode for proper cache separation
   const resolvedQueryKey = useMemo(() => {
@@ -195,6 +205,7 @@ export function useCippReportDB(config) {
     resolvedApiUrl,
     resolvedApiData,
     resolvedQueryKey,
+    apiDataKey,
     cacheColumns: extraColumns,
     controls,
     syncDialog: syncDialogElement,

--- a/frontend/src/components/CippTable/CippDataTable.jsx
+++ b/frontend/src/components/CippTable/CippDataTable.jsx
@@ -847,7 +847,11 @@ export const CippDataTable = (props) => {
 
       const combinedResults = allPages.flatMap((page) => {
         const nestedData = getNestedValue(page, api.dataKey)
-        return nestedData !== undefined ? nestedData : []
+        if (nestedData !== undefined) {
+          return nestedData
+        }
+        // dataKey miss on a bare-array page: the endpoint served the legacy shape.
+        return Array.isArray(page) ? page : []
       })
       const filtered = dataFilter
         ? combinedResults.filter(dataFilter)

--- a/frontend/src/pages/cipp/logs/index.jsx
+++ b/frontend/src/pages/cipp/logs/index.jsx
@@ -341,9 +341,11 @@ const Page = () => {
       }
       title={pageTitle}
       apiUrl={apiUrl}
+      apiDataKey="Results"
       simpleColumns={simpleColumns}
       queryKey={`Listlogs-${startDate}-${endDate}-${username}-${severity}-${filterEnabled}-${currentTenant}`}
       tenantInTitle={false}
+      defaultSorting={[{ id: 'DateTime', desc: true }]}
       apiData={{
         StartDate: startDate, // Pass start date filter from state
         EndDate: endDate, // Pass end date filter from state
@@ -351,6 +353,11 @@ const Page = () => {
         Severity: severity, // Pass severity filter from state
         Filter: filterEnabled, // Pass filter toggle state
         Tenant: currentTenant, // Pass current tenant from settings
+        manualPagination: true, // Page through ListLogs via Metadata.nextLink
+        // CippTablePage injects tenantFilter from the tenant selector, but ListLogs reads
+        // Tenant instead, and a literal 'AllTenants' tenantFilter would stop
+        // ApiGetCallWithPagination from ever fetching page two. Null drops the param.
+        tenantFilter: null,
       }}
       actions={actions}
       offCanvas={offcanvas}

--- a/frontend/src/pages/email/administration/mailboxes/index.jsx
+++ b/frontend/src/pages/email/administration/mailboxes/index.jsx
@@ -19,6 +19,7 @@ const Page = () => {
     syncTitle: 'Sync Mailboxes',
     allowToggle: true,
     defaultCached: true,
+    serverPagination: true,
   })
 
   // Anonymized report names break the usage merge in the Mailboxes cache sync, leaving
@@ -87,11 +88,15 @@ const Page = () => {
       <CippTablePage
         title={pageTitle}
         apiUrl={reportDB.resolvedApiUrl}
+        apiData={reportDB.resolvedApiData}
+        apiDataKey={reportDB.apiDataKey}
         queryKey={reportDB.resolvedQueryKey}
         actions={CippExchangeActions()}
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
         filters={filterList}
+        // Paged cache reads arrive in table walk order, not sorted like the unpaged report.
+        defaultSorting={[{ id: 'displayName', desc: false }]}
         tableFilter={
           <CippAnonymizedReportAlert show={reportDB.useReportDB && allZeroStorage}>
             All mailboxes report 0 storage used, which usually means Microsoft 365 report

--- a/frontend/src/pages/identity/administration/groups/index.jsx
+++ b/frontend/src/pages/identity/administration/groups/index.jsx
@@ -37,6 +37,7 @@ const Page = () => {
     defaultCached: false,
     allowAllTenantSync: true,
     cacheColumns: ['CacheTimestamp'],
+    serverPagination: true,
   })
 
   const actions = [
@@ -444,7 +445,10 @@ const Page = () => {
         }
         dataSourceControls={reportDB.controls}
         apiUrl={reportDB.resolvedApiUrl}
-        apiData={reportDB.useReportDB ? undefined : {}}
+        apiData={reportDB.resolvedApiData}
+        apiDataKey={reportDB.apiDataKey}
+        // Paged cache reads arrive in table walk order, not sorted like the unpaged report.
+        defaultSorting={[{ id: 'displayName', desc: false }]}
         queryKey={
           reportDB.useReportDB ? reportDB.resolvedQueryKey : `groups-${currentTenant}`
         }

--- a/frontend/src/pages/identity/administration/guest-users/index.jsx
+++ b/frontend/src/pages/identity/administration/guest-users/index.jsx
@@ -93,6 +93,7 @@ const Page = () => {
     defaultCached: true,
     allowAllTenantSync: true,
     cacheColumns: ['CacheTimestamp'],
+    serverPagination: true,
   })
 
   const tenantQuery =
@@ -100,10 +101,10 @@ const Page = () => {
   const userHubLink = `/identity/administration/users/user?userId=[id]&tenantFilter=${tenantQuery}`
 
   // Same url/data/queryKey as the table below, so react-query shares one request
-  // between the summary cards and the table.
+  // between the summary cards and the table; data must match what CippTablePage builds.
   const guestData = ApiGetCallWithPagination({
     url: reportDB.resolvedApiUrl,
-    data: { tenantFilter: currentTenant },
+    data: { tenantFilter: currentTenant, ...reportDB.resolvedApiData },
     queryKey: reportDB.resolvedQueryKey,
     waiting: true,
   })
@@ -111,7 +112,8 @@ const Page = () => {
   const guests = useMemo(
     () =>
       guestData.data?.pages?.flatMap((page) =>
-        Array.isArray(page) ? page : []
+        // Cached reads page as { Results, Metadata }; live reads stay a bare array.
+        Array.isArray(page) ? page : Array.isArray(page?.Results) ? page.Results : []
       ) ?? [],
     [guestData.data]
   )
@@ -269,6 +271,8 @@ const Page = () => {
         tableFilter={tableFilter}
         title={pageTitle}
         apiUrl={reportDB.resolvedApiUrl}
+        apiData={reportDB.resolvedApiData}
+        apiDataKey={reportDB.apiDataKey}
         queryKey={reportDB.resolvedQueryKey}
         dataSourceControls={reportDB.controls}
         actions={actions}
@@ -279,6 +283,8 @@ const Page = () => {
         }}
         simpleColumns={simpleColumns}
         filters={filterList}
+        // Paged cache reads arrive in table walk order, not sorted like the unpaged report.
+        defaultSorting={[{ id: 'displayName', desc: false }]}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/identity/reports/mfa-report/index.jsx
+++ b/frontend/src/pages/identity/reports/mfa-report/index.jsx
@@ -16,6 +16,7 @@ const Page = () => {
     syncTitle: 'Sync MFA Report',
     allowToggle: false,
     defaultCached: true,
+    serverPagination: true,
   })
 
   const simpleColumns = [
@@ -113,12 +114,15 @@ const Page = () => {
         title={pageTitle}
         apiUrl={reportDB.resolvedApiUrl}
         apiData={reportDB.resolvedApiData}
+        apiDataKey={reportDB.apiDataKey}
         queryKey={reportDB.resolvedQueryKey}
         simpleColumns={simpleColumns}
         filters={filters}
         actions={actions}
         dataSourceControls={reportDB.controls}
         initialFilters={urlFilters}
+        // Paged cache reads arrive in table walk order, not sorted like the unpaged report.
+        defaultSorting={[{ id: 'UPN', desc: false }]}
       />
       {reportDB.syncDialog}
     </>

--- a/frontend/src/pages/tenant/conditional/list-policies/index.jsx
+++ b/frontend/src/pages/tenant/conditional/list-policies/index.jsx
@@ -184,6 +184,7 @@ const Page = () => {
       }
       title={pageTitle}
       apiUrl={apiUrl}
+      apiData={{ manualPagination: true }}
       apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}

--- a/frontend/tests/components/CippComponents/CippFormatting.stories.jsx
+++ b/frontend/tests/components/CippComponents/CippFormatting.stories.jsx
@@ -153,7 +153,7 @@ export const Booleans = {
       await expect(canvasElement.textContent).toContain('Yes')
       await expect(canvasElement.textContent).toContain('No')
       expect(canvasElement.querySelector('[data-testid="CheckIcon"]')).not.toBeNull()
-      expect(canvasElement.querySelector('[data-testid="CancelIcon"]')).not.toBeNull()
+      expect(canvasElement.querySelector('[data-testid="CloseIcon"]')).not.toBeNull()
     })
 
     await step('enabled+date renders the scheduled variant', async () => {


### PR DESCRIPTION
This pull request introduces significant enhancements to the API's pagination capabilities and improves data handling in several backend PowerShell modules. The main focus is on adding support for manual, token-based pagination across multiple endpoints, updating OpenAPI documentation, and making data storage more robust and deterministic.

**API Pagination Enhancements:**

* Added support for manual, token-based pagination (`manualPagination`, `nextLink`, `PageSize`) to multiple API endpoints, including Conditional Access policies, Entra ID groups, guest accounts, Exchange mailboxes, MFA registration status, and CIPP platform audit logs. Descriptions were updated to clarify pagination behavior and response structure. (`backend/Config/openapi.json`: [[1]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507L41642-R41669) [[2]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507L47404-R47439) [[3]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507R47476-R47484) [[4]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507R47494-R47502) [[5]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507R47512-R47519) [[6]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507L47888-R47976) [[7]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507L49737-R49824) [[8]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507R49878-R49910) [[9]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507L50040-R50183) [[10]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507L51382-R51551)
* Introduced new query parameters such as `maxPageBytes` (for controlling raw JSON page size) and improved descriptions and filtering options for audit log queries. (`backend/Config/openapi.json`: [[1]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507R47240-R47248) [[2]](diffhunk://#diff-6facb14c4d6e8691c23c0c672f4c2e84032cd16bcc3587aafd7ec14ba6611507R49861)

**Backend Data Handling Improvements:**

* Implemented a new function `Get-CIPPDbItemPage` to efficiently fetch one page of items from the reporting database, supporting continuation tokens and multi-tenant scenarios. (`backend/Modules/CIPPCore/Public/Get-CIPPDbItemPage.ps1`: [backend/Modules/CIPPCore/Public/Get-CIPPDbItemPage.ps1R1-R61](diffhunk://#diff-131122f0afeadee7dd6f2c9f83956ceef0394275a227fa492487705eb8431214R1-R61))
* Updated `Add-CIPPDbItem` to ensure all row-level split markers are projected during queries, enabling correct reassembly of split entities and preventing orphaned rows. (`backend/Modules/CIPPCore/Public/Add-CIPPDbItem.ps1`: [backend/Modules/CIPPCore/Public/Add-CIPPDbItem.ps1L133-R137](diffhunk://#diff-adb0a85af84d3225d7b3319bc34ddee86aeac816c235c1998309bb2bb8e42407L133-R137))

**Deterministic and Robust Data Storage:**

* Changed the construction of `RowKey` in `Push-ListConditionalAccessPoliciesAllTenants.ps1` to use a deterministic, tenant-and-policy-based key instead of a GUID, preventing duplicate entries during concurrent runs and ensuring idempotency. Error rows now use a similarly deterministic key. (`backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-ListConditionalAccessPoliciesAllTenants.ps1`: [[1]](diffhunk://#diff-01d88ce400edb46f70e09831a5b59ed70796d59510af797a485a7c5d35aa2cd8L106-R107) [[2]](diffhunk://#diff-01d88ce400edb46f70e09831a5b59ed70796d59510af797a485a7c5d35aa2cd8L139-L147) [[3]](diffhunk://#diff-01d88ce400edb46f70e09831a5b59ed70796d59510af797a485a7c5d35aa2cd8L159-R159)