### PR TITLE
fix(alerts): key expiring-license snooze on subscription id

### DIFF
--- a/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertExpiringLicenses.ps1
+++ b/backend/Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertExpiringLicenses.ps1
@@ -52,6 +52,7 @@ function Get-CIPPAlertExpiringLicenses {
                         }
 
                         [PSCustomObject]@{
+                            Id             = $Term.SubscriptionId
                             Message        = $Message
                             License        = $_.License
                             SkuId          = $_.skuId

--- a/backend/Tests/Alerts/Get-CIPPAlertExpiringLicenses.Tests.ps1
+++ b/backend/Tests/Alerts/Get-CIPPAlertExpiringLicenses.Tests.ps1
@@ -1,0 +1,67 @@
+# Pester tests for Get-CIPPAlertExpiringLicenses.
+# Each emitted row must carry the Graph subscription id as `Id` so Get-AlertContentHash keys the
+# snooze fingerprint on it rather than falling back to `Message`, which embeds DaysUntilRenew and
+# therefore changes on every scheduled run (a snooze could never match the next run).
+
+BeforeAll {
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+    $AlertPath = Join-Path $RepoRoot 'Modules/CIPPAlerts/Public/Alerts/Get-CIPPAlertExpiringLicenses.ps1'
+    $HashPath = Join-Path $RepoRoot 'Modules/CIPPCore/Public/GraphHelper/Get-AlertContentHash.ps1'
+
+    function Get-CIPPLicenseOverview { param($TenantFilter, [switch]$AlertMode) }
+    function Write-AlertTrace { param($cmdletName, $tenantFilter, $data) }
+
+    . $AlertPath
+    . $HashPath
+}
+
+Describe 'Get-CIPPAlertExpiringLicenses' {
+    BeforeEach {
+        $script:CapturedAlertData = $null
+        Mock Write-AlertTrace {
+            param($cmdletName, $tenantFilter, $data)
+            $script:CapturedAlertData = @($data)
+        }
+    }
+
+    Context 'snooze identity' {
+        It 'emits the subscription id as Id on every row' {
+            Mock Get-CIPPLicenseOverview {
+                [pscustomobject]@{
+                    License = 'Microsoft 365 Business Premium'; skuId = 'cbdc14ab-d96c-4c30-b9f4-6ada7cdc1d46'
+                    CountUsed = 10; CountAvailable = 2; Tenant = 'contoso.onmicrosoft.com'
+                    TermInfo = @(
+                        [pscustomobject]@{ Status = 'Enabled'; Term = 'Yearly'; TotalLicenses = 12; DaysUntilRenew = 24; NextLifecycle = '2026-10-05T00:00:00Z'; SubscriptionId = '11111111-aaaa-4aaa-8aaa-111111111111' },
+                        [pscustomobject]@{ Status = 'Enabled'; Term = 'Monthly'; TotalLicenses = 5; DaysUntilRenew = 44; NextLifecycle = '2026-11-01T00:00:00Z'; SubscriptionId = '33333333-cccc-4ccc-8ccc-333333333333' }
+                    )
+                }
+            }
+
+            Get-CIPPAlertExpiringLicenses -InputValue @{ ExpiringLicensesDays = 60; ExpiringLicensesUnassignedOnly = $true } -TenantFilter 'contoso.onmicrosoft.com'
+
+            $script:CapturedAlertData.Count | Should -Be 2
+            $script:CapturedAlertData.Id | Should -Be @('11111111-aaaa-4aaa-8aaa-111111111111', '33333333-cccc-4ccc-8ccc-333333333333')
+        }
+
+        It 'produces the same content hash on consecutive runs even though DaysUntilRenew changes' {
+            $script:Days = 24
+            Mock Get-CIPPLicenseOverview {
+                [pscustomobject]@{
+                    License = 'Microsoft 365 Business Premium'; skuId = 'cbdc14ab-d96c-4c30-b9f4-6ada7cdc1d46'
+                    CountUsed = 10; CountAvailable = 2; Tenant = 'contoso.onmicrosoft.com'
+                    TermInfo = @([pscustomobject]@{ Status = 'Enabled'; Term = 'Yearly'; TotalLicenses = 12; DaysUntilRenew = $script:Days; NextLifecycle = '2026-10-05T00:00:00Z'; SubscriptionId = '11111111-aaaa-4aaa-8aaa-111111111111' })
+                }
+            }
+
+            Get-CIPPAlertExpiringLicenses -InputValue @{ ExpiringLicensesDays = 60; ExpiringLicensesUnassignedOnly = $true } -TenantFilter 'contoso.onmicrosoft.com'
+            $FirstHash = (Get-AlertContentHash -AlertItem $script:CapturedAlertData[0]).ContentHash
+
+            $script:Days = 17   # one week later
+            Get-CIPPAlertExpiringLicenses -InputValue @{ ExpiringLicensesDays = 60; ExpiringLicensesUnassignedOnly = $true } -TenantFilter 'contoso.onmicrosoft.com'
+            $SecondHash = (Get-AlertContentHash -AlertItem $script:CapturedAlertData[0]).ContentHash
+
+            $script:CapturedAlertData[0].Message | Should -Match 'expiring in 17 days'
+            $SecondHash | Should -Be $FirstHash
+        }
+    }
+}


### PR DESCRIPTION
Snoozing an expiring-license alert doesn't actually do anything right now. The rows this alert emits don't have a `UserPrincipalName` or `Id`, so `Get-AlertContentHash` ends up hashing `Message`. That message has `DaysUntilRenew` baked into it ("expiring in 24 days" → "expiring in 17 days" next week), so the hash is different every run and the snooze never matches. Same license but new alert as if it's brand new. 

Proposed fix is one line: add `Id = $Term.SubscriptionId` to the row. The hash keys on the Graph subscription id instead, which doesn't change until the subscription is gone, so a snooze actually sticks. A different SKU, or a second subscription of the same SKU, is a different id and still alerts like it should.

A few notes:
- Only the alert file changed. No frontend/docs. The one visible difference is an `Id` column showing up in the email/PSA table, same as the other alerts that already emit `Id`.
- Any existing snoozes on this alert were keyed on the old message hash and won't match after this. Not a real loss since they weren't matching anyway, and they clean themselves up after expiry.
- Added `backend/Tests/Alerts/Get-CIPPAlertExpiringLicenses.Tests.ps1`. It fails on current `dev` (hash changes between a 24-day and 17-day run) and passes with this change. `Invoke-CippTests.ps1 -Path backend/Tests/Alerts` is green with it in.
- I kept the key to just the subscription id on purpose. I can also see appending the count or renewal date to the subscription id which would re-fire the alert when unassigned seats change during a snooze, but felt like it defeats the point of snoozing, but happy to change that if you'd rather it wake up on any changes.