### PR TITLE
docs: add missing Filters sections to user documentation

### DIFF
--- a/docs/user-documentation/cipp/settings/tenants.md
+++ b/docs/user-documentation/cipp/settings/tenants.md
@@ -6,6 +6,15 @@ description: Centralised Tenant Management and Oversight
 
 The Tenants page lists every tenant CIPP knows about and controls how CIPP connects to each one. From here you can exclude tenants from processing, refresh or reset the permissions CIPP holds in a tenant, re-authenticate a direct tenant whose credentials have lapsed, refresh cached data, and remove a tenant altogether. Tenants are reached either through a Partner Center GDAP relationship or added directly with their own service account, and the actions available on a row depend on which of the two applies.
 
+## Filters
+
+| Filter           | Shows                                                                          |
+| ---------------- | ------------------------------------------------------------------------------ |
+| Included tenants | Tenants that are not excluded from CIPP processing.                            |
+| Excluded tenants | Tenants that are excluded from CIPP processing.                                |
+| Direct tenants   | Tenants that connect to CIPP directly rather than through a GDAP relationship. |
+| GDAP tenants     | Tenants that connect to CIPP through a GDAP relationship.                      |
+
 ## Table Details
 
 | Column                     | Description                                                                    |

--- a/docs/user-documentation/copilot/shadow-ai.md
+++ b/docs/user-documentation/copilot/shadow-ai.md
@@ -83,6 +83,14 @@ Lists the AI software found on the tenant's Intune-managed devices, which is the
 
 Preset filters are available from the **Filters** button for **Sanctioned**, **Unsanctioned**, and **High Risk** rows. Clicking a row (or using the More Info action) opens a detail panel for the matched tool, showing its description, an explanation of why it carries its catalogue risk rating, its sanction status, its key properties, and the list of devices it is installed on.
 
+### Filters
+
+| Filter       | Shows                                                                      |
+| ------------ | -------------------------------------------------------------------------- |
+| Sanctioned   | Shows only tools marked as company sanctioned for the tenant.              |
+| Unsanctioned | Shows only tools that are not marked as company sanctioned for the tenant. |
+| High Risk    | Shows only tools rated High risk.                                          |
+
 ### Table Details
 
 | Column      | Description                                                                                                                                                                                      |
@@ -110,6 +118,14 @@ The sign-in columns need Entra ID P1 and read `0` without it.
 {% endhint %}
 
 Preset filters are available from the **Filters** button for **Sanctioned**, **Unsanctioned**, and **High Risk** rows. Clicking a row (or using the More Info action) opens a detail panel for the matched tool, showing its description, an explanation of why it carries its catalogue risk rating, its sanction status, its key properties, the OAuth permissions granted, and the per-user sign-in activity from the last 7 days.
+
+### Filters
+
+| Filter       | Shows                                                                      |
+| ------------ | -------------------------------------------------------------------------- |
+| Sanctioned   | Shows only tools marked as company sanctioned for the tenant.              |
+| Unsanctioned | Shows only tools that are not marked as company sanctioned for the tenant. |
+| High Risk    | Shows only tools rated High risk.                                          |
 
 ### Table Details
 

--- a/docs/user-documentation/endpoint/mem/list-templates/README.md
+++ b/docs/user-documentation/endpoint/mem/list-templates/README.md
@@ -18,6 +18,13 @@ Opens a drawer for adding templates to CIPP, with two sources to choose between.
 
 {% @storylane/embed subdomain="app" url="https://app.storylane.io/share/939rpjvy23oy" linkValue="939rpjvy23oy" %}
 
+## Filters
+
+| Filter           | Shows                                                      |
+| ---------------- | ---------------------------------------------------------- |
+| Synced Templates | Templates that are still linked to a community repository. |
+| Custom Templates | Templates that are not linked to a community repository.   |
+
 ## Table Details
 
 | Column       | Description                                                                                                                                                                     |

--- a/docs/user-documentation/endpoint/reports/autopilot-deployment.md
+++ b/docs/user-documentation/endpoint/reports/autopilot-deployment.md
@@ -2,6 +2,13 @@
 
 Reports each Autopilot deployment event recorded in the selected tenant, newest first, with how long each stage took and why a deployment failed. The **Failed Deployments** and **Successful Deployments** filters narrow the table to those outcomes.
 
