### PR TITLE
fix(table): preserve preferred columns across tenants

### DIFF
--- a/docs/user-documentation/shared-features/table-features.md
+++ b/docs/user-documentation/shared-features/table-features.md
@@ -61,12 +61,14 @@ The **Columns** button controls which columns are visible.
 
 | Menu entry                 | Description                                                                             |
 | -------------------------- | --------------------------------------------------------------------------------------- |
-| Reset to preferred columns | Restores the column selection to the page defaults.                                     |
+| Reset to preferred columns | Restores your saved selection, or the page defaults if no selection is saved.           |
 | Save as preferred columns  | Saves the current selection so it is applied automatically whenever you open this page. |
 | Delete preferred columns   | Removes your saved selection for this page.                                             |
 | Column list                | Tick or untick individual columns to show or hide them.                                 |
 
 Preferred columns are stored per page in your browser's local storage, so they follow the browser and profile you are working in rather than your CIPP account.
+
+Your saved selection applies to the same page across all tenants and is restored when you reload the page. Columns that were not present when you saved keep their default visibility. **Reset to preferred columns** restores the saved choices and leaves any columns outside that selection unchanged.
 
 ### Export
 

--- a/frontend/src/components/CippTable/CIPPTableToptoolbar.jsx
+++ b/frontend/src/components/CippTable/CIPPTableToptoolbar.jsx
@@ -524,7 +524,10 @@ export const CIPPTableToptoolbar = React.memo(
         settings?.columnDefaults?.[pageName] &&
         Object.keys(settings?.columnDefaults?.[pageName]).length > 0
       ) {
-        setColumnVisibility(settings?.columnDefaults?.[pageName])
+        setColumnVisibility((previous) => ({
+          ...previous,
+          ...settings.columnDefaults[pageName],
+        }))
       } else {
         setColumnVisibility((prevVisibility) => {
           const updatedVisibility = {}

--- a/frontend/src/components/CippTable/CippDataTable.jsx
+++ b/frontend/src/components/CippTable/CippDataTable.jsx
@@ -754,6 +754,7 @@ export const CippDataTable = (props) => {
   const router = useRouter()
   const routerPageName = router.pathname.split('/').slice(1).join('/')
   const pageName = persistenceKey ?? (isInDialog ? '' : routerPageName)
+  const preferredColumnVisibility = pageName ? settings?.columnDefaults?.[pageName] : undefined
 
   // 'cards' below the md breakpoint (or when forced via settings/prop), 'table' otherwise.
   // simple tables always resolve to 'table'.
@@ -1003,7 +1004,8 @@ export const CippDataTable = (props) => {
       setSorting(defaultSorting)
     }
     setUsedColumns(finalColumns)
-    setColumnVisibility(newVisibility)
+    // Keep saved page preferences when new API data regenerates the columns.
+    setColumnVisibility({ ...newVisibility, ...preferredColumnVisibility })
   }, [
     columns.length,
     usedData,
@@ -1011,6 +1013,7 @@ export const CippDataTable = (props) => {
     settings?.currentTenant,
     filterTypeMap,
     subTables,
+    preferredColumnVisibility,
   ])
 
   // Previous-value refs for the guards below: CippDataTable is the single owner of this
@@ -1061,16 +1064,16 @@ export const CippDataTable = (props) => {
     if (!pageName) {
       return
     }
-    const preferred = settings?.columnDefaults?.[pageName]
+    const preferred = preferredColumnVisibility
     if (
       preferred &&
       Object.keys(preferred).length > 0 &&
       appliedColumnDefaultsRef.current[pageName] !== preferred
     ) {
       appliedColumnDefaultsRef.current[pageName] = preferred
-      setColumnVisibility(preferred)
+      setColumnVisibility((previous) => ({ ...previous, ...preferred }))
     }
-  }, [settings?.columnDefaults?.[pageName], pageName])
+  }, [preferredColumnVisibility, pageName])
 
   const createDialog = useDialog()
   const hasActions = !!actions

