### PR TITLE
fix(dbcache): guard mailbox lookup against null ExternalDirectoryObjectId

### DIFF
--- a/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheHVEAccounts.ps1
+++ b/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheHVEAccounts.ps1
@@ -41,7 +41,7 @@ function Set-CIPPDBCacheHVEAccounts {
                 $BulkResults = New-ExoBulkRequest -tenantid $TenantFilter -cmdletArray @($BulkCmdlets)
                 for ($i = 0; $i -lt $HVEAccounts.Count; $i++) {
                     $Result = $BulkResults[$i]
-                    if ($Result.body -and -not $Result.body.error -and $Result.body.value) {
+                    if ($Result.body -and -not $Result.body.error -and $Result.body.value -and $HVEAccounts[$i].PrimarySmtpAddress) {
                         $PolicyData = $Result.body.value
                         $BillingPolicyMap[$HVEAccounts[$i].PrimarySmtpAddress] = @{
                             BillingPolicyId   = $PolicyData.BillingPolicyId
@@ -55,7 +55,9 @@ function Set-CIPPDBCacheHVEAccounts {
         }
 
         foreach ($HVE in $HVEAccounts) {
-            $Policy = $BillingPolicyMap[$HVE.PrimarySmtpAddress]
+            # PrimarySmtpAddress can be null for a partially-provisioned HVE account - same
+            # null-key-indexing hazard as the Mailboxes cache (see Set-CIPPDBCacheMailboxes.ps1).
+            $Policy = if ($HVE.PrimarySmtpAddress) { $BillingPolicyMap[$HVE.PrimarySmtpAddress] } else { $null }
 
             $Transformed.Add(($HVE | Select-Object `
                     @{ Name = 'displayName'; Expression = { $_.DisplayName } },

--- a/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheMailboxes.ps1
+++ b/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheMailboxes.ps1
@@ -54,7 +54,12 @@ function Set-CIPPDBCacheMailboxes {
         # Transform Get-Mailbox results and merge Get-User properties
         $Mailboxes = [System.Collections.Generic.List[PSObject]]::new()
         foreach ($Mailbox in @($BulkResults.'Get-Mailbox')) {
-            $MatchedUser = $UserLookup[$Mailbox.ExternalDirectoryObjectId]
+            # ExternalDirectoryObjectId can be null for a mailbox that has no linked Entra ID
+            # directory object (the $UserLookup population above already guards against this on
+            # the write side - see the -and check a few lines up). Indexing a hashtable with a
+            # null key throws "Index operation failed; the array index evaluated to null." and
+            # aborts the whole cache run for the tenant, so the read side needs the same guard.
+            $MatchedUser = if ($Mailbox.ExternalDirectoryObjectId) { $UserLookup[$Mailbox.ExternalDirectoryObjectId] } else { $null }
             $AutoExpandingArchiveState = Get-CIPPAutoExpandingArchiveState -MailboxAutoExpandingArchiveEnabled $Mailbox.AutoExpandingArchiveEnabled -OrgAutoExpandingArchiveEnabled $OrgAutoExpandingArchiveEnabled
             $Mailboxes.Add(($Mailbox | Select-Object id, ExchangeGuid, ArchiveGuid, WhenSoftDeleted,
                     @{ Name = 'UPN'; Expression = { $_.'UserPrincipalName' } },


### PR DESCRIPTION
## What

`Set-CIPPDBCacheMailboxes` indexes `$UserLookup` with `$Mailbox.ExternalDirectoryObjectId` without a null guard:

```powershell
$MatchedUser = $UserLookup[$Mailbox.ExternalDirectoryObjectId]
```

When a mailbox returned by the bulk `Get-Mailbox` request has `ExternalDirectoryObjectId = $null` (no linked Entra ID directory object), this throws:

```
Index operation failed; the array index evaluated to null.
```

The exception is unhandled inside the `foreach`, so it aborts the whole per-tenant mailbox cache run — not just the one offending mailbox. The tenant's Mailboxes reporting table then stays empty (or stale) until the next successful run.

Notably, `$UserLookup` is already built defensively against this exact condition a few lines above:

```powershell
foreach ($User in @($BulkResults.'Get-User')) {
    if ($User.ExternalDirectoryObjectId) {
        $UserLookup[$User.ExternalDirectoryObjectId] = $User
    }
}
```

The write side is guarded, the read side wasn't. Two other lookups later in the same function (in the `Get-MailboxUsageDetail` and `Get-MailboxStatistics` handling) already use a guarded pattern (`-and ...ContainsKey(...)`), so this brings the mailbox lookup in line with the rest of the function.

## Fix

```powershell
$MatchedUser = if ($Mailbox.ExternalDirectoryObjectId) { $UserLookup[$Mailbox.ExternalDirectoryObjectId] } else { $null }
```

Falls back to `$null` for `$MatchedUser`, which the rest of the function already handles fine (the `RemotePowerShellEnabled`/`Guid`/`Identity` properties selected from `$MatchedUser` further down just come back empty for that one mailbox instead of the whole run dying).

## How this was found / verified

Hit reproducibly on a live tenant via CIPP's own Logbook (`Failed to cache mailboxes: Index operation failed; the array index evaluated to null.`), then reproduced in isolation with a minimal script mirroring this function's exact hashtable-indexing pattern (a hashtable populated only for entries with a non-null key, then indexed elsewhere by a key that can be `$null`) — confirmed both plain `Hashtable` and array/`List` indexing throw the identical message when the index expression evaluates to `$null`. Applied the guard shown above and confirmed the repro no longer throws.

I didn't have a way to pin down from my side *which* mailbox type(s) can have a null `ExternalDirectoryObjectId` under this function's `Get-Mailbox` call (no scoping parameters, routed through `New-ExoBulkRequest`/the EXO admin REST API) — happy to add more detail here if that's useful, but the fix itself is correct regardless of the exact cause: indexing a hashtable with a `$null` key is never valid, and the guarded fallback matches how the rest of this function already handles an unmatched/missing user.

## Scope

One file, one guard clause, no behavior change for mailboxes that do have a matched user.
