### PR TITLE
Fix: Normalize MFAMethods handling in auth method charts

### DIFF
--- a/frontend/src/components/CippComponents/AuthMethodCard.jsx
+++ b/frontend/src/components/CippComponents/AuthMethodCard.jsx
@@ -44,7 +44,7 @@ export const AuthMethodCard = ({ data, isLoading }) => {
     let whfbCount = 0;
 
     enabledUsers.forEach((user) => {
-      const methods = Array.isArray(user.MFAMethods) ? user.MFAMethods : [];
+      const methods = Array.isArray(user.MFAMethods) ? user.MFAMethods : user.MFAMethods ? [user.MFAMethods] : [];
       const perUser = user.PerUser === "enforced" || user.PerUser === "enabled";
       const hasRegistered = user.MFARegistration === true;
 

--- a/frontend/src/components/CippComponents/AuthMethodSankey.jsx
+++ b/frontend/src/components/CippComponents/AuthMethodSankey.jsx
@@ -45,7 +45,7 @@ export const AuthMethodSankey = ({ data }) => {
   let whfbCount = 0;
 
   enabledUsers.forEach((user) => {
-    const methods = user.MFAMethods || [];
+    const methods = Array.isArray(user.MFAMethods) ? user.MFAMethods : user.MFAMethods ? [user.MFAMethods] : [];
     const perUser = user.PerUser === "enforced" || user.PerUser === "enabled";
     const hasRegistered = user.MFARegistration === true;
 


### PR DESCRIPTION
Normalize the handling of MFAMethods to ensure consistent processing as an array, even when a single method is provided as a string. This change addresses miscounting of users in the Sankey components.