### PR TITLE
fix(standards): registration campaign fido2 case

### DIFF
--- a/backend/Config/standards.json
+++ b/backend/Config/standards.json
@@ -1555,7 +1555,7 @@
         "name": "standards.NudgeMFA.targetedAuthenticationMethod",
         "options": [
           { "label": "Microsoft Authenticator", "value": "microsoftAuthenticator" },
-          { "label": "Passkey (FIDO2)", "value": "fido2" }
+          { "label": "Passkey (FIDO2)", "value": "FIDO2" }
         ],
         "condition": {
           "field": "standards.NudgeMFA.state",

--- a/backend/Modules/CIPPCore/Public/Set-CIPPRegistrationCampaign.ps1
+++ b/backend/Modules/CIPPCore/Public/Set-CIPPRegistrationCampaign.ps1
@@ -44,8 +44,8 @@ function Set-CIPPRegistrationCampaign {
     if ($DesiredState -notin @('default', 'enabled', 'disabled')) {
         throw "State must be one of 'default', 'enabled' or 'disabled'"
     }
-    if ($DesiredMethod -notin @('microsoftAuthenticator', 'fido2')) {
-        throw "TargetedAuthenticationMethod must be 'microsoftAuthenticator' or 'fido2'"
+    if ($DesiredMethod -notin @('microsoftAuthenticator', 'FIDO2')) {
+        throw "TargetedAuthenticationMethod must be 'microsoftAuthenticator' or 'FIDO2'"
     }
     if ($DesiredSnooze -lt 0 -or $DesiredSnooze -gt 14) {
         throw 'SnoozeDurationInDays must be between 0 and 14'

--- a/frontend/src/data/standards.json
+++ b/frontend/src/data/standards.json
@@ -1555,7 +1555,7 @@
         "name": "standards.NudgeMFA.targetedAuthenticationMethod",
         "options": [
           { "label": "Microsoft Authenticator", "value": "microsoftAuthenticator" },
-          { "label": "Passkey (FIDO2)", "value": "fido2" }
+          { "label": "Passkey (FIDO2)", "value": "FIDO2" }
         ],
         "condition": {
           "field": "standards.NudgeMFA.state",


### PR DESCRIPTION
Solves https://github.com/CyberDrain/CIPP/issues/573 where case issues cause standards reports to incorrectly flag a value as "non-compliant". 

Apologies if anything is incorrect, this is my first pull & contribution to any open source project.