--- a/frontend/tests/components/CippTable/CippPreferredColumns.stories.jsx
+++ b/frontend/tests/components/CippTable/CippPreferredColumns.stories.jsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react'
+import { Button, Stack } from '@mui/material'
+import { http, HttpResponse } from 'msw'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+import { CippDataTable } from '../../../src/components/CippTable/CippDataTable'
+import { SettingsProvider } from '../../../src/contexts/settings-context'
+import { useSettings } from '../../../src/hooks/use-settings'
+
+const persistenceKey = 'storybook/preferred-columns/users'
+const columns = [
+  { id: 'displayName', accessorKey: 'displayName', header: 'Display Name' },
+  { id: 'mail', accessorKey: 'mail', header: 'Mail' },
+]
+const tenants = {
+  'tenant-a.example': [
+    { displayName: 'Alice', mail: 'alice@tenant-a.example', department: 'IT' },
+  ],
+  'tenant-b.example': [
+    { displayName: 'Bob', mail: 'bob@tenant-b.example', department: 'Sales', jobTitle: 'Manager' },
+    { displayName: 'Carol', mail: 'carol@tenant-b.example', department: 'HR', jobTitle: 'Analyst' },
+  ],
+}
+
+function PreferredColumnsExample() {
+  const settings = useSettings()
+  const { handleUpdate } = settings
+  const [tableKey, setTableKey] = useState(0)
+  const tenant = settings.currentTenant || 'tenant-a.example'
+
+  useEffect(() => {
+    handleUpdate({ currentTenant: 'tenant-a.example' })
+  }, [handleUpdate])
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={1}>
+        <Button onClick={() => settings.handleUpdate({ currentTenant: 'tenant-a.example' })}>
+          Tenant A
+        </Button>
+        <Button onClick={() => settings.handleUpdate({ currentTenant: 'tenant-b.example' })}>
+          Tenant B
+        </Button>
+        <Button onClick={() => setTableKey((key) => key + 1)}>Reload table</Button>
+        <Button onClick={() => {
+          settings.handleUpdate({
+            currentTenant: 'tenant-a.example',
+            columnDefaults: { ...settings.columnDefaults, [persistenceKey]: {} },
+          })
+          setTableKey((key) => key + 1)
+        }}>Reset example</Button>
+      </Stack>
+      <CippDataTable
+        key={tableKey}
+        title={`Users - ${tenant}`}
+        persistenceKey={persistenceKey}
+        api={{ url: '/api/TestPreferredColumns', dataKey: 'Results', data: { tenantFilter: tenant } }}
+        queryKey={`preferred-columns-${tenant}`}
+        columns={columns}
+        viewMode="table"
+        maxHeightOffset="100px"
+      />
+    </Stack>
+  )
+}
+
+export default {
+  title: 'Components/CippTable/Preferred Columns',
+  decorators: [(Story) => <SettingsProvider><Story /></SettingsProvider>],
+}
+
+export const AcrossTenants = {
+  beforeEach({ msw }) {
+    msw.use(http.get('/api/TestPreferredColumns', ({ request }) => {
+      const tenant = new URL(request.url).searchParams.get('tenantFilter')
+      return HttpResponse.json({ Results: tenants[tenant] || [], Metadata: {} })
+    }))
+  },
+  render: () => <PreferredColumnsExample />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const body = within(canvasElement.ownerDocument.body)
+    const checkbox = (name) => within(body.getByRole('menuitem', { name })).getByRole('checkbox')
+    const expectPreferred = async () => {
+      await waitFor(() => expect(canvas.getByRole('columnheader', { name: /Department/ })).toBeVisible())
+      expect(canvas.queryByRole('columnheader', { name: /^Mail/ })).toBeNull()
+    }
+
+    await step('save Department shown and Mail hidden on Tenant A', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Reset example' }))
+      await canvas.findByText('Alice')
+      await userEvent.click(canvas.getByRole('button', { name: 'Columns' }))
+      await userEvent.click(checkbox('Department'))
+      await userEvent.click(checkbox('Mail'))
+      await userEvent.click(body.getByRole('menuitem', { name: 'Save as preferred columns' }))
+      await expectPreferred()
+    })
+
+    await step('Tenant B retains the preference with a different response schema', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Tenant B' }))
+      await canvas.findByText('Bob')
+      await expectPreferred()
+    })
+
+    await step('resetting preferences leaves new columns at their current visibility', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Columns' }))
+      await userEvent.click(checkbox('Department'))
+      await userEvent.click(body.getByRole('menuitem', { name: 'Reset to preferred columns' }))
+      await expectPreferred()
+      expect(canvas.queryByRole('columnheader', { name: /Job Title/ })).toBeNull()
+    })
+
+    await step('reloading and returning to Tenant A retain the preference', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Reload table' }))
+      await canvas.findByText('Bob')
+      await expectPreferred()
+      await userEvent.click(canvas.getByRole('button', { name: 'Tenant A' }))
+      await canvas.findByText('Alice')
+      await expectPreferred()
+    })
+  },
+}