+## Filters
+
+| Filter                 | Shows                                              |
+| ---------------------- | -------------------------------------------------- |
+| Failed Deployments     | Autopilot deployments that failed.                 |
+| Successful Deployments | Autopilot deployments that completed successfully. |
+
 ## Table Details
 
 The properties returned are for the Graph resource type `deviceManagementAutopilotEvent`. For more information on the properties please see the [Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/intune-troubleshooting-devicemanagementautopilotevent?view=graph-rest-beta#properties).

--- a/docs/user-documentation/endpoint/reports/detected-apps.md
+++ b/docs/user-documentation/endpoint/reports/detected-apps.md
@@ -2,6 +2,15 @@
 
 Lists the applications Intune has detected across the enrolled devices in the selected tenant, with how many devices each one is installed on. This is a software inventory rather than a list of what CIPP or Intune has deployed, so applications installed outside Intune appear here too. Filter buttons narrow the list to Windows, macOS, iOS or Android applications.
 
+## Filters
+
+| Filter       | Shows                                     |
+| ------------ | ----------------------------------------- |
+| Windows Apps | Applications detected on Windows devices. |
+| macOS Apps   | Applications detected on macOS devices.   |
+| iOS Apps     | Applications detected on iOS devices.     |
+| Android Apps | Applications detected on Android devices. |
+
 ## Table Details
 
 The properties returned are for the Graph resource type `detectedApp`. For more information on the properties please see the [Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/intune-devices-detectedapp?view=graph-rest-beta#properties).

--- a/docs/user-documentation/identity/reports/group-usage.md
+++ b/docs/user-documentation/identity/reports/group-usage.md
@@ -2,6 +2,15 @@
 
 This report lists every group in the selected tenant together with where it is actually used — Conditional Access policies, Intune assignments, role assignments, application assignments, group-based licensing and transport rules. Groups nothing references are marked as unused, which makes this the quickest way to find groups that can be cleaned up, and to check what would break before removing one.
 
+## Filters
+
+| Filter                     | Shows                                                                    |
+| -------------------------- | ------------------------------------------------------------------------ |
+| Unused groups              | Groups that nothing currently references, so are candidates for cleanup. |
+| Used in Conditional Access | Groups referenced by at least one Conditional Access policy.             |
+| Used in Intune             | Groups referenced by at least one Intune assignment.                     |
+| Used for licensing         | Groups used to assign licences through group-based licensing.            |
+
 ## Table Details
 
 The table is served from the CIPP reporting database cache rather than live Graph calls, so it loads instantly. **Used Locations** names the systems that reference the group, **Used In** lists the specific policies or assignments, and **Usage Count** totals them; **Is Used** rolls that up to a simple Yes/No.

--- a/docs/user-documentation/tenant/administration/app-consent-requests.md
+++ b/docs/user-documentation/tenant/administration/app-consent-requests.md
@@ -20,6 +20,14 @@ The page opens with the filter already set to Pending, on the basis that outstan
 
 The table's own filter menu additionally offers Pending requests, Expired requests and Completed requests, which filter the rows already retrieved rather than fetching afresh.
 
+## Filters
+
+| Filter             | Shows                                                                        |
+| ------------------ | ---------------------------------------------------------------------------- |
+| Pending requests   | Shows only requests that are still awaiting a decision.                      |
+| Expired requests   | Shows only requests that expired before being approved or denied.            |
+| Completed requests | Shows only requests that an administrator has already reviewed and resolved. |
+
 ## Table Details
 
 | Column                 | Description                                                                                                                                             |

--- a/docs/user-documentation/tenant/gdap-management/relationships/README.md
+++ b/docs/user-documentation/tenant/gdap-management/relationships/README.md
@@ -2,6 +2,15 @@
 
 This page lists every delegated admin relationship attached to your Microsoft partner tenant. It shows the status of each relationship, the customer it belongs to, when it was created and activated, when it expires, and the roles it grants. Preset filters are available for the **Active**, **Approval Pending**, **Terminating**, and **Terminated** statuses.
 
+## Filters
+
+| Filter           | Shows                                                                     |
+| ---------------- | ------------------------------------------------------------------------- |
+| Active           | Relationships that are currently active.                                  |
+| Approval Pending | Relationships awaiting the customer's approval before they become active. |
+| Terminating      | Relationships that are in the process of being terminated.                |
+| Terminated       | Relationships that have already been terminated.                          |
+
 ## Table Details
 
 The properties returned are for the Graph resource type `delegatedAdminRelationship`. For more information on the properties please see the [Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/delegatedadminrelationship?view=graph-rest-beta).

--- a/docs/user-documentation/tenant/standards/alignment/README.md
+++ b/docs/user-documentation/tenant/standards/alignment/README.md
@@ -18,6 +18,13 @@ This page gives you a snapshot of how your tenants measure up against your Stand
 
 One row per tenant and template pairing, showing how closely that tenant matches that template overall.
 
+### Filters
+
+| Filter            | Shows                                                     |
+| ----------------- | --------------------------------------------------------- |
+| Drift Templates   | Shows only rows for templates that are Drift Standards.   |
+| Classic Templates | Shows only rows for templates that are Classic Standards. |
+
 ### Table Details
 
 | Column                     | Description                                                                                                                                                    |
@@ -40,6 +47,16 @@ Filters are available for **Drift Templates** and **Classic Templates**.
 ## Per Standard View
 
 One row per tenant per standard, so you can filter down to a single standard and see exactly which tenants are failing it.
+
+### Filters
+
+| Filter             | Shows                                                                                                              |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Non-Compliant      | Shows only rows where the tenant does not match the standard.                                                     |
+| Compliant          | Shows only rows where the tenant matches the standard.                                                            |
+| Accepted Deviation | Shows only rows where the tenant differs from the standard but the difference has been reviewed and accepted.     |
+| Customer Specific  | Shows only rows where the tenant has a deliberate customer-specific value in place of the template's.             |
+| License Missing    | Shows only rows where the tenant is not licensed for the setting, so the standard was skipped rather than failed. |
 
 ### Table Details
 
@@ -72,6 +89,15 @@ Filters are available for **Non-Compliant**, **Compliant**, **Accepted Deviation
 ## By Standard View
 
 One row per standard, aggregated across every tenant it applies to. Use this to find the standards that are failing widely rather than the tenants that are failing.
+
+### Filters
+
+| Filter             | Shows                                                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Fully Compliant    | Shows only standards where every applicable tenant is aligned, whether compliant, on an accepted deviation, or set to a customer-specific value. |
+| Has Non-Compliant  | Shows only standards where at least one tenant is non-compliant.                                                                                 |
+| License Missing    | Shows only standards where at least one tenant is missing the licence needed for it.                                                             |
+| Accepted Deviation | Shows only standards where at least one tenant has an accepted deviation from it.                                                                |
 
 ### Table Details
 

--- a/docs/user-documentation/tenant/standards/domains-analyser/README.md
+++ b/docs/user-documentation/tenant/standards/domains-analyser/README.md
@@ -35,6 +35,14 @@ Opens the Run Domain Analysis dialog. Pick a single tenant or all tenants and qu
 
 </details>
 
+## Filters
+
+| Filter                             | Shows                                                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------- |
+| Mail Provider is not Microsoft 365 | Domains whose detected mail provider is not Microsoft 365.                       |
+| onmicrosoft.com Domains            | Domains whose domain name includes onmicrosoft.com, the tenant's default domain. |
+| All Except onmicrosoft.com Domains | Domains other than the tenant's default onmicrosoft.com domains.                 |
+
 ## Table Details
 
 The table shows results for all domains in the tenant or tenants selected in the tenant-select.md dropdown.

--- a/docs/user-documentation/tools/scheduler/README.md
+++ b/docs/user-documentation/tools/scheduler/README.md
@@ -80,6 +80,15 @@ Each section shows a one-line summary of its current settings in its header, so 
 
 </details>
 
+## Filters
+
+| Filter    | Shows                                                |
+| --------- | ---------------------------------------------------- |
+| Running   | Tasks that are currently running.                    |
+| Planned   | Tasks that are waiting for their next scheduled run. |
+| Failed    | Tasks whose most recent run failed.                  |
+| Completed | Tasks whose most recent run completed successfully.  |
+
 ## Table Details
 
 Preset filters above the table narrow the list to tasks that are **Running**, **Planned**, **Failed**, or **Completed**.


### PR DESCRIPTION
## Summary

The house style guide for `docs/user-documentation/` added a rule for a `## Filters` section: any list/table page whose frontend defines named `filterName` presets needs a table documenting them (`| Filter | Shows |`).

I audited every page with code-defined filter presets against this rule. Of 38 pages that define `filterName` presets, **11 were missing the section**:

- `tenant/standards/alignment`
- `tenant/administration/app-consent-requests`
- `copilot/shadow-ai`
- `tenant/standards/domains-analyser`
- `tenant/gdap-management/relationships`
- `identity/reports/group-usage`
- `endpoint/reports/autopilot-deployment`
- `endpoint/reports/detected-apps`
- `endpoint/mem/list-templates`
- `cipp/settings/tenants`
- `tools/scheduler` (routed from `cipp/scheduler`)

Each `## Filters` table is grounded in that page's actual `filterList`/`filters` array in the frontend code (column matched, operator, values), positioned per the style rule (after Action Buttons/Page Actions, before Table Details), and reproduces each `filterName` verbatim as the Filter cell.

## Out of scope, found during the audit

- 5 pages define filter presets but have **no doc page at all yet**: `tenant/baselines/alignment`, `endpoint/reports/workfromanywhere`, and the three `dashboardv2/*` reports (`identity`, `custom`, `devices`). That's a missing-page gap, not a missing-section one — happy to write those up separately if wanted.
- A handful of **pre-existing** lint findings turned up on pages this PR touches, left untouched since they're unrelated to the Filters rule: an em dash and a "licenses" American-spelling hit on `identity/reports/group-usage.md`, "Catalog" American-spelling hits on `endpoint/mem/list-templates/README.md`, and a dead `#add-task` anchor link on `tools/scheduler/README.md`.

## Test plan

- [x] Every inserted table checked against the source `filterList` for accuracy
- [x] `lint_docs.py` run against all 11 changed files — no errors introduced by these changes (pre-existing findings noted above, left as-is)
- [ ] Spot-check a couple of pages in the rendered GitBook/docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)