### PR TITLE
fix(standards): honor CA template state radio in drift reporting

### DIFF
--- a/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardConditionalAccessTemplate.ps1
+++ b/backend/Modules/CIPPStandards/Public/Standards/Invoke-CIPPStandardConditionalAccessTemplate.ps1
@@ -184,9 +184,9 @@ function Invoke-CIPPStandardConditionalAccessTemplate {
                 return
             }
 
-            if ($Settings.state -and $Settings.state -ne 'donotchange' -and $CompareObj.state -eq $Settings.state) {
-                Write-Information "Policy is in the deployed state '$($CompareObj.state)'; not comparing against template state '$($Policy.state)'"
-                $Policy | Add-Member -NotePropertyName 'state' -NotePropertyValue $CompareObj.state -Force
+            # Override the template's state with the standard's state for drift comparison
+            if ($Settings.state -and $Settings.state -ne 'donotchange') {
+                $Policy | Add-Member -NotePropertyName 'state' -NotePropertyValue $Settings.state -Force
             }
 
             try {


### PR DESCRIPTION
### Issue

CA template reporting compared the tenant policy against the state stored in the imported template JSON, and only overrode that when the live policy already matched the standard radio. A template captured as Enabled, deployed as report-only, then reported with the radio set to Enabled looked compliant even though the tenant state did not match.

Same behaviour as #89; still present.

### Fix

When the radio is set (and is not "Do not change state"), use that value as the expected state for drift comparison. Deploy already passed the radio into `New-CIPPCAPolicy`; this only changes report/compare.

CA template packages expand into the same standard before queueing, so they pick this up without a second change. "Do not change state" still compares against each template's own JSON.

Closes #517