--- a/frontend/tests/components/CippTable/CippPreferredColumns.test.jsx
+++ b/frontend/tests/components/CippTable/CippPreferredColumns.test.jsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import { renderWithProviders, settingsWith } from '../../test-utils'
+import { SettingsContext } from '../../../src/contexts/settings-context'
+import { CippDataTable } from '../../../src/components/CippTable/CippDataTable'
+import router from '../../mocks/next-router'
+
+vi.mock('../../../src/api/ApiCall', async () => (await import('../../mocks/api-call')).apiCallMock())
+import { api, paginatedResult } from '../../mocks/api-call'
+
+const page = 'identity/administration/users'
+const idleResult = paginatedResult([], { isSuccess: false })
+const tenantResults = {
+  A: paginatedResult([{ displayName: 'Alice', mail: 'alice@example.com', department: 'IT' }]),
+  B: paginatedResult([
+    { displayName: 'Bob', mail: 'bob@example.com', department: 'Sales', jobTitle: 'Manager' },
+    { displayName: 'Carol', mail: 'carol@example.com', department: 'HR', jobTitle: 'Analyst' },
+  ]),
+}
+const customColumns = [
+  { id: 'displayName', accessorKey: 'displayName', header: 'Display Name' },
+  { id: 'mail', accessorKey: 'mail', header: 'Mail' },
+]
+const modes = [
+  ['custom', { columns: customColumns }],
+  ['simple', { simpleColumns: ['displayName', 'mail'] }],
+  ['automatic', {}],
+]
+
+function Example({ tableProps, saved = {}, otherSaved = {} }) {
+  const [settings, setSettings] = useState(() => settingsWith({
+    currentTenant: 'A',
+    columnDefaults: { [page]: saved, ...otherSaved },
+  }))
+  const [tableKey, setTableKey] = useState(0)
+  return (
+    <SettingsContext.Provider value={{
+      ...settings,
+      handleUpdate: (update) => setSettings((previous) => ({ ...previous, ...update })),
+    }}>
+      <button onClick={() => setSettings((previous) => ({ ...previous, currentTenant: 'B' }))}>
+        Tenant B
+      </button>
+      <button onClick={() => setTableKey((key) => key + 1)}>Reload table</button>
+      <CippDataTable
+        key={tableKey}
+        api={{ url: '/api/TestPreferredColumns', dataKey: 'Results', data: { tenantFilter: settings.currentTenant } }}
+        queryKey={`preferred-${settings.currentTenant}`}
+        viewMode="table"
+        {...tableProps}
+      />
+    </SettingsContext.Provider>
+  )
+}
+
+const columnCheckbox = (name) => within(screen.getByRole('menuitem', { name })).getByRole('checkbox')
+
+beforeEach(() => {
+  router.pathname = `/${page}`
+  api.paginated = (options) => tenantResults[options.data?.tenantFilter] || idleResult
+})
+
+afterEach(() => {
+  router.pathname = '/'
+})
+
+describe.each(modes)('preferred columns with %s columns', (_mode, tableProps) => {
+  it('keeps saved selections after switching tenants with different API data and remounting', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<Example tableProps={tableProps} />)
+    await screen.findByText('1-1 of 1')
+    await user.click(screen.getByRole('button', { name: 'Columns' }))
+    if (!columnCheckbox('Department').checked) await user.click(columnCheckbox('Department'))
+    await user.click(columnCheckbox('Mail'))
+    await user.click(screen.getByRole('menuitem', { name: 'Save as preferred columns' }))
+
+    await user.click(screen.getByRole('button', { name: 'Tenant B' }))
+    await screen.findByText('1-2 of 2')
+    await user.click(screen.getByRole('button', { name: 'Columns' }))
+    expect(columnCheckbox('Department')).toBeChecked()
+    expect(columnCheckbox('Mail')).not.toBeChecked()
+    // A field absent from the saved preference retains this table's default.
+    expect(columnCheckbox('Job Title').checked).toBe(_mode === 'automatic')
+    await user.click(columnCheckbox('Department'))
+    await user.click(screen.getByRole('menuitem', { name: 'Reset to preferred columns' }))
+    await user.click(screen.getByRole('button', { name: 'Columns' }))
+    expect(columnCheckbox('Department')).toBeChecked()
+    expect(columnCheckbox('Mail')).not.toBeChecked()
+    expect(columnCheckbox('Job Title').checked).toBe(_mode === 'automatic')
+    await user.keyboard('{Escape}')
+
+    await user.click(screen.getByRole('button', { name: 'Reload table' }))
+    await screen.findByText('1-2 of 2')
+    await user.click(screen.getByRole('button', { name: 'Columns' }))
+    expect(columnCheckbox('Department')).toBeChecked()
+    expect(columnCheckbox('Mail')).not.toBeChecked()
+  })
+
+  it('applies existing preferences when API data arrives after mount', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<Example tableProps={tableProps} saved={{ department: true, mail: false }} />)
+    await screen.findByText('1-1 of 1')
+    await user.click(screen.getByRole('button', { name: 'Columns' }))
+    await waitFor(() => expect(columnCheckbox('Department')).toBeChecked())
+    expect(columnCheckbox('Mail')).not.toBeChecked()
+    expect(columnCheckbox('Display Name')).toBeChecked()
+  })
+})
+
+it('does not apply the parent page preference to an unkeyed dialog table', async () => {
+  const user = userEvent.setup()
+  renderWithProviders(<Example
+    tableProps={{ columns: customColumns, isInDialog: true }}
+    saved={{ department: true, mail: false }}
+  />)
+  await screen.findByText('1-1 of 1')
+  await user.click(screen.getByRole('button', { name: 'Columns' }))
+  expect(columnCheckbox('Department')).not.toBeChecked()
+  expect(columnCheckbox('Mail')).toBeChecked()
+})
+
+it('uses the explicit persistence key for a dialog table', async () => {
+  const user = userEvent.setup()
+  renderWithProviders(<Example
+    tableProps={{ columns: customColumns, isInDialog: true, persistenceKey: 'related-users' }}
+    saved={{ department: false, mail: true }}
+    otherSaved={{ 'related-users': { department: true, mail: false } }}
+  />)
+  await screen.findByText('1-1 of 1')
+  await user.click(screen.getByRole('button', { name: 'Columns' }))
+  expect(columnCheckbox('Department')).toBeChecked()
+  expect(columnCheckbox('Mail')).not.toBeChecked()
+})
+
+it('does not restore deleted preferences after a tenant switch or reload', async () => {
+  const user = userEvent.setup()
+  renderWithProviders(<Example
+    tableProps={{ simpleColumns: ['displayName', 'mail'] }}
+    saved={{ department: true, mail: false }}
+  />)
+  await screen.findByText('1-1 of 1')
+  await user.click(screen.getByRole('button', { name: 'Columns' }))
+  await user.click(screen.getByRole('menuitem', { name: 'Delete preferred columns' }))
+  await user.click(screen.getByRole('button', { name: 'Tenant B' }))
+  await screen.findByText('1-2 of 2')
+  await user.click(screen.getByRole('button', { name: 'Columns' }))
+  expect(columnCheckbox('Department')).not.toBeChecked()
+  expect(columnCheckbox('Mail')).toBeChecked()
+  await user.keyboard('{Escape}')
+  await user.click(screen.getByRole('button', { name: 'Reload table' }))
+  await screen.findByText('1-2 of 2')
+  await user.click(screen.getByRole('button', { name: 'Columns' }))
+  expect(columnCheckbox('Department')).not.toBeChecked()
+  expect(columnCheckbox('Mail')).toBeChecked()
+})


### PR DESCRIPTION
Addresses #487 

Saved column preferences now survive tenant switches and table reloads. Rebuilding columns from API data preserves saved visibility while retaining defaults for newly encountered fields.

“Reset to preferred columns” also avoids unexpectedly revealing fields absent from the saved preference. Updated the shared table documentation.

Validation:
- 190 table unit tests passed.
- 16 browser tests passed.
- Reproduced with mocked tenants using different API responses.
- Verified the live Users table.