### PR TITLE
Refactor: Update default shortcut location to Shortcuts folder

### DIFF
--- a/docs/user-documentation/identity/administration/users/user/onedrive-shortcuts.md
+++ b/docs/user-documentation/identity/administration/users/user/onedrive-shortcuts.md
@@ -13,7 +13,7 @@ Opens a dialog that adds a shortcut to a chosen SharePoint site into the user's 
 | Field | Description |
 | ----- | ----------- |
 | Select a Site | The SharePoint site to link to. Existing sites can be picked, or a URL typed directly. |
-| Shortcut location | Where the shortcut is created: the OneDrive root, or the Shortcuts folder. Defaults to the OneDrive root. |
+| Shortcut location | Where the shortcut is created: the OneDrive root, or the Shortcuts folder. Defaults to the Shortcuts folder. |
 
 </details>
 

--- a/frontend/src/components/CippComponents/CippUserActions.jsx
+++ b/frontend/src/components/CippComponents/CippUserActions.jsx
@@ -868,7 +868,7 @@ export const useCippUserActions = () => {
         userid: 'id',
       },
       defaultvalues: {
-        destination: { label: 'OneDrive root', value: 'root' },
+        destination: { label: 'Shortcuts folder (Microsoft UI)', value: 'shortcuts' },
       },
       fields: [
         {

--- a/frontend/src/pages/identity/administration/users/user/onedrive-shortcuts.jsx
+++ b/frontend/src/pages/identity/administration/users/user/onedrive-shortcuts.jsx
@@ -144,7 +144,7 @@ const Page = () => {
           title="Add OneDrive Shortcut"
           row={user}
           defaultvalues={{
-            destination: { label: 'OneDrive root', value: 'root' },
+            destination: { label: 'Shortcuts folder (Microsoft UI)', value: 'shortcuts' },
           }}
           relatedQueryKeys={[shortcutsQueryKey]}
           fields={[


### PR DESCRIPTION
Change the default location for creating shortcuts from the OneDrive root to the Shortcuts folder. Done as Microsoft wants us to use that folder, so we should prolly leard users in that direction by default