### PR TITLE
Fix: Fix calendar permission folder selection

### DIFF
--- a/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Mailbox Permissions/Push-GetCalendarPermissionsBatch.ps1
+++ b/backend/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Mailbox Permissions/Push-GetCalendarPermissionsBatch.ps1
@@ -29,6 +29,10 @@ function Push-GetCalendarPermissionsBatch {
         try {
             $CacheEntries = Get-CIPPAzDataTableEntity @FolderCacheTable -Filter "PartitionKey eq '$TenantFilter'"
             foreach ($Entry in $CacheEntries) {
+                # Entries predating the FolderType fix can name a subfolder instead of the root,
+                # and the name alone cannot say which. Anything unstamped is a miss: Phase 1
+                # rediscovers it and overwrites the row, so a poisoned cache self-heals.
+                if ($Entry.FolderType -ne 'Calendar') { continue }
                 $CachedFolders[$Entry.RowKey] = $Entry.FolderName
             }
             Write-Information "CAL Cached Folders count is $($CachedFolders.Count)"
@@ -70,23 +74,37 @@ function Push-GetCalendarPermissionsBatch {
             }
 
             Write-Information "Phase 1: Bulk Get-MailboxFolderStatistics for $($CacheMissMailboxes.Count) mailboxes"
-            $FolderStatsResults = New-ExoBulkRequest -tenantid $TenantFilter -cmdletArray @($FolderStatsRequests)
+            $FolderStatsResults = New-ExoBulkRequest -tenantid $TenantFilter -cmdletArray @($FolderStatsRequests) -Select 'Name,FolderType'
 
+            # One call returns EVERY calendar folder flattened under one OperationGuid, so
+            # last-wins cached whatever the mailbox listed last - 'United States holidays' for
+            # over half a tenant, after which Phase 2 queried that folder and got nothing.
+            # FolderType stays English in any mailbox language, same reason
+            # Invoke-ListCalendarPermissions uses it. No fallback on purpose: a guess here
+            # poisons a cache that never expires.
             foreach ($Result in $FolderStatsResults) {
                 if ($Result.error) {
                     Write-Information "Failed to get folder stats for $($Result.OperationGuid): $($Result.error)"
                     continue
                 }
                 $MailboxUPN = $Result.OperationGuid
-                $FolderName = $Result.name
-                if ($MailboxUPN -and $FolderName) {
-                    $FolderNameMap[$MailboxUPN] = $FolderName
-                    $NewCacheEntries.Add(@{
-                            PartitionKey = $TenantFilter
-                            RowKey       = $MailboxUPN
-                            FolderName   = $FolderName
-                        })
-                }
+                if (-not $MailboxUPN -or -not $Result.Name -or $Result.FolderType -ne 'Calendar') { continue }
+                if ($FolderNameMap.ContainsKey($MailboxUPN)) { continue }
+
+                $FolderNameMap[$MailboxUPN] = $Result.Name
+                $NewCacheEntries.Add(@{
+                        PartitionKey = $TenantFilter
+                        RowKey       = $MailboxUPN
+                        FolderName   = $Result.Name
+                        FolderType   = 'Calendar'
+                    })
+            }
+
+            # Loud on purpose: if the API stops returning FolderType, every mailbox fails the
+            # filter above and the whole type silently collects nothing.
+            $NoRootCalendar = $CacheMissMailboxes.Count - $NewCacheEntries.Count
+            if ($NoRootCalendar -gt 0) {
+                Write-Information "No root calendar folder (FolderType 'Calendar') found for $NoRootCalendar of $($CacheMissMailboxes.Count) cache-miss mailboxes"
             }
 
             # Persist newly discovered folder names to cache

--- a/backend/Modules/CIPPCore/Public/Baselines/Get-CIPPBaselinecalDefaultState.ps1
+++ b/backend/Modules/CIPPCore/Public/Baselines/Get-CIPPBaselinecalDefaultState.ps1
@@ -13,6 +13,11 @@ function Get-CIPPBaselinecalDefaultState {
         Only the 'Default' principal is graded; named delegates are somebody's deliberate
         grant and are none of this standard's business. AccessRights arrives as an array on
         some rows and a string on others, so it is joined before comparing.
+
+        Coverage is deliberately NOT graded here. 'offenders' is the only channel the compare
+        keeps, and an entry there leaves 'targets' empty - ExoBulkSweep then returns at its
+        `if ($Attempted -eq 0)` guard, before refreshCache, while the engine records Remediated.
+        Invoke-CIPPStandardcalDefault carries the coverage check instead.
     .FUNCTIONALITY
         Internal
     #>

--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardcalDefault.ps1
@@ -64,16 +64,42 @@ function Invoke-CIPPStandardcalDefault {
     }
 
     # Filter to only Default user permissions that don't match target level
-    $DefaultPermissions = $CalendarPermissions | Where-Object { $_.User -eq 'Default' }
+    $DefaultPermissions = @($CalendarPermissions | Where-Object { $_.User -eq 'Default' })
     $NeedsUpdate = @($DefaultPermissions | Where-Object {
             $currentRights = if ($_.AccessRights -is [array]) { $_.AccessRights -join ',' } else { $_.AccessRights }
             $currentRights -ne $permissionLevel
         })
 
-    $CurrentValue = if ($NeedsUpdate.Count -eq 0) {
+    # Coverage is graded separately from compliance: a mailbox with no cached Default row can
+    # never enter $NeedsUpdate, so an incomplete collection used to read as a clean sweep.
+    # Matched by identity, not counts - a stale row for a deleted mailbox would offset a newly
+    # uncovered one. Identity is "<mailbox>:\<calendar>", keyed by UPN, alias or Exchange GUID.
+    $Mailboxes = @(New-CIPPDbRequest -TenantFilter $Tenant -Type 'Mailboxes' -Fields 'UPN', 'primarySmtpAddress', 'Id', 'ExternalDirectoryObjectId')
+
+    $GradedIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($Permission in $DefaultPermissions) {
+        $MailboxId = ("$($Permission.Identity)" -split ':\\')[0]
+        # An empty key would match every mailbox missing that field and hide real gaps.
+        if ($MailboxId) { $null = $GradedIds.Add($MailboxId) }
+    }
+
+    $UncheckedMailboxes = @($Mailboxes | Where-Object {
+            $Keys = [string[]]@($_.UPN, $_.primarySmtpAddress, $_.Id, $_.ExternalDirectoryObjectId | Where-Object { $_ })
+            -not $GradedIds.Overlaps($Keys)
+        })
+    $Unchecked = $UncheckedMailboxes.Count
+
+    $UncheckedNames = @($UncheckedMailboxes | ForEach-Object { $_.UPN ? $_.UPN : $_.primarySmtpAddress })
+    $UncheckedSample = ($UncheckedNames | Select-Object -First 10) -join ', '
+    $CoverageWarning = "$Unchecked of $($Mailboxes.Count) mailboxes have no cached Default calendar permission and were NOT evaluated ($UncheckedSample). The calendar permission cache is incomplete."
+
+    $CurrentValue = if ($NeedsUpdate.Count -eq 0 -and $Unchecked -eq 0) {
         [PSCustomObject]@{ state = 'Configured correctly' }
     } else {
-        [PSCustomObject]@{ NonCompliantCalendars = $NeedsUpdate | Select-Object -Property Identity, AccessRights }
+        [PSCustomObject]@{
+            NonCompliantCalendars = @($NeedsUpdate | Select-Object -Property Identity, AccessRights)
+            UncheckedMailboxes    = $Unchecked
+        }
     }
     $ExpectedValue = [PSCustomObject]@{
         state = 'Configured correctly'
@@ -81,7 +107,11 @@ function Invoke-CIPPStandardcalDefault {
 
     if ($Settings.remediate -eq $true) {
         if ($NeedsUpdate.Count -eq 0) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'All calendars already have the correct default permission level.' -sev Info
+            if ($Unchecked -gt 0) {
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "All $($DefaultPermissions.Count) checked calendars already have the correct default permission level, but $CoverageWarning" -sev Warning
+            } else {
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "All $($DefaultPermissions.Count) calendars already have the correct default permission level." -sev Info
+            }
         } else {
             $UpdateDB = $false
             try {
@@ -124,7 +154,11 @@ function Invoke-CIPPStandardcalDefault {
 
     if ($Settings.alert -eq $true) {
         if ($NeedsUpdate.Count -eq 0) {
-            Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Default calendar permissions are correctly configured for all mailboxes' -sev Info
+            if ($Unchecked -gt 0) {
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message "Default calendar permissions are correctly configured for all $($DefaultPermissions.Count) checked mailboxes, but $CoverageWarning" -sev Warning
+            } else {
+                Write-LogMessage -API 'Standards' -tenant $Tenant -message 'Default calendar permissions are correctly configured for all mailboxes' -sev Info
+            }
         } else {
             Write-StandardsAlert -message "Default calendar permission is not set to $permissionLevel for $($NeedsUpdate.Count) calendars" -object ($NeedsUpdate | Select-Object -Property Identity, AccessRights) -tenant $Tenant -standardName 'calDefault' -standardId $Settings.standardId
             Write-LogMessage -API 'Standards' -tenant $Tenant -message "Default calendar permission is not set to $permissionLevel for $($NeedsUpdate.Count) calendars" -sev Info

--- a/backend/Tests/DBCache/Push-GetCalendarPermissionsBatch.Tests.ps1
+++ b/backend/Tests/DBCache/Push-GetCalendarPermissionsBatch.Tests.ps1
@@ -1,0 +1,134 @@
+# Pester tests for Push-GetCalendarPermissionsBatch
+#
+# Phase 1 caches each mailbox's calendar folder name forever; Phase 2 reads permissions from
+# it. Get-MailboxFolderStatistics returns EVERY calendar folder flattened under one
+# OperationGuid, so picking the wrong row is silent and permanent - it cached holiday
+# calendars for over half a tenant, and those mailboxes then cached no permissions at all.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Get-ChildItem -Path (Join-Path $RepoRoot 'Modules') -Recurse -Filter 'Push-GetCalendarPermissionsBatch.ps1' -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+    if (-not $FunctionPath) { throw 'Could not locate Push-GetCalendarPermissionsBatch.ps1 under Modules/' }
+
+    # Minimal stubs so Mock has commands to replace during tests.
+    function Write-LogMessage { param($API, $tenant, $message, $sev, $LogData) }
+    function Get-CippTable { param($tablename) }
+    function Get-CIPPAzDataTableEntity { param($Context, $Filter, $Property) }
+    function Add-CIPPAzDataTableEntity { param($Context, $Entity, [switch]$Force) }
+    function New-ExoBulkRequest { param($tenantid, $cmdletArray, $useSystemMailbox, $Anchor, $NoAuthCheck, $Select, $ReturnWithCommand) }
+
+    . $FunctionPath
+
+    function New-WorkItem {
+        param($Mailboxes = @('user1@contoso.com'))
+        [PSCustomObject]@{
+            TenantFilter = 'contoso.onmicrosoft.com'
+            Mailboxes    = $Mailboxes
+            BatchNumber  = 1
+            TotalBatches = 1
+        }
+    }
+
+    function New-FolderStat {
+        param($UPN, $Name, $FolderType)
+        [PSCustomObject]@{ Name = $Name; FolderType = $FolderType; OperationGuid = $UPN }
+    }
+}
+
+Describe 'Push-GetCalendarPermissionsBatch' {
+    BeforeEach {
+        $script:CacheEntries = @()
+        $script:FolderStats = @()
+        $script:PermResults = @()
+        $script:Written = [System.Collections.Generic.List[object]]::new()
+        $script:ExoCalls = [System.Collections.Generic.List[object]]::new()
+
+        Mock -CommandName Write-LogMessage -MockWith { }
+        Mock -CommandName Get-CippTable -MockWith { @{ Context = 'CalendarFolderCache' } }
+        Mock -CommandName Get-CIPPAzDataTableEntity -MockWith { $script:CacheEntries }
+        Mock -CommandName Add-CIPPAzDataTableEntity -MockWith { foreach ($e in @($Entity)) { $script:Written.Add($e) } }
+        Mock -CommandName New-ExoBulkRequest -MockWith {
+            $Name = @($cmdletArray)[0].CmdletInput.CmdletName
+            $script:ExoCalls.Add([PSCustomObject]@{ Cmdlet = $Name; Select = $Select; Array = @($cmdletArray) })
+            if ($Name -eq 'Get-MailboxFolderStatistics') { $script:FolderStats } else { $script:PermResults }
+        }
+    }
+
+    It 'caches the root calendar even when a subfolder is the last folder returned' {
+        # The exact ordering that produced the bug: the root arrives first and a localised
+        # holiday calendar arrives last, so last-wins cached the holiday calendar.
+        $script:FolderStats = @(
+            New-FolderStat -UPN 'user1@contoso.com' -Name 'Calendar' -FolderType 'Calendar'
+            New-FolderStat -UPN 'user1@contoso.com' -Name 'Helligdage i Danmark' -FolderType 'User Created'
+            New-FolderStat -UPN 'user1@contoso.com' -Name 'Birthdays' -FolderType 'Birthday'
+        )
+
+        Push-GetCalendarPermissionsBatch -Item (New-WorkItem)
+
+        $script:Written.Count | Should -Be 1
+        $script:Written[0].FolderName | Should -Be 'Calendar'
+        $script:Written[0].FolderType | Should -Be 'Calendar'
+        $script:Written[0].RowKey | Should -Be 'user1@contoso.com'
+
+        # ...and Phase 2 must then ask for that folder, not the holiday calendar.
+        $Phase2 = @($script:ExoCalls | Where-Object { $_.Cmdlet -eq 'Get-MailboxFolderPermission' })
+        $Phase2.Count | Should -Be 1
+        $Phase2[0].Array[0].CmdletInput.Parameters.Identity | Should -Be 'user1@contoso.com:\Calendar'
+    }
+
+    It 'skips a mailbox with no root calendar rather than caching a guess' {
+        $script:FolderStats = @(
+            New-FolderStat -UPN 'user1@contoso.com' -Name 'United States holidays' -FolderType 'User Created'
+        )
+
+        Push-GetCalendarPermissionsBatch -Item (New-WorkItem)
+
+        # Nothing cached, and no permission request built - a wrong name here would stick forever.
+        $script:Written.Count | Should -Be 0
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 0 -Exactly
+        @($script:ExoCalls | Where-Object { $_.Cmdlet -eq 'Get-MailboxFolderPermission' }).Count | Should -Be 0
+    }
+
+    It 'treats a cache entry with no FolderType as a miss so a poisoned cache self-heals' {
+        # Rows written before the fix carry a folder name but no FolderType, and the name alone
+        # cannot say whether it is the root or a subfolder.
+        $script:CacheEntries = @(
+            [PSCustomObject]@{ PartitionKey = 'contoso.onmicrosoft.com'; RowKey = 'user1@contoso.com'; FolderName = 'Helligdage i Danmark' }
+        )
+        $script:FolderStats = @(
+            New-FolderStat -UPN 'user1@contoso.com' -Name 'Calendar' -FolderType 'Calendar'
+        )
+
+        Push-GetCalendarPermissionsBatch -Item (New-WorkItem)
+
+        @($script:ExoCalls | Where-Object { $_.Cmdlet -eq 'Get-MailboxFolderStatistics' }).Count | Should -Be 1
+        $script:Written[0].FolderName | Should -Be 'Calendar'
+    }
+
+    It 'trusts a cache entry stamped as a root calendar and skips discovery' {
+        $script:CacheEntries = @(
+            [PSCustomObject]@{ PartitionKey = 'contoso.onmicrosoft.com'; RowKey = 'user1@contoso.com'; FolderName = 'Kalender'; FolderType = 'Calendar' }
+        )
+
+        Push-GetCalendarPermissionsBatch -Item (New-WorkItem)
+
+        @($script:ExoCalls | Where-Object { $_.Cmdlet -eq 'Get-MailboxFolderStatistics' }).Count | Should -Be 0
+        $Phase2 = @($script:ExoCalls | Where-Object { $_.Cmdlet -eq 'Get-MailboxFolderPermission' })
+        $Phase2[0].Array[0].CmdletInput.Parameters.Identity | Should -Be 'user1@contoso.com:\Kalender'
+    }
+
+    It 'returns the permissions it read under the Get-MailboxFolderPermission key' {
+        $script:CacheEntries = @(
+            [PSCustomObject]@{ PartitionKey = 'contoso.onmicrosoft.com'; RowKey = 'user1@contoso.com'; FolderName = 'Calendar'; FolderType = 'Calendar' }
+        )
+        $script:PermResults = @(
+            [PSCustomObject]@{ Identity = 'user1@contoso.com:\Calendar'; User = 'Default'; AccessRights = @('Reviewer'); FolderName = 'Calendar'; OperationGuid = 'user1@contoso.com' }
+        )
+
+        $Result = Push-GetCalendarPermissionsBatch -Item (New-WorkItem)
+
+        @($Result['Get-MailboxFolderPermission']).Count | Should -Be 1
+        @($Result['Get-MailboxFolderPermission'])[0].User | Should -Be 'Default'
+    }
+}

--- a/backend/Tests/Standards/Invoke-CIPPStandardcalDefault.Coverage.Tests.ps1
+++ b/backend/Tests/Standards/Invoke-CIPPStandardcalDefault.Coverage.Tests.ps1
@@ -1,0 +1,125 @@
+# Pester tests for the coverage guard in Invoke-CIPPStandardcalDefault.
+#
+# Regression under test: only mailboxes with a cached 'Default' row are graded, so a missing
+# mailbox could never enter $NeedsUpdate and an incomplete collection read as a clean sweep.
+# On a real tenant 44 of 79 went uncollected; the standard saw 35 rows, all correct, and
+# logged the all-clear while 8 of the unseen mailboxes were misconfigured.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $FunctionPath = Join-Path $RepoRoot 'Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardcalDefault.ps1'
+    if (-not (Test-Path $FunctionPath)) { throw "Could not locate $FunctionPath" }
+
+    # Minimal stubs so Mock has commands to replace during tests.
+    function Write-LogMessage { param($API, $tenant, $message, $sev, $LogData) }
+    function Test-CIPPStandardLicense { param($StandardName, $TenantFilter, $Preset) }
+    function New-CIPPDbRequest { param($TenantFilter, $Type, [string[]]$Fields) }
+    function Set-CIPPStandardsCompareField { param($FieldName, $CurrentValue, $ExpectedValue, $TenantFilter) }
+    function Add-CIPPBPAField { param($FieldName, $FieldValue, $StoreAs, $Tenant) }
+    function Write-StandardsAlert { param($message, $object, $tenant, $standardName, $standardId) }
+    function New-ExoRequest { param($tenantid, $cmdlet, $cmdParams) }
+    function Set-CIPPDBCacheMailboxes { param($TenantFilter) }
+    function Get-CippException { param($Exception) }
+
+    . $FunctionPath
+
+    function New-CalRow {
+        param($Upn, $Rights)
+        [PSCustomObject]@{ Identity = "$Upn`:\Calendar"; User = 'Default'; AccessRights = @($Rights) }
+    }
+}
+
+Describe 'Invoke-CIPPStandardcalDefault coverage guard' {
+    BeforeEach {
+        $script:Messages = [System.Collections.Generic.List[object]]::new()
+        $script:Compared = $null
+
+        Mock -CommandName Test-CIPPStandardLicense -MockWith { $true }
+        Mock -CommandName Write-LogMessage -MockWith { $script:Messages.Add([PSCustomObject]@{ Message = $message; Sev = $sev }) }
+        Mock -CommandName Set-CIPPStandardsCompareField -MockWith { $script:Compared = $CurrentValue }
+        Mock -CommandName Add-CIPPBPAField -MockWith { }
+        Mock -CommandName Write-StandardsAlert -MockWith { }
+        # Nothing here may reach Exchange: every case below is a no-drift case.
+        Mock -CommandName New-ExoRequest -MockWith { throw 'New-ExoRequest must not be called' }
+
+        # Pester 5 runs a Describe body at discovery, so shared fixtures have to be built here
+        # to exist when an It actually runs.
+        $script:Settings = @{ permissionLevel = 'Reviewer'; remediate = $true; alert = $true; report = $true }
+    }
+
+    It 'reports a clean sweep only when every cached mailbox was graded' {
+        Mock -CommandName New-CIPPDbRequest -MockWith {
+            if ($Type -eq 'Mailboxes') { @(1..3 | ForEach-Object { [PSCustomObject]@{ UPN = "u$_@x.com" } }) }
+            else { @(1..3 | ForEach-Object { New-CalRow -Upn "u$_@x.com" -Rights 'Reviewer' }) }
+        }
+
+        Invoke-CIPPStandardcalDefault -Tenant 'contoso.onmicrosoft.com' -Settings $script:Settings
+
+        $script:Compared.state | Should -Be 'Configured correctly'
+        @($script:Messages | Where-Object { $_.Sev -eq 'Warning' }).Count | Should -Be 0
+        @($script:Messages | Where-Object { $_.Message -like 'All 3 calendars already*' }).Count | Should -Be 1
+    }
+
+    It 'does not claim alignment when mailboxes were never evaluated' {
+        # 3 mailboxes cached, but only 1 has a Default calendar row - the shape the collector bug
+        # produced. Every graded row is already correct, so the old code logged the all-clear.
+        Mock -CommandName New-CIPPDbRequest -MockWith {
+            if ($Type -eq 'Mailboxes') { @(1..3 | ForEach-Object { [PSCustomObject]@{ UPN = "u$_@x.com" } }) }
+            else { @(New-CalRow -Upn 'u1@x.com' -Rights 'Reviewer') }
+        }
+
+        Invoke-CIPPStandardcalDefault -Tenant 'contoso.onmicrosoft.com' -Settings $script:Settings
+
+        $script:Compared.state | Should -BeNullOrEmpty
+        $script:Compared.UncheckedMailboxes | Should -Be 2
+        @($script:Compared.NonCompliantCalendars).Count | Should -Be 0
+
+        $Warnings = @($script:Messages | Where-Object { $_.Sev -eq 'Warning' })
+        $Warnings.Count | Should -Be 2   # one from the remediate branch, one from the alert branch
+        $Warnings[0].Message | Should -BeLike '*2 of 3 mailboxes have no cached Default calendar permission and were NOT evaluated*'
+        $Warnings[0].Message | Should -BeLike '*u2@x.com*'   # names them, not just a count
+    }
+
+    It 'does not let a stale row for a deleted mailbox mask an uncovered one' {
+        # ghost@x.com was deleted but still has a Default row; u2@x.com is genuinely uncovered.
+        # Counts net to 2 - 2 = 0 and read as full coverage; identities see the gap.
+        Mock -CommandName New-CIPPDbRequest -MockWith {
+            if ($Type -eq 'Mailboxes') { @(1..2 | ForEach-Object { [PSCustomObject]@{ UPN = "u$_@x.com" } }) }
+            else { @(New-CalRow -Upn 'u1@x.com' -Rights 'Reviewer'; New-CalRow -Upn 'ghost@x.com' -Rights 'Reviewer') }
+        }
+
+        Invoke-CIPPStandardcalDefault -Tenant 'contoso.onmicrosoft.com' -Settings $script:Settings
+
+        $script:Compared.UncheckedMailboxes | Should -Be 1
+        @($script:Messages | Where-Object { $_.Sev -eq 'Warning' -and $_.Message -like '*u2@x.com*' }).Count | Should -Be 2
+    }
+
+    It 'matches a mailbox whose calendar Identity is an Exchange GUID, not a UPN' {
+        # Get-MailboxFolderPermission echoes its own canonical identity, which on the real tenant
+        # was the ExternalDirectoryObjectId - without the key fan-out this reads as uncovered.
+        Mock -CommandName New-CIPPDbRequest -MockWith {
+            if ($Type -eq 'Mailboxes') {
+                @([PSCustomObject]@{ UPN = 'u1@x.com'; ExternalDirectoryObjectId = '25a48edf-ef11-423e-aa2d-ce4831b94b51' })
+            } else {
+                @([PSCustomObject]@{ Identity = '25a48edf-ef11-423e-aa2d-ce4831b94b51:\Calendar'; User = 'Default'; AccessRights = @('Reviewer') })
+            }
+        }
+
+        Invoke-CIPPStandardcalDefault -Tenant 'contoso.onmicrosoft.com' -Settings $script:Settings
+
+        $script:Compared.state | Should -Be 'Configured correctly'
+    }
+
+    It 'still flags real drift, and counts coverage alongside it' {
+        Mock -CommandName New-CIPPDbRequest -MockWith {
+            if ($Type -eq 'Mailboxes') { @(1..4 | ForEach-Object { [PSCustomObject]@{ UPN = "u$_@x.com" } }) }
+            else { @(New-CalRow -Upn 'u1@x.com' -Rights 'Reviewer'; New-CalRow -Upn 'u2@x.com' -Rights 'AvailabilityOnly') }
+        }
+        Mock -CommandName New-ExoRequest -MockWith { }
+
+        Invoke-CIPPStandardcalDefault -Tenant 'contoso.onmicrosoft.com' -Settings $script:Settings
+
+        @($script:Compared.NonCompliantCalendars).Count | Should -Be 1
+        $script:Compared.UncheckedMailboxes | Should -Be 2
+    }
+}


### PR DESCRIPTION
Cache the root calendar folder instead of the last one returned to ensure accurate folder statistics. Update the handling of default calendar permissions to warn about incomplete coverage when no cached default row exists. This improves the reliability of calendar permission evaluations.