### PR TITLE
fix(alerts): Baseline initial MX records

### DIFF
--- a/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertMXRecordChanged.ps1
+++ b/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertMXRecordChanged.ps1
@@ -23,6 +23,11 @@ function Get-CIPPAlertMXRecordChanged {
         $ChangedDomains = foreach ($Domain in $DomainData) {
             try {
                 $PreviousDomain = $PreviousResults | Where-Object { $_.Domain -eq $Domain.Domain }
+                if (-not $PreviousDomain) {
+                    Write-Information "Initializing MX record baseline for domain $($Domain.Domain): $($Domain.ActualMXRecords.Hostname -join ', ')"
+                    continue
+                }
+
                 $PreviousRecords = if ($PreviousDomain.ActualMXRecords) { @($PreviousDomain.ActualMXRecords -split ',' | Sort-Object) } else { @() }
                 $CurrentRecords = if ($Domain.ActualMXRecords.Hostname) { @($Domain.ActualMXRecords.Hostname | Sort-Object) } else { @() }
 

--- a/backend/Tests/Alerts/Get-CIPPAlertMXRecordChanged.Tests.ps1
+++ b/backend/Tests/Alerts/Get-CIPPAlertMXRecordChanged.Tests.ps1
@@ -1,0 +1,87 @@
+# Pester tests for Get-CIPPAlertMXRecordChanged.
+# A domain without a CacheMxRecords row is being observed for the first time; its current
+# records establish the baseline and must not be reported as a change.
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $AlertPath = Join-Path $RepoRoot 'Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertMXRecordChanged.ps1'
+
+    function Get-CIPPDomainAnalyser { param($TenantFilter) }
+    function Get-CippTable { param($TableName) }
+    function Get-CIPPAzDataTableEntity { param($TableName, $Filter) }
+    function Add-CIPPAzDataTableEntity { param($TableName, $Entity, [switch]$Force) }
+    function Write-AlertTrace { param($cmdletName, $tenantFilter, $data) }
+    function Write-LogMessage { param($message, $API, $tenant, $sev) }
+
+    . $AlertPath
+}
+
+Describe 'Get-CIPPAlertMXRecordChanged' {
+    BeforeEach {
+        $script:PreviousResults = @()
+        $script:DomainData = @(
+            [pscustomobject]@{
+                Domain          = 'contoso.com'
+                ActualMXRecords = [pscustomobject]@{ Hostname = @('contoso-com.mail.protection.outlook.com') }
+                LastRefresh     = '2026-09-04T12:00:00Z'
+                MailProvider    = 'Microsoft 365'
+            }
+        )
+        $script:CapturedAlertData = $null
+
+        Mock Get-CIPPDomainAnalyser { $script:DomainData }
+        Mock Get-CippTable { @{ TableName = 'CacheMxRecords' } }
+        Mock Get-CIPPAzDataTableEntity { $script:PreviousResults }
+        Mock Add-CIPPAzDataTableEntity {}
+        Mock Write-AlertTrace {
+            param($cmdletName, $tenantFilter, $data)
+            $script:CapturedAlertData = @($data)
+        }
+        Mock Write-LogMessage {}
+    }
+
+    It 'stores current MX records as the baseline without alerting when no prior domain row exists' {
+        Get-CIPPAlertMXRecordChanged -TenantFilter 'tenant.onmicrosoft.com'
+
+        Should -Invoke Write-AlertTrace -Times 0 -Exactly
+        Should -Invoke Add-CIPPAzDataTableEntity -Times 1 -Exactly -ParameterFilter {
+            $Entity.PartitionKey -eq 'tenant.onmicrosoft.com' -and
+            $Entity.RowKey -eq 'contoso.com' -and
+            $Entity.ActualMXRecords -eq 'contoso-com.mail.protection.outlook.com' -and
+            $Force
+        }
+    }
+
+    It 'alerts when a previously cached domain changes MX records' {
+        $script:PreviousResults = @(
+            [pscustomobject]@{
+                Domain          = 'contoso.com'
+                ActualMXRecords = 'old-mx.contoso.com'
+            }
+        )
+
+        Get-CIPPAlertMXRecordChanged -TenantFilter 'tenant.onmicrosoft.com'
+
+        Should -Invoke Write-AlertTrace -Times 1 -Exactly
+        $script:CapturedAlertData.Count | Should -Be 1
+        $script:CapturedAlertData[0].Domain | Should -Be 'contoso.com'
+        $script:CapturedAlertData[0].PreviousRecords | Should -Be 'old-mx.contoso.com'
+        $script:CapturedAlertData[0].CurrentRecords | Should -Be 'contoso-com.mail.protection.outlook.com'
+    }
+
+    It 'alerts when an existing cached domain changes from no MX records to populated records' {
+        $script:PreviousResults = @(
+            [pscustomobject]@{
+                Domain          = 'contoso.com'
+                ActualMXRecords = ''
+            }
+        )
+
+        Get-CIPPAlertMXRecordChanged -TenantFilter 'tenant.onmicrosoft.com'
+
+        Should -Invoke Write-AlertTrace -Times 1 -Exactly
+        $script:CapturedAlertData.Count | Should -Be 1
+        $script:CapturedAlertData[0].PreviousRecords | Should -Be ''
+        $script:CapturedAlertData[0].CurrentRecords | Should -Be 'contoso-com.mail.protection.outlook.com'
+    }
+}


### PR DESCRIPTION
## Issue

When the "Alert on MX record changes" alert is first activated, it treats the empty pre-cached row becoming cached with data as an alerting change. This displays in the UI as:  
> "Domain: MX records changed from [] to [expectedValue]"

## Fix Summary

- Treat the first observed MX record set for each domain as its baseline rather than an MX-change alert.
- Preserve change alerts for domains that already have a cached record set, including an empty-to-populated transition.
- Add Pester coverage for baseline initialization and subsequent MX changes.

## Validation

- MX alert tests: 3 passed
- Full Alert test suite: 52 passed
- PowerShell parser validation passed

## Notes

The baseline behavior applies when an individual domain has no existing `CacheMxRecords` row. Once that row exists, later MX changes continue to alert normally.