### PR TITLE
feat(identity): add Has Owner column to groups list

### DIFF
--- a/backend/Modules/CIPPCore/Public/Get-CIPPGroupsReport.ps1
+++ b/backend/Modules/CIPPCore/Public/Get-CIPPGroupsReport.ps1
@@ -68,6 +68,9 @@ function Get-CIPPGroupsReport {
                 if ($Group.owners -and -not $Group.ownersCsv) {
                     $Group | Add-Member -NotePropertyName 'ownersCsv' -NotePropertyValue ($Group.owners.userPrincipalName -join ',') -Force
                 }
+                if ($null -eq $Group.hasOwner) {
+                    $Group | Add-Member -NotePropertyName 'hasOwner' -NotePropertyValue (-not [string]::IsNullOrEmpty($Group.ownersCsv)) -Force
+                }
                 # Per-item timestamp: a page may span tenants.
                 $Group | Add-Member -NotePropertyName 'CacheTimestamp' -NotePropertyValue $Item.Timestamp -Force
                 if ($TenantFilter -eq 'AllTenants') {
@@ -122,6 +125,7 @@ function Get-CIPPGroupsReport {
             if ($Group.owners -and -not $Group.ownersCsv) {
                 $Group | Add-Member -NotePropertyName 'ownersCsv' -NotePropertyValue ($Group.owners.userPrincipalName -join ',') -Force
             }
+            $Group | Add-Member -NotePropertyName 'hasOwner' -NotePropertyValue (-not [string]::IsNullOrEmpty($Group.ownersCsv)) -Force
             $Group | Add-Member -NotePropertyName 'CacheTimestamp' -NotePropertyValue $CacheTimestamp -Force
             $Results.Add($Group)
         } catch {

--- a/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheGroups.ps1
+++ b/backend/Modules/CIPPDB/Public/DBCache/Set-CIPPDBCacheGroups.ps1
@@ -84,6 +84,10 @@ function Set-CIPPDBCacheGroups {
                 if ($Group.owners) {
                     $NoteProperties['ownersCsv'] = ($Group.owners.userPrincipalName -join ',')
                 }
+                # Set unconditionally (unlike ownersCsv above) so a genuinely owner-less group
+                # still gets an explicit false baked into the blob - the AsRawJson paged read
+                # streams this stored blob verbatim and never recomputes it.
+                $NoteProperties['hasOwner'] = [bool]($Group.owners -and $Group.owners.Count -gt 0)
                 $NoteProperties['primDomain'] = ($Group.mail -split '@' | Select-Object -Last 1)
                 $NoteProperties['teamsEnabled'] = ($Group.resourceProvisioningOptions -contains 'Team')
                 $NoteProperties['dynamicGroupBool'] = ($Group.groupTypes -contains 'DynamicMembership')

--- a/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
+++ b/backend/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Groups/Invoke-ListGroups.ps1
@@ -179,7 +179,12 @@ function Invoke-ListGroups {
                 $GroupProperties.Add(@{Name = 'membersCsv'; Expression = { $_.members.userPrincipalName -join ',' } })
             }
             if ($ExpandOwners -and -not $ExpandMembers) {
-                $GroupProperties.Add(@{Name = 'ownersCsv'; Expression = { $_.owners.userPrincipalName -join ',' } })
+                # hasOwner only - ownersCsv is deliberately not emitted here. Populating it would
+                # make subTableShowsCachedColumn() (frontend) swap the interactive "View owners"
+                # button (Add/Remove Owner actions) for a read-only CSV column tenant-wide, since
+                # that check only looks at whether the field is populated, not which caller asked
+                # for it.
+                $GroupProperties.Add(@{Name = 'hasOwner'; Expression = { $_.owners.Count -gt 0 } })
             }
             $GroupProperties.Add(@{Name = 'teamsEnabled'; Expression = { if ($_.resourceProvisioningOptions -like '*Team*') { $true }else { $false } } })
             $GroupProperties.Add(@{Name = 'groupType'; Expression = {

--- a/backend/Tests/DBCache/Set-CIPPDBCache.Memory.Tests.ps1
+++ b/backend/Tests/DBCache/Set-CIPPDBCache.Memory.Tests.ps1
@@ -148,15 +148,33 @@ Describe 'DBCache collectors reworked for bounded memory' {
             Should -Invoke New-GraphGetRequest -Times 1 -Exactly -ParameterFilter { $Stream.IsPresent }
             $Row = $script:DbWrites[0].Rows[0]
             # membersCsv/ownersCsv are precomputed so the paged list read can stream the blob
-            # verbatim; both sit next to their source arrays in the emitted order.
-            $Added = @($Row.PSObject.Properties.Name) | Select-Object -Last 8
-            $Added | Should -Be @('members', 'membersCsv', 'ownersCsv', 'primDomain', 'teamsEnabled', 'dynamicGroupBool', 'groupType', 'calculatedGroupType')
+            # verbatim; both sit next to their source arrays in the emitted order. hasOwner is
+            # set unconditionally right after, so the AsRawJson paged read has a stable owner
+            # flag even for a genuinely owner-less group (where ownersCsv itself never gets set).
+            $Added = @($Row.PSObject.Properties.Name) | Select-Object -Last 9
+            $Added | Should -Be @('members', 'membersCsv', 'ownersCsv', 'hasOwner', 'primDomain', 'teamsEnabled', 'dynamicGroupBool', 'groupType', 'calculatedGroupType')
             $Row.membersCsv | Should -Be 'user1@contoso.com'
             $Row.ownersCsv | Should -Be 'owner1@contoso.com'
+            $Row.hasOwner | Should -BeTrue
             $Row.groupType | Should -Be 'Microsoft 365'
             $Row.calculatedGroupType | Should -Be 'm365'
             $Row.primDomain | Should -Be 'contoso.com'
             $Row.teamsEnabled | Should -BeTrue
+        }
+
+        It 'sets hasOwner to false for a genuinely owner-less group' {
+            Mock -CommandName New-GraphGetRequest -MockWith {
+                @([pscustomobject]@{ id = 'g1'; displayName = 'One'; mail = 'one@contoso.com'; groupTypes = @('Unified'); mailEnabled = $true; securityEnabled = $false; resourceProvisioningOptions = @('Team'); owners = @() })
+            }
+            Mock -CommandName New-GraphBulkRequest -MockWith {
+                @([pscustomobject]@{ id = 'g1'; body = [pscustomobject]@{ value = @() } })
+            }
+
+            Set-CIPPDBCacheGroups -TenantFilter 'contoso.com'
+
+            $Row = $script:DbWrites[0].Rows[0]
+            $Row.hasOwner | Should -BeFalse
+            $Row.PSObject.Properties.Name | Should -Not -Contain 'ownersCsv'
         }
 
         It 'omits the members property entirely when no member lookup ran' {

--- a/frontend/src/pages/identity/administration/groups/index.jsx
+++ b/frontend/src/pages/identity/administration/groups/index.jsx
@@ -26,6 +26,9 @@ const Page = () => {
     allowAllTenantSync: true,
     cacheColumns: ['CacheTimestamp'],
     serverPagination: true,
+    // Adds hasOwner to the live list in a single Graph $expand, so the Has Owner
+    // column works without switching to cached ReportDB data.
+    apiData: { expandOwners: true },
   })
 
   const actions = [
@@ -501,6 +504,7 @@ const Page = () => {
           'onPremisesSyncEnabled',
           'members',
           'owners',
+          'hasOwner',
         ]}
         subTables={[
           {


### PR DESCRIPTION
## Summary
- Adds a `hasOwner` boolean to the Groups list response — live view via the existing (already-supported, just previously unused) `expandOwners` Graph `$expand`, cached/AllTenants view via the CIPPDB report cache which already fetches owners.
- Adds it as a filterable column on the Groups page, so groups missing an owner are visible and filterable without expanding each row.
- Deliberately does *not* emit `ownersCsv` on the live path, since doing so would silently swap out the existing interactive "View owners" button (with its Add/Remove Owner actions) for a read-only text column.

## Test plan
- [x] PowerShell parser check on all three edited backend files
- [x] ESLint clean on the edited frontend file
- [x] Backend Pester suite for the touched files passes (`Invoke-ListGroups.Tests.ps1`, `Get-CIPPGroupsReport.Tests.ps1` — 7/7, including the `-AsRawJson` blob-splicing tests)
- [x] Confirmed via diff that the frontend `cachedColumn`/sub-table swap logic this PR routes around (`util-subTables.js`) is byte-identical to when it was last tested — the frontend Vitest suite itself currently can't run on `dev` at all (unrelated pre-existing `ReferenceError: React is not defined` in the shared theme, breaks every unit test, not caused by this PR)


Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)